### PR TITLE
New data set: 2020-12-09T080904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-08T112603Z.json
+pjson/2020-12-09T080904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-08T112603Z.json pjson/2020-12-09T080904Z.json```:
```
--- pjson/2020-12-08T112603Z.json	2020-12-08 11:26:04.032600632 +0000
+++ pjson/2020-12-09T080904Z.json	2020-12-09 08:09:04.341960398 +0000
@@ -161,6 +161,46 @@
       "sqlType": "sqlTypeOther",
       "domain": null,
       "defaultValue": null
+    },
+    {
+      "name": "Fallzahl_aktiv",
+      "type": "esriFieldTypeInteger",
+      "alias": "Fallzahl_aktiv",
+      "sqlType": "sqlTypeOther",
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "Krh_N_belegt",
+      "type": "esriFieldTypeInteger",
+      "alias": "Krh_N_belegt",
+      "sqlType": "sqlTypeOther",
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "Krh_N_frei",
+      "type": "esriFieldTypeInteger",
+      "alias": "Krh_N_frei",
+      "sqlType": "sqlTypeOther",
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "Krh_I_belegt",
+      "type": "esriFieldTypeInteger",
+      "alias": "Krh_I_belegt",
+      "sqlType": "sqlTypeOther",
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "Krh_I_frei",
+      "type": "esriFieldTypeInteger",
+      "alias": "Krh_I_frei",
+      "sqlType": "sqlTypeOther",
+      "domain": null,
+      "defaultValue": null
     }
   ],
   "features": [
@@ -184,7 +224,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": null,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -207,7 +252,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": null,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -230,7 +280,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": null,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -253,7 +308,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": null,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -276,7 +336,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -299,7 +364,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -322,7 +392,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -345,7 +420,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -368,7 +448,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -391,7 +476,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -414,7 +504,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -437,7 +532,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -460,7 +560,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -483,7 +588,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -506,7 +616,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -529,7 +644,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -552,7 +672,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -575,7 +700,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -598,7 +728,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -621,7 +756,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -644,7 +784,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -667,7 +812,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -690,7 +840,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -713,7 +868,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -736,7 +896,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -759,7 +924,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -782,7 +952,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -805,7 +980,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -828,7 +1008,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -851,7 +1036,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -874,7 +1064,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -897,7 +1092,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -920,7 +1120,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -943,7 +1148,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -966,7 +1176,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -989,7 +1204,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1012,7 +1232,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1035,7 +1260,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1058,7 +1288,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1081,7 +1316,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1104,7 +1344,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1127,7 +1372,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1150,7 +1400,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1173,7 +1428,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1196,7 +1456,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1219,7 +1484,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1242,7 +1512,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1265,7 +1540,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1288,7 +1568,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1311,7 +1596,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1334,7 +1624,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1357,7 +1652,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1380,7 +1680,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1403,7 +1708,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1426,7 +1736,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1449,7 +1764,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1472,7 +1792,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1495,7 +1820,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1518,7 +1848,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1541,7 +1876,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1564,7 +1904,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1587,7 +1932,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1610,7 +1960,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1633,7 +1988,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1656,7 +2016,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1679,7 +2044,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1702,7 +2072,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1725,7 +2100,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1748,7 +2128,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1771,7 +2156,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1794,7 +2184,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1817,7 +2212,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1840,7 +2240,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1863,7 +2268,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1886,7 +2296,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1909,7 +2324,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1932,7 +2352,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1955,7 +2380,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -1978,7 +2408,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2001,7 +2436,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2024,7 +2464,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2047,7 +2492,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2070,7 +2520,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2093,7 +2548,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2116,7 +2576,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2139,7 +2604,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2162,7 +2632,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2185,7 +2660,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2208,7 +2688,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2231,7 +2716,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2254,7 +2744,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2277,7 +2772,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2300,7 +2800,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2323,7 +2828,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2346,7 +2856,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2369,7 +2884,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2392,7 +2912,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2415,7 +2940,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2438,7 +2968,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2461,7 +2996,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2484,7 +3024,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2507,7 +3052,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2530,7 +3080,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2553,7 +3108,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2576,7 +3136,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2599,7 +3164,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2622,7 +3192,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2645,7 +3220,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2668,7 +3248,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2691,7 +3276,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2714,7 +3304,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2737,7 +3332,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2760,7 +3360,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2783,7 +3388,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2806,7 +3416,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2829,7 +3444,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2852,7 +3472,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2875,7 +3500,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2898,7 +3528,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2921,7 +3556,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2944,7 +3584,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2967,7 +3612,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -2990,7 +3640,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3013,7 +3668,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3036,7 +3696,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3059,7 +3724,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3082,7 +3752,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3105,7 +3780,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3128,7 +3808,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3151,7 +3836,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3174,7 +3864,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3197,7 +3892,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3220,7 +3920,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3243,7 +3948,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3266,7 +3976,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3289,7 +4004,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3312,7 +4032,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3335,7 +4060,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3358,7 +4088,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3381,7 +4116,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3404,7 +4144,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3427,7 +4172,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3450,7 +4200,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3473,7 +4228,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3496,7 +4256,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3519,7 +4284,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3542,7 +4312,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3565,7 +4340,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3588,7 +4368,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3611,7 +4396,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3634,7 +4424,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3657,7 +4452,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3680,7 +4480,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3703,7 +4508,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3726,7 +4536,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3749,7 +4564,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3772,7 +4592,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3795,7 +4620,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3818,7 +4648,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3841,7 +4676,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3864,7 +4704,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3887,7 +4732,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3910,7 +4760,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3933,7 +4788,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3956,7 +4816,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -3979,7 +4844,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4002,7 +4872,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4025,7 +4900,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4048,7 +4928,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4071,7 +4956,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4094,7 +4984,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4117,7 +5012,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4140,7 +5040,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4163,7 +5068,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4186,7 +5096,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4209,7 +5124,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4232,7 +5152,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4255,7 +5180,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4278,7 +5208,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4301,7 +5236,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4324,7 +5264,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4347,7 +5292,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4370,7 +5320,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4393,7 +5348,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4416,7 +5376,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4439,7 +5404,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4462,7 +5432,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4485,7 +5460,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4508,7 +5488,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4531,7 +5516,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4554,7 +5544,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4577,7 +5572,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4600,7 +5600,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4623,7 +5628,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4646,7 +5656,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4669,7 +5684,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4692,7 +5712,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4715,7 +5740,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4738,7 +5768,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4761,7 +5796,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4784,7 +5824,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4807,7 +5852,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4830,7 +5880,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4853,7 +5908,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4876,7 +5936,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4899,7 +5964,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4922,7 +5992,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4945,7 +6020,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4968,7 +6048,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -4991,7 +6076,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5014,7 +6104,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5037,7 +6132,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5060,7 +6160,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5083,7 +6188,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5106,7 +6216,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5129,7 +6244,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5152,7 +6272,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5175,7 +6300,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5198,7 +6328,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5221,7 +6356,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5244,7 +6384,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5267,7 +6412,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5290,7 +6440,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5313,7 +6468,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5336,7 +6496,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5359,7 +6524,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5382,7 +6552,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5405,7 +6580,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5428,7 +6608,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5451,7 +6636,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5474,7 +6664,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5497,7 +6692,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5520,7 +6720,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5543,7 +6748,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5566,7 +6776,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5589,7 +6804,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5612,7 +6832,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5635,7 +6860,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5658,7 +6888,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5681,7 +6916,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5704,7 +6944,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5727,7 +6972,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5750,7 +7000,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5773,7 +7028,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5796,7 +7056,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5819,7 +7084,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5842,7 +7112,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5865,7 +7140,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5888,7 +7168,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5911,7 +7196,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5934,7 +7224,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5957,7 +7252,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -5980,7 +7280,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6003,7 +7308,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6026,7 +7336,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6049,7 +7364,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6072,7 +7392,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6095,7 +7420,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6118,7 +7448,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6141,7 +7476,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6164,7 +7504,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6187,7 +7532,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6210,7 +7560,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6233,7 +7588,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6256,7 +7616,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6279,7 +7644,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6302,7 +7672,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6325,7 +7700,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6348,7 +7728,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": null
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6371,7 +7756,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 201.2
+        "Inzidenz_RKI": 201.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6394,7 +7784,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 187.9
+        "Inzidenz_RKI": 187.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 189,
+        "Krh_N_frei": 26,
+        "Krh_I_belegt": 70,
+        "Krh_I_frei": 20
       }
     },
     {
@@ -6417,7 +7812,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 27,
-        "Inzidenz_RKI": 196.3
+        "Inzidenz_RKI": 196.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6440,7 +7840,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 22,
-        "Inzidenz_RKI": 189.5
+        "Inzidenz_RKI": 189.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6463,7 +7868,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 190.4
+        "Inzidenz_RKI": 190.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6486,7 +7896,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 192.7
+        "Inzidenz_RKI": 192.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6509,7 +7924,12 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 228.6
+        "Inzidenz_RKI": 228.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -6532,7 +7952,12 @@
         "Zeitraum": "01.12.2020 - 07.12.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 227.2
+        "Inzidenz_RKI": 227.2,
+        "Fallzahl_aktiv": 2770,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
