### PR TITLE
New data set: 2020-12-04T111003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-03T111703Z.json
+pjson/2020-12-04T111003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-03T111703Z.json pjson/2020-12-04T111003Z.json```:
```
--- pjson/2020-12-03T111703Z.json	2020-12-03 11:17:03.294037878 +0000
+++ pjson/2020-12-04T111003Z.json	2020-12-04 11:10:04.031798279 +0000
@@ -6137,7 +6137,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605916800000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
@@ -6183,7 +6183,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 14,
@@ -6229,7 +6229,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 259,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -6250,13 +6250,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 189,
         "BelegteBetten": null,
-        "Inzidenz": 168.6,
+        "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
+        "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 132
+        "Inzidenz_RKI": null
       }
     },
     {
@@ -6275,7 +6275,7 @@
         "BelegteBetten": null,
         "Inzidenz": 200.1,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -6298,7 +6298,7 @@
         "BelegteBetten": null,
         "Inzidenz": 189.6,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -6321,7 +6321,7 @@
         "BelegteBetten": null,
         "Inzidenz": 190.739609899781,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -6367,10 +6367,10 @@
         "BelegteBetten": null,
         "Inzidenz": 229.893315133446,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 9,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 201.2
       }
     },
@@ -6388,12 +6388,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 102,
         "BelegteBetten": null,
-        "Inzidenz": 234.6,
+        "Inzidenz": 234.563023097094,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 187.9
       }
     },
@@ -6402,23 +6402,46 @@
         "Datum": "03.12.2020",
         "Fallzahl": 7163,
         "ObjectId": 272,
-        "Sterbefall": 79,
-        "Genesungsfall": 4642,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 364,
-        "Zuwachs_Fallzahl": 211,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 106,
         "BelegteBetten": null,
         "Inzidenz": 232,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "26.11.2020 - 02.12.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 93,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 196.3
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.12.2020",
+        "Fallzahl": 7392,
+        "ObjectId": 273,
+        "Sterbefall": 83,
+        "Genesungsfall": 4824,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 385,
+        "Zuwachs_Fallzahl": 229,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 182,
+        "BelegteBetten": null,
+        "Inzidenz": 228.6,
+        "Datum_neu": 1607040000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "27.11.2020 - 03.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 189.5
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
