### PR TITLE
New data set: 2020-12-08T112603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-07T111105Z.json
+pjson/2020-12-08T112603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-07T111105Z.json pjson/2020-12-08T112603Z.json```:
```
--- pjson/2020-12-07T111105Z.json	2020-12-07 11:11:05.550823826 +0000
+++ pjson/2020-12-08T112603Z.json	2020-12-08 11:26:04.032600632 +0000
@@ -5748,7 +5748,7 @@
         "Datum_neu": 1604448000000,
         "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null
       }
@@ -6206,7 +6206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 267,
+        "F\u00e4lle_Meldedatum": 268,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -6229,7 +6229,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -6252,10 +6252,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 246,
+        "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null
       }
     },
@@ -6275,7 +6275,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -6298,7 +6298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -6321,10 +6321,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null
       }
     },
@@ -6342,13 +6342,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 218,
         "BelegteBetten": null,
-        "Inzidenz": 230.1,
+        "Inzidenz": null,
         "Datum_neu": 1606694400000,
         "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 188.8
+        "SterbeF_Meldedatum": 13,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null
       }
     },
     {
@@ -6367,10 +6367,10 @@
         "BelegteBetten": null,
         "Inzidenz": 229.893315133446,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 330,
+        "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 9,
-        "Hosp_Meldedatum": 19,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 201.2
       }
     },
@@ -6390,10 +6390,10 @@
         "BelegteBetten": null,
         "Inzidenz": 234.563023097094,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 284,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 22,
+        "SterbeF_Meldedatum": 5,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 187.9
       }
     },
@@ -6413,10 +6413,10 @@
         "BelegteBetten": null,
         "Inzidenz": 232,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 22,
+        "SterbeF_Meldedatum": 4,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 196.3
       }
     },
@@ -6436,10 +6436,10 @@
         "BelegteBetten": null,
         "Inzidenz": 228.6,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 189.5
       }
     },
@@ -6459,10 +6459,10 @@
         "BelegteBetten": null,
         "Inzidenz": 212.7,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 190.4
       }
     },
@@ -6482,10 +6482,10 @@
         "BelegteBetten": null,
         "Inzidenz": 218.4,
         "Datum_neu": 1607212800000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 192.7
       }
     },
@@ -6494,23 +6494,46 @@
         "Datum": "07.12.2020",
         "Fallzahl": 8042,
         "ObjectId": 276,
-        "Sterbefall": 95,
-        "Genesungsfall": 5157,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 443,
-        "Zuwachs_Fallzahl": 204,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 204,
         "BelegteBetten": null,
-        "Inzidenz": 262.4,
+        "Inzidenz": 262.401666726535,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "30.11.2020 - 06.12.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 126,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 228.6
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.12.2020",
+        "Fallzahl": 8283,
+        "ObjectId": 277,
+        "Sterbefall": 103,
+        "Genesungsfall": 5410,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 469,
+        "Zuwachs_Fallzahl": 241,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 26,
+        "Zuwachs_Genesung": 253,
+        "BelegteBetten": null,
+        "Inzidenz": 263.3,
+        "Datum_neu": 1607385600000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": "01.12.2020 - 07.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 227.2
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
