### PR TITLE
New data set: 2020-11-19T112104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-18T111404Z.json
+pjson/2020-11-19T112104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-18T111404Z.json pjson/2020-11-19T112104Z.json```:
```
--- pjson/2020-11-18T111404Z.json	2020-11-18 11:14:04.833638025 +0000
+++ pjson/2020-11-19T112104Z.json	2020-11-19 11:21:04.375907263 +0000
@@ -4066,7 +4066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1598832000000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4198,7 +4198,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599350400000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4374,7 +4374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600041600000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4418,7 +4418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600214400000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4440,7 +4440,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600300800000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4462,7 +4462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600387200000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4484,7 +4484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600473600000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4506,7 +4506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600560000000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 0,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5410,7 +5410,7 @@
         "Datum_neu": 1604102400000,
         "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0
       }
     },
@@ -5520,7 +5520,7 @@
         "Datum_neu": 1604534400000,
         "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5
       }
     },
@@ -5565,7 +5565,7 @@
         "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5586,7 +5586,7 @@
         "Datum_neu": 1604793600000,
         "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1
       }
     },
@@ -5608,7 +5608,7 @@
         "Datum_neu": 1604880000000,
         "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6
       }
     },
@@ -5630,7 +5630,7 @@
         "Datum_neu": 1604966400000,
         "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3
       }
     },
@@ -5648,7 +5648,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 136.678760012931,
+        "Inzidenz": null,
         "Datum_neu": 1605052800000,
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
@@ -5675,7 +5675,7 @@
         "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 5
+        "Hosp_Meldedatum": 4
       }
     },
     {
@@ -5716,7 +5716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.3,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5738,7 +5738,7 @@
         "BelegteBetten": null,
         "Inzidenz": 108.480908078595,
         "Datum_neu": 1605398400000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5758,9 +5758,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 161,
         "BelegteBetten": null,
-        "Inzidenz": 113.7,
+        "Inzidenz": 113.689428499587,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5776,13 +5776,13 @@
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
         "Inzidenz": 138.1,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 6
@@ -5793,22 +5793,44 @@
         "Datum": "18.11.2020",
         "Fallzahl": 4381,
         "ObjectId": 257,
-        "Sterbefall": 32,
-        "Genesungsfall": 2858,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 223,
-        "Zuwachs_Fallzahl": 120,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 184,
         "BelegteBetten": null,
-        "Inzidenz": 142.3,
+        "Inzidenz": 142.2,
         "Datum_neu": 1605657600000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "11.11.2020 - 17.11.2020",
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
+    },
+    {
+      "attributes": {
+        "Datum": "19.11.2020",
+        "Fallzahl": 4478,
+        "ObjectId": 258,
+        "Sterbefall": 37,
+        "Genesungsfall": 2979,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 224,
+        "Zuwachs_Fallzahl": 97,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 121,
+        "BelegteBetten": null,
+        "Inzidenz": 151.2,
+        "Datum_neu": 1605744000000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "12.11.2020 - 18.11.2020",
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 0
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
