### PR TITLE
New data set: 2020-11-17T110104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-16T110604Z.json
+pjson/2020-11-17T110104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-16T110604Z.json pjson/2020-11-17T110104Z.json```:
```
--- pjson/2020-11-16T110604Z.json	2020-11-16 11:06:04.757646175 +0000
+++ pjson/2020-11-17T110104Z.json	2020-11-17 11:01:04.433060353 +0000
@@ -5166,7 +5166,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603152000000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3
@@ -5210,7 +5210,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603324800000,
-        "F\u00e4lle_Meldedatum": 89,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3
@@ -5232,7 +5232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603411200000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5298,7 +5298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7
@@ -5320,7 +5320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5
@@ -5342,7 +5342,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603843200000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6
@@ -5474,7 +5474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 5
@@ -5496,7 +5496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6
@@ -5518,7 +5518,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3
@@ -5540,7 +5540,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604620800000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6
@@ -5604,7 +5604,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 81,
         "BelegteBetten": null,
-        "Inzidenz": 145.3,
+        "Inzidenz": null,
         "Datum_neu": 1604880000000,
         "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
@@ -5628,7 +5628,7 @@
         "BelegteBetten": null,
         "Inzidenz": 132.4,
         "Datum_neu": 1604966400000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 2
@@ -5648,9 +5648,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 136.678760012931,
+        "Inzidenz": 136.7,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1
@@ -5672,10 +5672,10 @@
         "BelegteBetten": null,
         "Inzidenz": 109.4,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 169,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 3
+        "Hosp_Meldedatum": 4
       }
     },
     {
@@ -5694,10 +5694,10 @@
         "BelegteBetten": null,
         "Inzidenz": 118.4,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 1
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5716,7 +5716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.3,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 35,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5738,7 +5738,7 @@
         "BelegteBetten": null,
         "Inzidenz": 108.480908078595,
         "Datum_neu": 1605398400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5749,19 +5749,41 @@
         "Datum": "16.11.2020",
         "Fallzahl": 4014,
         "ObjectId": 255,
-        "Sterbefall": 32,
-        "Genesungsfall": 2530,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 208,
-        "Zuwachs_Fallzahl": 128,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 161,
         "BelegteBetten": null,
         "Inzidenz": 113.7,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 69,
-        "Zeitraum": "09.11.2020 - 15.11.2020",
+        "F\u00e4lle_Meldedatum": 137,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.11.2020",
+        "Fallzahl": 4261,
+        "ObjectId": 256,
+        "Sterbefall": 32,
+        "Genesungsfall": 2674,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 211,
+        "Zuwachs_Fallzahl": 247,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 144,
+        "BelegteBetten": null,
+        "Inzidenz": 138.1,
+        "Datum_neu": 1605571200000,
+        "F\u00e4lle_Meldedatum": 57,
+        "Zeitraum": "10.11.2020 - 16.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
