### PR TITLE
New data set: 2020-11-28T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-27T110203Z.json
+pjson/2020-11-28T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-27T110203Z.json pjson/2020-11-28T110403Z.json```:
```
--- pjson/2020-11-27T110203Z.json	2020-11-27 11:02:03.662379333 +0000
+++ pjson/2020-11-28T110403Z.json	2020-11-28 11:04:03.757265090 +0000
@@ -5034,7 +5034,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602633600000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1
@@ -5056,7 +5056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602720000000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1
@@ -5100,7 +5100,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602892800000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
@@ -5298,7 +5298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7
@@ -5452,7 +5452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604275200000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5
@@ -5474,7 +5474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 5
@@ -5694,7 +5694,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10
@@ -5782,7 +5782,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 10
@@ -5846,9 +5846,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 176,
         "BelegteBetten": null,
-        "Inzidenz": 155.2,
+        "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 12
@@ -5914,7 +5914,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 13
@@ -5936,7 +5936,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.1,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 259,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6
@@ -5958,7 +5958,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.5,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 244,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 3
@@ -5980,7 +5980,7 @@
         "BelegteBetten": null,
         "Inzidenz": 168.6,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 166,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 2
@@ -5991,19 +5991,41 @@
         "Datum": "27.11.2020",
         "Fallzahl": 5964,
         "ObjectId": 266,
-        "Sterbefall": 55,
-        "Genesungsfall": 3898,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 302,
-        "Zuwachs_Fallzahl": 314,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 200,
         "BelegteBetten": null,
         "Inzidenz": 200.1,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 35,
-        "Zeitraum": "20.11.2020 - 26.11.2020",
+        "F\u00e4lle_Meldedatum": 73,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.11.2020",
+        "Fallzahl": 6091,
+        "ObjectId": 267,
+        "Sterbefall": 55,
+        "Genesungsfall": 3984,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 302,
+        "Zuwachs_Fallzahl": 127,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 86,
+        "BelegteBetten": null,
+        "Inzidenz": 189.6,
+        "Datum_neu": 1606521600000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "21.11.2020 - 27.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within a minute as well.

Thanks!
