### PR TITLE
New data set: 2020-11-21T111004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-20T110303Z.json
+pjson/2020-11-21T111004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-20T110303Z.json pjson/2020-11-21T111004Z.json```:
```
--- pjson/2020-11-20T110303Z.json	2020-11-20 11:03:04.134065745 +0000
+++ pjson/2020-11-21T111004Z.json	2020-11-21 11:10:04.870376613 +0000
@@ -5543,7 +5543,7 @@
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 6
+        "Hosp_Meldedatum": 7
       }
     },
     {
@@ -5565,7 +5565,7 @@
         "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 3
+        "Hosp_Meldedatum": 2
       }
     },
     {
@@ -5631,7 +5631,7 @@
         "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 3
+        "Hosp_Meldedatum": 8
       }
     },
     {
@@ -5650,10 +5650,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 1
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 2
       }
     },
     {
@@ -5672,10 +5672,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 4
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 10
       }
     },
     {
@@ -5692,12 +5692,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 156,
         "BelegteBetten": null,
-        "Inzidenz": 118.4,
+        "Inzidenz": null,
         "Datum_neu": 1605225600000,
         "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 3
+        "Hosp_Meldedatum": 9
       }
     },
     {
@@ -5716,7 +5716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.3,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5760,7 +5760,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.689428499587,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5782,7 +5782,7 @@
         "BelegteBetten": null,
         "Inzidenz": 138.1,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 8
@@ -5804,7 +5804,7 @@
         "BelegteBetten": null,
         "Inzidenz": 142.2,
         "Datum_neu": 1605657600000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5826,10 +5826,10 @@
         "BelegteBetten": null,
         "Inzidenz": 151.2,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5837,19 +5837,41 @@
         "Datum": "20.11.2020",
         "Fallzahl": 4707,
         "ObjectId": 259,
-        "Sterbefall": 38,
-        "Genesungsfall": 3155,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 227,
-        "Zuwachs_Fallzahl": 229,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 176,
         "BelegteBetten": null,
         "Inzidenz": 155.2,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "13.11.2020 - 19.11.2020",
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 4,
+        "Hosp_Meldedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.11.2020",
+        "Fallzahl": 4792,
+        "ObjectId": 260,
+        "Sterbefall": 44,
+        "Genesungsfall": 3223,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 246,
+        "Zuwachs_Fallzahl": 85,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 68,
+        "BelegteBetten": null,
+        "Inzidenz": 136.5,
+        "Datum_neu": 1605916800000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "14.11.2020 - 20.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
