### PR TITLE
New data set: 2020-11-30T145103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-30T124004Z.json
+pjson/2020-11-30T145103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-30T124004Z.json pjson/2020-11-30T145103Z.json```:
```
--- pjson/2020-11-30T124004Z.json	2020-11-30 12:40:04.307371754 +0000
+++ pjson/2020-11-30T145103Z.json	2020-11-30 14:51:04.020221816 +0000
@@ -6187,7 +6187,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": 135.4
       }
     },
     {
@@ -6210,7 +6210,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": 126.4
       }
     },
     {
@@ -6233,7 +6233,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": 107.4
       }
     },
     {
@@ -6256,7 +6256,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": 132
       }
     },
     {
@@ -6279,7 +6279,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": 152.5
       }
     },
     {
@@ -6302,7 +6302,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": 173.5
       }
     },
     {
@@ -6325,7 +6325,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": 177.6
       }
     },
     {
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
