### PR TITLE
New data set: 2020-12-07T111105Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-06T110103Z.json
+pjson/2020-12-07T111105Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-06T110103Z.json pjson/2020-12-07T111105Z.json```:
```
--- pjson/2020-12-06T110103Z.json	2020-12-06 11:01:03.442563389 +0000
+++ pjson/2020-12-07T111105Z.json	2020-12-07 11:11:05.550823826 +0000
@@ -5631,7 +5631,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604016000000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
@@ -6252,7 +6252,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 244,
+        "F\u00e4lle_Meldedatum": 246,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 8,
@@ -6275,7 +6275,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -6298,7 +6298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -6319,13 +6319,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 16,
         "BelegteBetten": null,
-        "Inzidenz": 190.739609899781,
+        "Inzidenz": null,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 177.6
+        "Inzidenz_RKI": null
       }
     },
     {
@@ -6344,10 +6344,10 @@
         "BelegteBetten": null,
         "Inzidenz": 230.1,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 188.8
       }
     },
@@ -6367,10 +6367,10 @@
         "BelegteBetten": null,
         "Inzidenz": 229.893315133446,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 9,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 201.2
       }
     },
@@ -6390,10 +6390,10 @@
         "BelegteBetten": null,
         "Inzidenz": 234.563023097094,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 284,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 187.9
       }
     },
@@ -6413,10 +6413,10 @@
         "BelegteBetten": null,
         "Inzidenz": 232,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 196.3
       }
     },
@@ -6436,7 +6436,7 @@
         "BelegteBetten": null,
         "Inzidenz": 228.6,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 15,
@@ -6459,10 +6459,10 @@
         "BelegteBetten": null,
         "Inzidenz": 212.7,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 190.4
       }
     },
@@ -6471,23 +6471,46 @@
         "Datum": "06.12.2020",
         "Fallzahl": 7838,
         "ObjectId": 275,
-        "Sterbefall": 95,
-        "Genesungsfall": 4953,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 425,
-        "Zuwachs_Fallzahl": 282,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 36,
         "BelegteBetten": null,
         "Inzidenz": 218.4,
         "Datum_neu": 1607212800000,
-        "F\u00e4lle_Meldedatum": 138,
-        "Zeitraum": "29.11.2020 - 05.12.2020",
+        "F\u00e4lle_Meldedatum": 231,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 192.7
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.12.2020",
+        "Fallzahl": 8042,
+        "ObjectId": 276,
+        "Sterbefall": 95,
+        "Genesungsfall": 5157,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 443,
+        "Zuwachs_Fallzahl": 204,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 204,
+        "BelegteBetten": null,
+        "Inzidenz": 262.4,
+        "Datum_neu": 1607299200000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "30.11.2020 - 06.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 228.6
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
