### PR TITLE
New data set: 2020-11-22T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-21T111004Z.json
+pjson/2020-11-22T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-21T111004Z.json pjson/2020-11-22T110504Z.json```:
```
--- pjson/2020-11-21T111004Z.json	2020-11-21 11:10:04.870376613 +0000
+++ pjson/2020-11-22T110504Z.json	2020-11-22 11:05:04.931221570 +0000
@@ -4198,7 +4198,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599350400000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4374,7 +4374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600041600000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4528,7 +4528,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600646400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -4748,7 +4748,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601510400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5386,7 +5386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604016000000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12
@@ -5474,7 +5474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 5
@@ -5606,7 +5606,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604880000000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6
@@ -5714,7 +5714,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 73,
         "BelegteBetten": null,
-        "Inzidenz": 113.3,
+        "Inzidenz": null,
         "Datum_neu": 1605312000000,
         "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
@@ -5848,7 +5848,7 @@
         "BelegteBetten": null,
         "Inzidenz": 155.2,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 0
@@ -5859,19 +5859,41 @@
         "Datum": "21.11.2020",
         "Fallzahl": 4792,
         "ObjectId": 260,
-        "Sterbefall": 44,
-        "Genesungsfall": 3223,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 246,
-        "Zuwachs_Fallzahl": 85,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
         "Inzidenz": 136.5,
         "Datum_neu": 1605916800000,
-        "F\u00e4lle_Meldedatum": 18,
-        "Zeitraum": "14.11.2020 - 20.11.2020",
+        "F\u00e4lle_Meldedatum": 35,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.11.2020",
+        "Fallzahl": 4842,
+        "ObjectId": 261,
+        "Sterbefall": 44,
+        "Genesungsfall": 3248,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 246,
+        "Zuwachs_Fallzahl": 50,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 25,
+        "BelegteBetten": null,
+        "Inzidenz": 133.6,
+        "Datum_neu": 1606003200000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "15.11.2020 - 21.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
