### PR TITLE
New data set: 2020-12-02T111803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-01T111103Z.json
+pjson/2020-12-02T111803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-01T111103Z.json pjson/2020-12-02T111803Z.json```:
```
--- pjson/2020-12-01T111103Z.json	2020-12-01 11:11:03.896401736 +0000
+++ pjson/2020-12-02T111803Z.json	2020-12-02 11:18:03.341869304 +0000
@@ -5585,7 +5585,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603843200000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
@@ -6025,7 +6025,7 @@
         "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null
       }
     },
@@ -6045,7 +6045,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 10,
@@ -6114,7 +6114,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 12,
@@ -6187,7 +6187,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 135.4
+        "Inzidenz_RKI": null
       }
     },
     {
@@ -6204,13 +6204,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 116,
         "BelegteBetten": null,
-        "Inzidenz": 147.1,
+        "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 262,
+        "F\u00e4lle_Meldedatum": 261,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 126.4
+        "Inzidenz_RKI": null
       }
     },
     {
@@ -6229,7 +6229,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.5,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 256,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -6252,10 +6252,10 @@
         "BelegteBetten": null,
         "Inzidenz": 168.6,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 132
       }
     },
@@ -6275,7 +6275,7 @@
         "BelegteBetten": null,
         "Inzidenz": 200.1,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -6298,7 +6298,7 @@
         "BelegteBetten": null,
         "Inzidenz": 189.6,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -6321,10 +6321,10 @@
         "BelegteBetten": null,
         "Inzidenz": 190.739609899781,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 177.6
       }
     },
@@ -6344,10 +6344,10 @@
         "BelegteBetten": null,
         "Inzidenz": 230.1,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 188.8
       }
     },
@@ -6356,22 +6356,45 @@
         "Datum": "01.12.2020",
         "Fallzahl": 6664,
         "ObjectId": 270,
-        "Sterbefall": 67,
-        "Genesungsfall": 4434,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 321,
-        "Zuwachs_Fallzahl": 216,
-        "Zuwachs_Sterbefall": 12,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
-        "Inzidenz": 229.9,
+        "Inzidenz": 229.893315133446,
         "Datum_neu": 1606780800000,
+        "F\u00e4lle_Meldedatum": 210,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 9,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": 201.2
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.12.2020",
+        "Fallzahl": 6952,
+        "ObjectId": 271,
+        "Sterbefall": 76,
+        "Genesungsfall": 4536,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 341,
+        "Zuwachs_Fallzahl": 288,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 102,
+        "BelegteBetten": null,
+        "Inzidenz": 234.6,
+        "Datum_neu": 1606867200000,
         "F\u00e4lle_Meldedatum": 39,
-        "Zeitraum": "24.11.2020 - 30.11.2020",
+        "Zeitraum": "25.11.2020 - 01.12.2020",
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 201.2
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 187.9
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
