### PR TITLE
New data set: 2020-11-27T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-26T112103Z.json
+pjson/2020-11-27T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-26T112103Z.json pjson/2020-11-27T110203Z.json```:
```
--- pjson/2020-11-26T112103Z.json	2020-11-26 11:21:03.683008133 +0000
+++ pjson/2020-11-27T110203Z.json	2020-11-27 11:02:03.662379333 +0000
@@ -5188,7 +5188,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603238400000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5
@@ -5298,7 +5298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7
@@ -5364,7 +5364,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603929600000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 9
@@ -5386,7 +5386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604016000000,
-        "F\u00e4lle_Meldedatum": 156,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12
@@ -5452,7 +5452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604275200000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5
@@ -5518,7 +5518,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5
@@ -5540,7 +5540,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604620800000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8
@@ -5562,7 +5562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604707200000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2
@@ -5584,7 +5584,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604793600000,
-        "F\u00e4lle_Meldedatum": 28,
+        "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1
@@ -5694,7 +5694,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10
@@ -5760,7 +5760,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4
@@ -5785,7 +5785,7 @@
         "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 9
+        "Hosp_Meldedatum": 10
       }
     },
     {
@@ -5824,9 +5824,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 121,
         "BelegteBetten": null,
-        "Inzidenz": 151.2,
+        "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4
@@ -5848,7 +5848,7 @@
         "BelegteBetten": null,
         "Inzidenz": 155.2,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 12
@@ -5914,7 +5914,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 13
@@ -5936,10 +5936,10 @@
         "BelegteBetten": null,
         "Inzidenz": 147.1,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 226,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 5
+        "Hosp_Meldedatum": 6
       }
     },
     {
@@ -5958,10 +5958,10 @@
         "BelegteBetten": null,
         "Inzidenz": 143.5,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 1
+        "Hosp_Meldedatum": 3
       }
     },
     {
@@ -5969,19 +5969,41 @@
         "Datum": "26.11.2020",
         "Fallzahl": 5650,
         "ObjectId": 265,
-        "Sterbefall": 49,
-        "Genesungsfall": 3698,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 296,
-        "Zuwachs_Fallzahl": 216,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 189,
         "BelegteBetten": null,
         "Inzidenz": 168.6,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "19.11.2020 - 25.11.2020",
+        "F\u00e4lle_Meldedatum": 121,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 6,
+        "Hosp_Meldedatum": 2
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.11.2020",
+        "Fallzahl": 5964,
+        "ObjectId": 266,
+        "Sterbefall": 55,
+        "Genesungsfall": 3898,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 302,
+        "Zuwachs_Fallzahl": 314,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 200,
+        "BelegteBetten": null,
+        "Inzidenz": 200.1,
+        "Datum_neu": 1606435200000,
+        "F\u00e4lle_Meldedatum": 35,
+        "Zeitraum": "20.11.2020 - 26.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
