### PR TITLE
New data set: 2020-11-24T111303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-23T113503Z.json
+pjson/2020-11-24T111303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-23T113503Z.json pjson/2020-11-24T111303Z.json```:
```
--- pjson/2020-11-23T113503Z.json	2020-11-23 11:35:03.837793693 +0000
+++ pjson/2020-11-24T111303Z.json	2020-11-24 11:13:03.422233187 +0000
@@ -5100,7 +5100,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602892800000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5144,7 +5144,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 35,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1
@@ -5298,7 +5298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7
@@ -5320,7 +5320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5
@@ -5433,7 +5433,7 @@
         "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5474,7 +5474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 5
@@ -5496,7 +5496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6
@@ -5543,7 +5543,7 @@
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 7
+        "Hosp_Meldedatum": 8
       }
     },
     {
@@ -5562,7 +5562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604707200000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5653,7 +5653,7 @@
         "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 4
       }
     },
     {
@@ -5672,7 +5672,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 10
@@ -5694,7 +5694,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 197,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10
@@ -5716,7 +5716,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5758,12 +5758,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 161,
         "BelegteBetten": null,
-        "Inzidenz": 113.689428499587,
+        "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 4
       }
     },
     {
@@ -5782,10 +5782,10 @@
         "BelegteBetten": null,
         "Inzidenz": 138.1,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 8
+        "Hosp_Meldedatum": 9
       }
     },
     {
@@ -5826,7 +5826,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.2,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 3
@@ -5848,10 +5848,10 @@
         "BelegteBetten": null,
         "Inzidenz": 155.2,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 170,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 10
       }
     },
     {
@@ -5870,10 +5870,10 @@
         "BelegteBetten": null,
         "Inzidenz": 136.5,
         "Datum_neu": 1605916800000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5892,7 +5892,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.6,
         "Datum_neu": 1606003200000,
-        "F\u00e4lle_Meldedatum": 28,
+        "F\u00e4lle_Meldedatum": 29,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3
@@ -5903,19 +5903,41 @@
         "Datum": "23.11.2020",
         "Fallzahl": 5041,
         "ObjectId": 262,
-        "Sterbefall": 44,
-        "Genesungsfall": 3347,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 255,
-        "Zuwachs_Fallzahl": 199,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 99,
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 69,
-        "Zeitraum": "16.11.2020 - 22.11.2020",
+        "F\u00e4lle_Meldedatum": 101,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 10
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.11.2020",
+        "Fallzahl": 5227,
+        "ObjectId": 263,
+        "Sterbefall": 44,
+        "Genesungsfall": 3463,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 283,
+        "Zuwachs_Fallzahl": 186,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 28,
+        "Zuwachs_Genesung": 116,
+        "BelegteBetten": null,
+        "Inzidenz": 147.1,
+        "Datum_neu": 1606176000000,
+        "F\u00e4lle_Meldedatum": 53,
+        "Zeitraum": "17.11.2020 - 23.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
