### PR TITLE
New data set: 2020-12-09T120703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-08T112603Z.json
+pjson/2020-12-09T120703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-09T080904Z.json pjson/2020-12-09T120703Z.json```:
```
--- pjson/2020-12-09T080904Z.json	2020-12-09 08:09:04.341960398 +0000
+++ pjson/2020-12-09T120703Z.json	2020-12-09 12:07:03.993499451 +0000
@@ -5568,7 +5568,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600041600000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -6940,7 +6940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604275200000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -7192,7 +7192,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -7418,7 +7418,7 @@
         "Datum_neu": 1605744000000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7556,7 +7556,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 268,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -7584,7 +7584,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 262,
+        "F\u00e4lle_Meldedatum": 264,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 4,
@@ -7668,9 +7668,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7696,7 +7696,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -7724,7 +7724,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 206,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 17,
@@ -7750,13 +7750,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
-        "Inzidenz": 229.893315133446,
+        "Inzidenz": null,
         "Datum_neu": 1606780800000,
         "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 201.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -7780,16 +7780,16 @@
         "BelegteBetten": null,
         "Inzidenz": 234.563023097094,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 187.9,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 189,
-        "Krh_N_frei": 26,
-        "Krh_I_belegt": 70,
-        "Krh_I_frei": 20
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
       }
     },
     {
@@ -7808,9 +7808,9 @@
         "BelegteBetten": null,
         "Inzidenz": 232,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
+        "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 196.3,
         "Fallzahl_aktiv": null,
@@ -7836,9 +7836,9 @@
         "BelegteBetten": null,
         "Inzidenz": 228.6,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 12,
+        "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 189.5,
         "Fallzahl_aktiv": null,
@@ -7864,10 +7864,10 @@
         "BelegteBetten": null,
         "Inzidenz": 212.7,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 190.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -7892,7 +7892,7 @@
         "BelegteBetten": null,
         "Inzidenz": 218.4,
         "Datum_neu": 1607212800000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 10,
@@ -7920,10 +7920,10 @@
         "BelegteBetten": null,
         "Inzidenz": 262.401666726535,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 254,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 5,
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 228.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -7937,23 +7937,51 @@
         "Datum": "08.12.2020",
         "Fallzahl": 8283,
         "ObjectId": 277,
-        "Sterbefall": 103,
-        "Genesungsfall": 5410,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 469,
-        "Zuwachs_Fallzahl": 241,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 253,
         "BelegteBetten": null,
-        "Inzidenz": 263.3,
+        "Inzidenz": 263.299687488775,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "01.12.2020 - 07.12.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 138,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 227.2,
-        "Fallzahl_aktiv": 2770,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.12.2020",
+        "Fallzahl": 8566,
+        "ObjectId": 278,
+        "Sterbefall": 110,
+        "Genesungsfall": 5680,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 490,
+        "Zuwachs_Fallzahl": 283,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 270,
+        "BelegteBetten": null,
+        "Inzidenz": 253.6,
+        "Datum_neu": 1607472000000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "02.12.2020 - 08.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 211.8,
+        "Fallzahl_aktiv": 2776,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
