### PR TITLE
New data set: 2020-12-11T111703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-10T111803Z.json
+pjson/2020-12-11T111703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-10T111803Z.json pjson/2020-12-11T111703Z.json```:
```
--- pjson/2020-12-10T111803Z.json	2020-12-10 11:18:03.737862318 +0000
+++ pjson/2020-12-11T111703Z.json	2020-12-11 11:17:03.679611164 +0000
@@ -7033,7 +7033,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602460800000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7064,7 +7064,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602547200000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -7095,7 +7095,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602633600000,
-        "F\u00e4lle_Meldedatum": 28,
+        "F\u00e4lle_Meldedatum": 29,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7126,7 +7126,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602720000000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1,
@@ -8459,7 +8459,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 226,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -8555,7 +8555,7 @@
         "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8583,10 +8583,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 317,
+        "F\u00e4lle_Meldedatum": 318,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8643,13 +8643,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 106,
         "BelegteBetten": null,
-        "Inzidenz": 232,
+        "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 282,
+        "F\u00e4lle_Meldedatum": 284,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 27,
-        "Inzidenz_RKI": 196.3,
+        "SterbeF_Meldedatum": 7,
+        "Hosp_Meldedatum": 29,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -8769,10 +8769,10 @@
         "BelegteBetten": null,
         "Inzidenz": 262.401666726535,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 307,
+        "F\u00e4lle_Meldedatum": 339,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 12,
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 228.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8800,10 +8800,10 @@
         "BelegteBetten": null,
         "Inzidenz": 263.299687488775,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 268,
+        "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8831,10 +8831,10 @@
         "BelegteBetten": null,
         "Inzidenz": 253.6,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 346,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 8,
+        "SterbeF_Meldedatum": 12,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 211.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8851,30 +8851,61 @@
         "Datum": "10.12.2020",
         "Fallzahl": 9011,
         "ObjectId": 279,
-        "Sterbefall": 122,
-        "Genesungsfall": 5920,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 509,
-        "Zuwachs_Fallzahl": 445,
-        "Zuwachs_Sterbefall": 12,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 240,
         "BelegteBetten": null,
         "Inzidenz": 273.4,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 81,
-        "Zeitraum": "03.12.2020 - 09.12.2020",
+        "F\u00e4lle_Meldedatum": 336,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": 203.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.12.2020",
+        "Fallzahl": 9570,
+        "ObjectId": 280,
+        "Sterbefall": 136,
+        "Genesungsfall": 6140,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 548,
+        "Zuwachs_Fallzahl": 559,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 39,
+        "Zuwachs_Genesung": 220,
+        "BelegteBetten": null,
+        "Inzidenz": 319.9,
+        "Datum_neu": 1607644800000,
+        "F\u00e4lle_Meldedatum": 88,
+        "Zeitraum": "04.12.2020 - 10.12.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 203.1,
-        "Fallzahl_aktiv": 2969,
-        "Krh_N_belegt": 226,
-        "Krh_N_frei": 31,
-        "Krh_I_belegt": 63,
-        "Krh_I_frei": 20,
-        "Fallzahl_aktiv_Zuwachs": 193,
-        "Krh_N": 257,
-        "Krh_I": 83
+        "Inzidenz_RKI": 239.6,
+        "Fallzahl_aktiv": 3294,
+        "Krh_N_belegt": 233,
+        "Krh_N_frei": 30,
+        "Krh_I_belegt": 65,
+        "Krh_I_frei": 19,
+        "Fallzahl_aktiv_Zuwachs": 325,
+        "Krh_N": 263,
+        "Krh_I": 84
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
