### PR TITLE
New data set: 2020-12-13T110904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-12T111803Z.json
+pjson/2020-12-13T110904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-12T111803Z.json pjson/2020-12-13T110904Z.json```:
```
--- pjson/2020-12-12T111803Z.json	2020-12-12 11:18:03.796645819 +0000
+++ pjson/2020-12-13T110904Z.json	2020-12-13 11:09:04.435678280 +0000
@@ -8369,7 +8369,7 @@
         "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8397,7 +8397,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 269,
+        "F\u00e4lle_Meldedatum": 270,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -8428,7 +8428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 252,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
@@ -8645,7 +8645,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 284,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 29,
@@ -8678,7 +8678,7 @@
         "Datum_neu": 1607040000000,
         "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 13,
+        "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8705,13 +8705,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 93,
         "BelegteBetten": null,
-        "Inzidenz": 212.7,
+        "Inzidenz": null,
         "Datum_neu": 1607126400000,
         "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 190.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -8771,7 +8771,7 @@
         "Datum_neu": 1607299200000,
         "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
+        "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 228.6,
         "Fallzahl_aktiv": null,
@@ -8800,9 +8800,9 @@
         "BelegteBetten": null,
         "Inzidenz": 263.299687488775,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 315,
+        "F\u00e4lle_Meldedatum": 321,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
+        "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": null,
@@ -8833,7 +8833,7 @@
         "Datum_neu": 1607472000000,
         "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 17,
+        "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 211.8,
         "Fallzahl_aktiv": null,
@@ -8862,7 +8862,7 @@
         "BelegteBetten": null,
         "Inzidenz": 273.4,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 389,
+        "F\u00e4lle_Meldedatum": 398,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 21,
@@ -8893,7 +8893,7 @@
         "BelegteBetten": null,
         "Inzidenz": 319.9,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -8913,30 +8913,61 @@
         "Datum": "12.12.2020",
         "Fallzahl": 9771,
         "ObjectId": 281,
-        "Sterbefall": 145,
-        "Genesungsfall": 6277,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 558,
-        "Zuwachs_Fallzahl": 201,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 137,
         "BelegteBetten": null,
         "Inzidenz": 321.3,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 71,
-        "Zeitraum": "05.12.2020 - 11.12.2020",
+        "F\u00e4lle_Meldedatum": 191,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 300.7,
-        "Fallzahl_aktiv": 3349,
-        "Krh_N_belegt": 236,
-        "Krh_N_frei": 38,
-        "Krh_I_belegt": 68,
-        "Krh_I_frei": 15,
-        "Fallzahl_aktiv_Zuwachs": 55,
-        "Krh_N": 274,
-        "Krh_I": 83
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.12.2020",
+        "Fallzahl": 9998,
+        "ObjectId": 282,
+        "Sterbefall": 151,
+        "Genesungsfall": 6363,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 559,
+        "Zuwachs_Fallzahl": 227,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 86,
+        "BelegteBetten": null,
+        "Inzidenz": 344.5,
+        "Datum_neu": 1607817600000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": "06.12.2020 - 12.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 311.4,
+        "Fallzahl_aktiv": 3484,
+        "Krh_N_belegt": 228,
+        "Krh_N_frei": 44,
+        "Krh_I_belegt": 69,
+        "Krh_I_frei": 12,
+        "Fallzahl_aktiv_Zuwachs": 135,
+        "Krh_N": 272,
+        "Krh_I": 81
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
