### PR TITLE
New data set: 2020-11-16T110604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-15T110104Z.json
+pjson/2020-11-16T110604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-15T110104Z.json pjson/2020-11-16T110604Z.json```:
```
--- pjson/2020-11-15T110104Z.json	2020-11-15 11:01:04.858352289 +0000
+++ pjson/2020-11-16T110604Z.json	2020-11-16 11:06:04.757646175 +0000
@@ -5452,7 +5452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604275200000,
-        "F\u00e4lle_Meldedatum": 170,
+        "F\u00e4lle_Meldedatum": 171,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5
@@ -5474,7 +5474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 5
@@ -5540,7 +5540,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604620800000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6
@@ -5562,7 +5562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604707200000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5582,7 +5582,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
-        "Inzidenz": 121.6,
+        "Inzidenz": null,
         "Datum_neu": 1604793600000,
         "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
@@ -5628,7 +5628,7 @@
         "BelegteBetten": null,
         "Inzidenz": 132.4,
         "Datum_neu": 1604966400000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 2
@@ -5648,9 +5648,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 136.7,
+        "Inzidenz": 136.678760012931,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1
@@ -5672,7 +5672,7 @@
         "BelegteBetten": null,
         "Inzidenz": 109.4,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 168,
+        "F\u00e4lle_Meldedatum": 169,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 3
@@ -5694,7 +5694,7 @@
         "BelegteBetten": null,
         "Inzidenz": 118.4,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 1
@@ -5716,7 +5716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.3,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 35,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5727,19 +5727,41 @@
         "Datum": "15.11.2020",
         "Fallzahl": 3886,
         "ObjectId": 254,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 30,
+        "BelegteBetten": null,
+        "Inzidenz": 108.480908078595,
+        "Datum_neu": 1605398400000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.11.2020",
+        "Fallzahl": 4014,
+        "ObjectId": 255,
         "Sterbefall": 32,
-        "Genesungsfall": 2369,
+        "Genesungsfall": 2530,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 208,
-        "Zuwachs_Fallzahl": 32,
+        "Zuwachs_Fallzahl": 128,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
-        "Zuwachs_Genesung": 30,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 161,
         "BelegteBetten": null,
-        "Inzidenz": 108.5,
-        "Datum_neu": 1605398400000,
-        "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "08.11.2020 - 14.11.2020",
+        "Inzidenz": 113.7,
+        "Datum_neu": 1605484800000,
+        "F\u00e4lle_Meldedatum": 69,
+        "Zeitraum": "09.11.2020 - 15.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
