### PR TITLE
New data set: 2020-11-30T124004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-29T110203Z.json
+pjson/2020-11-30T124004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-30T122803Z.json pjson/2020-11-30T124004Z.json```:
```
--- pjson/2020-11-30T122803Z.json	2020-11-30 12:28:03.758099836 +0000
+++ pjson/2020-11-30T124004Z.json	2020-11-30 12:40:04.307371754 +0000
@@ -5953,7 +5953,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10,
@@ -6022,7 +6022,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4,
@@ -6045,7 +6045,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 10,
@@ -6114,7 +6114,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 12,
@@ -6158,7 +6158,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 25,
         "BelegteBetten": null,
-        "Inzidenz": 133.6,
+        "Inzidenz": null,
         "Datum_neu": 1606003200000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
@@ -6183,7 +6183,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 13,
@@ -6206,7 +6206,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.1,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 261,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
@@ -6229,10 +6229,10 @@
         "BelegteBetten": null,
         "Inzidenz": 143.5,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 244,
+        "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null
       }
     },
@@ -6252,10 +6252,10 @@
         "BelegteBetten": null,
         "Inzidenz": 168.6,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 171,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null
       }
     },
@@ -6275,10 +6275,10 @@
         "BelegteBetten": null,
         "Inzidenz": 200.1,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null
       }
     },
@@ -6298,10 +6298,10 @@
         "BelegteBetten": null,
         "Inzidenz": 189.6,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null
       }
     },
@@ -6310,23 +6310,46 @@
         "Datum": "29.11.2020",
         "Fallzahl": 6182,
         "ObjectId": 268,
-        "Sterbefall": 55,
-        "Genesungsfall": 4000,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 304,
-        "Zuwachs_Fallzahl": 91,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 16,
         "BelegteBetten": null,
-        "Inzidenz": 190.7,
+        "Inzidenz": 190.739609899781,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "22.11.2020 - 28.11.2020",
+        "F\u00e4lle_Meldedatum": 82,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.11.2020",
+        "Fallzahl": 6448,
+        "ObjectId": 269,
+        "Sterbefall": 55,
+        "Genesungsfall": 4218,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 308,
+        "Zuwachs_Fallzahl": 266,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 218,
+        "BelegteBetten": null,
+        "Inzidenz": 230.1,
+        "Datum_neu": 1606694400000,
+        "F\u00e4lle_Meldedatum": 28,
+        "Zeitraum": "23.11.2020 - 29.11.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 188.8
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
