### PR TITLE
New data set: 2020-11-30T122803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-29T110203Z.json
+pjson/2020-11-30T122803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-30T073902Z.json pjson/2020-11-30T122803Z.json```:
```
--- pjson/2020-11-30T073902Z.json	2020-11-30 07:39:02.940419682 +0000
+++ pjson/2020-11-30T122803Z.json	2020-11-30 12:28:03.758099836 +0000
@@ -6325,7 +6325,7 @@
         "Zeitraum": "22.11.2020 - 28.11.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 188.8
+        "Inzidenz_RKI": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
