### PR TITLE
New data set: 2020-12-12T111803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-11T111703Z.json
+pjson/2020-12-12T111803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-11T111703Z.json pjson/2020-12-12T111803Z.json```:
```
--- pjson/2020-12-11T111703Z.json	2020-12-11 11:17:03.679611164 +0000
+++ pjson/2020-12-12T111803Z.json	2020-12-12 11:18:03.796645819 +0000
@@ -7777,7 +7777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
@@ -7901,7 +7901,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604880000000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 7,
@@ -8118,7 +8118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -8211,7 +8211,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -8335,7 +8335,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 14,
@@ -8397,10 +8397,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 264,
+        "F\u00e4lle_Meldedatum": 269,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 4,
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8428,9 +8428,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 251,
+        "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 7,
+        "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8461,7 +8461,7 @@
         "Datum_neu": 1606435200000,
         "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8554,7 +8554,7 @@
         "Datum_neu": 1606694400000,
         "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 13,
+        "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8616,7 +8616,7 @@
         "Datum_neu": 1606867200000,
         "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 5,
+        "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8647,7 +8647,7 @@
         "Datum_neu": 1606953600000,
         "F\u00e4lle_Meldedatum": 284,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 7,
+        "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8674,13 +8674,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 182,
         "BelegteBetten": null,
-        "Inzidenz": 228.6,
+        "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 22,
-        "Inzidenz_RKI": 189.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -8741,7 +8741,7 @@
         "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 192.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8769,7 +8769,7 @@
         "BelegteBetten": null,
         "Inzidenz": 262.401666726535,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 339,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 15,
@@ -8800,10 +8800,10 @@
         "BelegteBetten": null,
         "Inzidenz": 263.299687488775,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 302,
+        "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 27,
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8831,10 +8831,10 @@
         "BelegteBetten": null,
         "Inzidenz": 253.6,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 346,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 15,
+        "SterbeF_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 211.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8862,10 +8862,10 @@
         "BelegteBetten": null,
         "Inzidenz": 273.4,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 17,
+        "SterbeF_Meldedatum": 12,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 203.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8882,30 +8882,61 @@
         "Datum": "11.12.2020",
         "Fallzahl": 9570,
         "ObjectId": 280,
-        "Sterbefall": 136,
-        "Genesungsfall": 6140,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 548,
-        "Zuwachs_Fallzahl": 559,
-        "Zuwachs_Sterbefall": 14,
-        "Zuwachs_Krankenhauseinweisung": 39,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 220,
         "BelegteBetten": null,
         "Inzidenz": 319.9,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 88,
-        "Zeitraum": "04.12.2020 - 10.12.2020",
+        "F\u00e4lle_Meldedatum": 118,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 239.6,
-        "Fallzahl_aktiv": 3294,
-        "Krh_N_belegt": 233,
-        "Krh_N_frei": 30,
-        "Krh_I_belegt": 65,
-        "Krh_I_frei": 19,
-        "Fallzahl_aktiv_Zuwachs": 325,
-        "Krh_N": 263,
-        "Krh_I": 84
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.12.2020",
+        "Fallzahl": 9771,
+        "ObjectId": 281,
+        "Sterbefall": 145,
+        "Genesungsfall": 6277,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 558,
+        "Zuwachs_Fallzahl": 201,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 137,
+        "BelegteBetten": null,
+        "Inzidenz": 321.3,
+        "Datum_neu": 1607731200000,
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": "05.12.2020 - 11.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 300.7,
+        "Fallzahl_aktiv": 3349,
+        "Krh_N_belegt": 236,
+        "Krh_N_frei": 38,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": 15,
+        "Fallzahl_aktiv_Zuwachs": 55,
+        "Krh_N": 274,
+        "Krh_I": 83
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
