### PR TITLE
New data set: 2020-12-09T122204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-09T120703Z.json
+pjson/2020-12-09T122204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-09T120703Z.json pjson/2020-12-09T122204Z.json```:
```
--- pjson/2020-12-09T120703Z.json	2020-12-09 12:07:03.993499451 +0000
+++ pjson/2020-12-09T122204Z.json	2020-12-09 12:22:04.779973568 +0000
@@ -7750,7 +7750,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 229.893315133446,
         "Datum_neu": 1606780800000,
         "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
@@ -7786,10 +7786,10 @@
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 187.9,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_N_frei": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null
+        "Krh_N_belegt": 189,
+        "Krh_N_frei": 26,
+        "Krh_I_belegt": 70,
+        "Krh_I_frei": 20
       }
     },
     {
@@ -7982,10 +7982,10 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 211.8,
         "Fallzahl_aktiv": 2776,
-        "Krh_N_belegt": null,
-        "Krh_N_frei": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null
+        "Krh_N_belegt": 226,
+        "Krh_N_frei": 23,
+        "Krh_I_belegt": 64,
+        "Krh_I_frei": 21
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
