### PR TITLE
New data set: 2020-11-25T111503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-24T111303Z.json
+pjson/2020-11-25T111503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-24T111303Z.json pjson/2020-11-25T111503Z.json```:
```
--- pjson/2020-11-24T111303Z.json	2020-11-24 11:13:03.422233187 +0000
+++ pjson/2020-11-25T111503Z.json	2020-11-25 11:15:03.555581003 +0000
@@ -1624,7 +1624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1589241600000,
-        "F\u00e4lle_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5719,7 +5719,7 @@
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0
+        "Hosp_Meldedatum": 1
       }
     },
     {
@@ -5738,7 +5738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605398400000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5760,7 +5760,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4
@@ -5780,9 +5780,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 138.1,
+        "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 9
@@ -5826,10 +5826,10 @@
         "BelegteBetten": null,
         "Inzidenz": 151.2,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 3
+        "Hosp_Meldedatum": 4
       }
     },
     {
@@ -5848,10 +5848,10 @@
         "BelegteBetten": null,
         "Inzidenz": 155.2,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 170,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 10
+        "Hosp_Meldedatum": 12
       }
     },
     {
@@ -5870,7 +5870,7 @@
         "BelegteBetten": null,
         "Inzidenz": 136.5,
         "Datum_neu": 1605916800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3
@@ -5892,7 +5892,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.6,
         "Datum_neu": 1606003200000,
-        "F\u00e4lle_Meldedatum": 29,
+        "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3
@@ -5914,10 +5914,10 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 10
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 12
       }
     },
     {
@@ -5925,21 +5925,43 @@
         "Datum": "24.11.2020",
         "Fallzahl": 5227,
         "ObjectId": 263,
-        "Sterbefall": 44,
-        "Genesungsfall": 3463,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 283,
-        "Zuwachs_Fallzahl": 186,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 28,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 116,
         "BelegteBetten": null,
         "Inzidenz": 147.1,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 53,
-        "Zeitraum": "17.11.2020 - 23.11.2020",
+        "F\u00e4lle_Meldedatum": 130,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 3
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.11.2020",
+        "Fallzahl": 5434,
+        "ObjectId": 264,
+        "Sterbefall": 47,
+        "Genesungsfall": 3509,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 293,
+        "Zuwachs_Fallzahl": 207,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 46,
+        "BelegteBetten": null,
+        "Inzidenz": 143.5,
+        "Datum_neu": 1606262400000,
+        "F\u00e4lle_Meldedatum": 48,
+        "Zeitraum": "18.11.2020 - 24.11.2020",
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0
+        "Hosp_Meldedatum": 1
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
