### PR TITLE
New data set: 2020-12-05T113603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-04T111003Z.json
+pjson/2020-12-05T113603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-04T111003Z.json pjson/2020-12-05T113603Z.json```:
```
--- pjson/2020-12-04T111003Z.json	2020-12-04 11:10:04.031798279 +0000
+++ pjson/2020-12-05T113603Z.json	2020-12-05 11:36:03.840108615 +0000
@@ -4274,7 +4274,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1598918400000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -4573,7 +4573,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600041600000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -5286,7 +5286,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602720000000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1,
@@ -5378,7 +5378,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -5539,7 +5539,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7,
@@ -5585,7 +5585,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603843200000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
@@ -5700,7 +5700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604275200000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -5864,7 +5864,7 @@
         "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null
       }
     },
@@ -5884,7 +5884,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604966400000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 10,
@@ -5933,7 +5933,7 @@
         "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null
       }
     },
@@ -5953,7 +5953,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10,
@@ -6048,7 +6048,7 @@
         "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null
       }
     },
@@ -6094,7 +6094,7 @@
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null
       }
     },
@@ -6114,7 +6114,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 12,
@@ -6183,10 +6183,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null
       }
     },
@@ -6206,10 +6206,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 263,
+        "F\u00e4lle_Meldedatum": 264,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null
       }
     },
@@ -6273,13 +6273,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 200,
         "BelegteBetten": null,
-        "Inzidenz": 200.1,
+        "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 152.5
+        "Inzidenz_RKI": null
       }
     },
     {
@@ -6298,7 +6298,7 @@
         "BelegteBetten": null,
         "Inzidenz": 189.6,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -6321,10 +6321,10 @@
         "BelegteBetten": null,
         "Inzidenz": 190.739609899781,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 177.6
       }
     },
@@ -6344,7 +6344,7 @@
         "BelegteBetten": null,
         "Inzidenz": 230.1,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 13,
@@ -6365,9 +6365,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
-        "Inzidenz": 229.893315133446,
+        "Inzidenz": 229.9,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 9,
         "Hosp_Meldedatum": 18,
@@ -6388,12 +6388,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 102,
         "BelegteBetten": null,
-        "Inzidenz": 234.563023097094,
+        "Inzidenz": 234.6,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 187.9
       }
     },
@@ -6413,10 +6413,10 @@
         "BelegteBetten": null,
         "Inzidenz": 232,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 171,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 196.3
       }
     },
@@ -6425,23 +6425,46 @@
         "Datum": "04.12.2020",
         "Fallzahl": 7392,
         "ObjectId": 273,
-        "Sterbefall": 83,
-        "Genesungsfall": 4824,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 385,
-        "Zuwachs_Fallzahl": 229,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 182,
         "BelegteBetten": null,
         "Inzidenz": 228.6,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "27.11.2020 - 03.12.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 12,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 189.5
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.12.2020",
+        "Fallzahl": 7556,
+        "ObjectId": 274,
+        "Sterbefall": 95,
+        "Genesungsfall": 4917,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 402,
+        "Zuwachs_Fallzahl": 164,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 93,
+        "BelegteBetten": null,
+        "Inzidenz": 212.7,
+        "Datum_neu": 1607126400000,
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": "28.11.2020 - 04.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 190.4
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
