### PR TITLE
New data set: 2020-12-10T111803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-09T123003Z.json
+pjson/2020-12-10T111803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-09T123003Z.json pjson/2020-12-10T111803Z.json```:
```
--- pjson/2020-12-09T123003Z.json	2020-12-09 12:30:03.963396857 +0000
+++ pjson/2020-12-10T111803Z.json	2020-12-10 11:18:03.737862318 +0000
@@ -8025,7 +8025,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10,
@@ -8335,7 +8335,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 14,
@@ -8366,7 +8366,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 272,
+        "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -8521,7 +8521,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606608000000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -8552,7 +8552,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 17,
@@ -8581,9 +8581,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
-        "Inzidenz": 229.893315133446,
+        "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 327,
+        "F\u00e4lle_Meldedatum": 317,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 21,
@@ -8612,21 +8612,21 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 102,
         "BelegteBetten": null,
-        "Inzidenz": 234.563023097094,
+        "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
-        "Inzidenz_RKI": 187.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 189,
-        "Krh_N_frei": 26,
-        "Krh_I_belegt": 70,
-        "Krh_I_frei": 20,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_N": 215,
-        "Krh_I": 90
+        "Krh_N": null,
+        "Krh_I": null
       }
     },
     {
@@ -8645,7 +8645,7 @@
         "BelegteBetten": null,
         "Inzidenz": 232,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 282,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 27,
@@ -8676,7 +8676,7 @@
         "BelegteBetten": null,
         "Inzidenz": 228.6,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 22,
@@ -8707,10 +8707,10 @@
         "BelegteBetten": null,
         "Inzidenz": 212.7,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 190.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8738,7 +8738,7 @@
         "BelegteBetten": null,
         "Inzidenz": 218.4,
         "Datum_neu": 1607212800000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 10,
@@ -8769,10 +8769,10 @@
         "BelegteBetten": null,
         "Inzidenz": 262.401666726535,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 254,
+        "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 228.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8800,10 +8800,10 @@
         "BelegteBetten": null,
         "Inzidenz": 263.299687488775,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 268,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 15,
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8820,30 +8820,61 @@
         "Datum": "09.12.2020",
         "Fallzahl": 8566,
         "ObjectId": 278,
-        "Sterbefall": 110,
-        "Genesungsfall": 5680,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 490,
-        "Zuwachs_Fallzahl": 283,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 270,
         "BelegteBetten": null,
         "Inzidenz": 253.6,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 21,
-        "Zeitraum": "02.12.2020 - 08.12.2020",
+        "F\u00e4lle_Meldedatum": 207,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": 211.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.12.2020",
+        "Fallzahl": 9011,
+        "ObjectId": 279,
+        "Sterbefall": 122,
+        "Genesungsfall": 5920,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 509,
+        "Zuwachs_Fallzahl": 445,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 240,
+        "BelegteBetten": null,
+        "Inzidenz": 273.4,
+        "Datum_neu": 1607558400000,
+        "F\u00e4lle_Meldedatum": 81,
+        "Zeitraum": "03.12.2020 - 09.12.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 211.8,
-        "Fallzahl_aktiv": 2776,
+        "Inzidenz_RKI": 203.1,
+        "Fallzahl_aktiv": 2969,
         "Krh_N_belegt": 226,
-        "Krh_N_frei": 23,
-        "Krh_I_belegt": 64,
-        "Krh_I_frei": 21,
-        "Fallzahl_aktiv_Zuwachs": 6,
-        "Krh_N": 249,
-        "Krh_I": 85
+        "Krh_N_frei": 31,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": 20,
+        "Fallzahl_aktiv_Zuwachs": 193,
+        "Krh_N": 257,
+        "Krh_I": 83
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
