### PR TITLE
New data set: 2020-11-13T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-12T124804Z.json
+pjson/2020-11-13T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-12T124804Z.json pjson/2020-11-13T110903Z.json```:
```
--- pjson/2020-11-12T124804Z.json	2020-11-12 12:48:05.040239751 +0000
+++ pjson/2020-11-13T110903Z.json	2020-11-13 11:09:04.115986969 +0000
@@ -5320,7 +5320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5
@@ -5386,7 +5386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604016000000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12
@@ -5408,7 +5408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604102400000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5452,7 +5452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604275200000,
-        "F\u00e4lle_Meldedatum": 169,
+        "F\u00e4lle_Meldedatum": 170,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 6
@@ -5474,7 +5474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 4
@@ -5496,7 +5496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 178,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6
@@ -5516,9 +5516,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
-        "Inzidenz": 104.709220877187,
+        "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3
@@ -5562,7 +5562,7 @@
         "BelegteBetten": null,
         "Inzidenz": 123.8,
         "Datum_neu": 1604707200000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5606,10 +5606,10 @@
         "BelegteBetten": null,
         "Inzidenz": 145.3,
         "Datum_neu": 1604880000000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 3
+        "Hosp_Meldedatum": 4
       }
     },
     {
@@ -5628,7 +5628,7 @@
         "BelegteBetten": null,
         "Inzidenz": 132.4,
         "Datum_neu": 1604966400000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 2
@@ -5650,10 +5650,10 @@
         "BelegteBetten": null,
         "Inzidenz": 136.678760012931,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 1
       }
     },
     {
@@ -5661,21 +5661,43 @@
         "Datum": "12.11.2020",
         "Fallzahl": 3615,
         "ObjectId": 251,
-        "Sterbefall": 29,
-        "Genesungsfall": 2110,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 195,
-        "Zuwachs_Fallzahl": 75,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 140,
         "BelegteBetten": null,
         "Inzidenz": 109.4,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 64,
-        "Zeitraum": "05.11.2020 - 11.11.2020",
+        "F\u00e4lle_Meldedatum": 153,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 0
+        "Hosp_Meldedatum": 2
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.11.2020",
+        "Fallzahl": 3797,
+        "ObjectId": 252,
+        "Sterbefall": 31,
+        "Genesungsfall": 2266,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 200,
+        "Zuwachs_Fallzahl": 182,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 156,
+        "BelegteBetten": null,
+        "Inzidenz": 118.4,
+        "Datum_neu": 1605225600000,
+        "F\u00e4lle_Meldedatum": 74,
+        "Zeitraum": "06.11.2020 - 12.11.2020",
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 1
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
