### PR TITLE
New data set: 2020-11-18T111404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-17T110104Z.json
+pjson/2020-11-18T111404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-17T110104Z.json pjson/2020-11-18T111404Z.json```:
```
--- pjson/2020-11-17T110104Z.json	2020-11-17 11:01:04.433060353 +0000
+++ pjson/2020-11-18T111404Z.json	2020-11-18 11:14:04.833638025 +0000
@@ -4066,7 +4066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1598832000000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4198,7 +4198,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599350400000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4374,7 +4374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600041600000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4418,7 +4418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600214400000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4440,7 +4440,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600300800000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4462,7 +4462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600387200000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4484,7 +4484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600473600000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4506,7 +4506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600560000000,
-        "F\u00e4lle_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5166,7 +5166,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603152000000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3
@@ -5386,7 +5386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604016000000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12
@@ -5474,7 +5474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 5
@@ -5518,10 +5518,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 3
+        "Hosp_Meldedatum": 5
       }
     },
     {
@@ -5562,7 +5562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604707200000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5606,7 +5606,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604880000000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6
@@ -5626,12 +5626,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
-        "Inzidenz": 132.4,
+        "Inzidenz": null,
         "Datum_neu": 1604966400000,
         "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5648,7 +5648,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 136.7,
+        "Inzidenz": 136.678760012931,
         "Datum_neu": 1605052800000,
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
@@ -5672,10 +5672,10 @@
         "BelegteBetten": null,
         "Inzidenz": 109.4,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 4
+        "Hosp_Meldedatum": 5
       }
     },
     {
@@ -5694,7 +5694,7 @@
         "BelegteBetten": null,
         "Inzidenz": 118.4,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 3
@@ -5716,7 +5716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.3,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5738,7 +5738,7 @@
         "BelegteBetten": null,
         "Inzidenz": 108.480908078595,
         "Datum_neu": 1605398400000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5760,10 +5760,10 @@
         "BelegteBetten": null,
         "Inzidenz": 113.7,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0
+        "Hosp_Meldedatum": 2
       }
     },
     {
@@ -5771,19 +5771,41 @@
         "Datum": "17.11.2020",
         "Fallzahl": 4261,
         "ObjectId": 256,
-        "Sterbefall": 32,
-        "Genesungsfall": 2674,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 211,
-        "Zuwachs_Fallzahl": 247,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
         "Inzidenz": 138.1,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 57,
-        "Zeitraum": "10.11.2020 - 16.11.2020",
+        "F\u00e4lle_Meldedatum": 93,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 6
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.11.2020",
+        "Fallzahl": 4381,
+        "ObjectId": 257,
+        "Sterbefall": 32,
+        "Genesungsfall": 2858,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 223,
+        "Zuwachs_Fallzahl": 120,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 184,
+        "BelegteBetten": null,
+        "Inzidenz": 142.3,
+        "Datum_neu": 1605657600000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "11.11.2020 - 17.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
