### PR TITLE
New data set: 2020-11-15T110104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-14T110304Z.json
+pjson/2020-11-15T110104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-14T110304Z.json pjson/2020-11-15T110104Z.json```:
```
--- pjson/2020-11-14T110304Z.json	2020-11-14 11:03:04.618845849 +0000
+++ pjson/2020-11-15T110104Z.json	2020-11-15 11:01:04.858352289 +0000
@@ -5345,7 +5345,7 @@
         "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 5
+        "Hosp_Meldedatum": 6
       }
     },
     {
@@ -5477,7 +5477,7 @@
         "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 4
+        "Hosp_Meldedatum": 5
       }
     },
     {
@@ -5538,9 +5538,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 38,
         "BelegteBetten": null,
-        "Inzidenz": 129.5,
+        "Inzidenz": null,
         "Datum_neu": 1604620800000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6
@@ -5560,7 +5560,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 66,
         "BelegteBetten": null,
-        "Inzidenz": 123.8,
+        "Inzidenz": null,
         "Datum_neu": 1604707200000,
         "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
@@ -5609,7 +5609,7 @@
         "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 5
+        "Hosp_Meldedatum": 6
       }
     },
     {
@@ -5648,9 +5648,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 136.678760012931,
+        "Inzidenz": 136.7,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1
@@ -5672,10 +5672,10 @@
         "BelegteBetten": null,
         "Inzidenz": 109.4,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 167,
+        "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5694,7 +5694,7 @@
         "BelegteBetten": null,
         "Inzidenz": 118.4,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 1
@@ -5705,19 +5705,41 @@
         "Datum": "14.11.2020",
         "Fallzahl": 3854,
         "ObjectId": 253,
-        "Sterbefall": 32,
-        "Genesungsfall": 2339,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 204,
-        "Zuwachs_Fallzahl": 57,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 73,
         "BelegteBetten": null,
         "Inzidenz": 113.3,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "07.11.2020 - 13.11.2020",
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.11.2020",
+        "Fallzahl": 3886,
+        "ObjectId": 254,
+        "Sterbefall": 32,
+        "Genesungsfall": 2369,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 208,
+        "Zuwachs_Fallzahl": 32,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 30,
+        "BelegteBetten": null,
+        "Inzidenz": 108.5,
+        "Datum_neu": 1605398400000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "08.11.2020 - 14.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
