### PR TITLE
New data set: 2020-12-06T110103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-05T113603Z.json
+pjson/2020-12-06T110103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-05T113603Z.json pjson/2020-12-06T110103Z.json```:
```
--- pjson/2020-12-05T113603Z.json	2020-12-05 11:36:03.840108615 +0000
+++ pjson/2020-12-06T110103Z.json	2020-12-06 11:01:03.442563389 +0000
@@ -3676,7 +3676,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1596672000000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -4274,7 +4274,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1598918400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -5056,7 +5056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601856000000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -6186,7 +6186,7 @@
         "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null
       }
     },
@@ -6206,7 +6206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 264,
+        "F\u00e4lle_Meldedatum": 267,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -6229,7 +6229,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 259,
+        "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -6252,7 +6252,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 242,
+        "F\u00e4lle_Meldedatum": 244,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 8,
@@ -6275,7 +6275,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 217,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -6296,13 +6296,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 86,
         "BelegteBetten": null,
-        "Inzidenz": 189.6,
+        "Inzidenz": null,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 173.5
+        "Inzidenz_RKI": null
       }
     },
     {
@@ -6347,7 +6347,7 @@
         "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 188.8
       }
     },
@@ -6365,9 +6365,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
-        "Inzidenz": 229.9,
+        "Inzidenz": 229.893315133446,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 9,
         "Hosp_Meldedatum": 18,
@@ -6388,12 +6388,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 102,
         "BelegteBetten": null,
-        "Inzidenz": 234.6,
+        "Inzidenz": 234.563023097094,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 187.9
       }
     },
@@ -6413,10 +6413,10 @@
         "BelegteBetten": null,
         "Inzidenz": 232,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 171,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 196.3
       }
     },
@@ -6436,10 +6436,10 @@
         "BelegteBetten": null,
         "Inzidenz": 228.6,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 189.5
       }
     },
@@ -6448,23 +6448,46 @@
         "Datum": "05.12.2020",
         "Fallzahl": 7556,
         "ObjectId": 274,
-        "Sterbefall": 95,
-        "Genesungsfall": 4917,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 402,
-        "Zuwachs_Fallzahl": 164,
-        "Zuwachs_Sterbefall": 12,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 93,
         "BelegteBetten": null,
         "Inzidenz": 212.7,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 36,
-        "Zeitraum": "28.11.2020 - 04.12.2020",
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 190.4
       }
+    },
+    {
+      "attributes": {
+        "Datum": "06.12.2020",
+        "Fallzahl": 7838,
+        "ObjectId": 275,
+        "Sterbefall": 95,
+        "Genesungsfall": 4953,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 425,
+        "Zuwachs_Fallzahl": 282,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 36,
+        "BelegteBetten": null,
+        "Inzidenz": 218.4,
+        "Datum_neu": 1607212800000,
+        "F\u00e4lle_Meldedatum": 138,
+        "Zeitraum": "29.11.2020 - 05.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 192.7
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
