### PR TITLE
New data set: 2020-12-01T111103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-11-30T145103Z.json
+pjson/2020-12-01T111103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-11-30T145103Z.json pjson/2020-12-01T111103Z.json```:
```
--- pjson/2020-11-30T145103Z.json	2020-11-30 14:51:04.020221816 +0000
+++ pjson/2020-12-01T111103Z.json	2020-12-01 11:11:03.896401736 +0000
@@ -4987,7 +4987,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601596800000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -5378,7 +5378,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -5539,7 +5539,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7,
@@ -5562,7 +5562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -5700,7 +5700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604275200000,
-        "F\u00e4lle_Meldedatum": 178,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -5746,7 +5746,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 200,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
@@ -5861,7 +5861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604880000000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -5907,7 +5907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -5976,7 +5976,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -6045,7 +6045,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 10,
@@ -6181,9 +6181,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 99,
         "BelegteBetten": null,
-        "Inzidenz": 153.6,
+        "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 13,
@@ -6206,7 +6206,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.1,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 261,
+        "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
@@ -6229,7 +6229,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.5,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 251,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -6252,10 +6252,10 @@
         "BelegteBetten": null,
         "Inzidenz": 168.6,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 132
       }
     },
@@ -6275,10 +6275,10 @@
         "BelegteBetten": null,
         "Inzidenz": 200.1,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 178,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 152.5
       }
     },
@@ -6298,7 +6298,7 @@
         "BelegteBetten": null,
         "Inzidenz": 189.6,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -6321,7 +6321,7 @@
         "BelegteBetten": null,
         "Inzidenz": 190.739609899781,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -6333,23 +6333,46 @@
         "Datum": "30.11.2020",
         "Fallzahl": 6448,
         "ObjectId": 269,
-        "Sterbefall": 55,
-        "Genesungsfall": 4218,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 308,
-        "Zuwachs_Fallzahl": 266,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 218,
         "BelegteBetten": null,
         "Inzidenz": 230.1,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 28,
-        "Zeitraum": "23.11.2020 - 29.11.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 112,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 12,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 188.8
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.12.2020",
+        "Fallzahl": 6664,
+        "ObjectId": 270,
+        "Sterbefall": 67,
+        "Genesungsfall": 4434,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 321,
+        "Zuwachs_Fallzahl": 216,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 216,
+        "BelegteBetten": null,
+        "Inzidenz": 229.9,
+        "Datum_neu": 1606780800000,
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": "24.11.2020 - 30.11.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 201.2
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
