### PR TITLE
New data set: 2020-12-14T111203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-13T110904Z.json
+pjson/2020-12-14T111203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-13T110904Z.json pjson/2020-12-14T111203Z.json```:
```
--- pjson/2020-12-13T110904Z.json	2020-12-13 11:09:04.435678280 +0000
+++ pjson/2020-12-14T111203Z.json	2020-12-14 11:12:03.967281130 +0000
@@ -7128,7 +7128,7 @@
         "Datum_neu": 1602720000000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7283,7 +7283,7 @@
         "Datum_neu": 1603152000000,
         "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7345,7 +7345,7 @@
         "Datum_neu": 1603324800000,
         "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7469,7 +7469,7 @@
         "Datum_neu": 1603670400000,
         "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7500,7 +7500,7 @@
         "Datum_neu": 1603756800000,
         "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7531,7 +7531,7 @@
         "Datum_neu": 1603843200000,
         "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7686,7 +7686,7 @@
         "Datum_neu": 1604275200000,
         "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7717,7 +7717,7 @@
         "Datum_neu": 1604361600000,
         "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
+        "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7841,7 +7841,7 @@
         "Datum_neu": 1604707200000,
         "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7903,7 +7903,7 @@
         "Datum_neu": 1604880000000,
         "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8366,7 +8366,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 271,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8,
@@ -8397,7 +8397,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 270,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -8583,7 +8583,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 318,
+        "F\u00e4lle_Meldedatum": 323,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 22,
@@ -8645,7 +8645,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 286,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 29,
@@ -8736,13 +8736,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 36,
         "BelegteBetten": null,
-        "Inzidenz": 218.4,
+        "Inzidenz": null,
         "Datum_neu": 1607212800000,
         "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 192.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -8769,9 +8769,9 @@
         "BelegteBetten": null,
         "Inzidenz": 262.401666726535,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
+        "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 228.6,
         "Fallzahl_aktiv": null,
@@ -8800,10 +8800,10 @@
         "BelegteBetten": null,
         "Inzidenz": 263.299687488775,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 321,
+        "F\u00e4lle_Meldedatum": 320,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8831,10 +8831,10 @@
         "BelegteBetten": null,
         "Inzidenz": 253.6,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 365,
+        "F\u00e4lle_Meldedatum": 385,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 211.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8862,10 +8862,10 @@
         "BelegteBetten": null,
         "Inzidenz": 273.4,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 398,
+        "F\u00e4lle_Meldedatum": 444,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 203.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8893,10 +8893,10 @@
         "BelegteBetten": null,
         "Inzidenz": 319.9,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 239.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8924,10 +8924,10 @@
         "BelegteBetten": null,
         "Inzidenz": 321.3,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 297,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 300.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8944,30 +8944,61 @@
         "Datum": "13.12.2020",
         "Fallzahl": 9998,
         "ObjectId": 282,
-        "Sterbefall": 151,
-        "Genesungsfall": 6363,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 559,
-        "Zuwachs_Fallzahl": 227,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 86,
         "BelegteBetten": null,
         "Inzidenz": 344.5,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 61,
-        "Zeitraum": "06.12.2020 - 12.12.2020",
+        "F\u00e4lle_Meldedatum": 121,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 311.4,
-        "Fallzahl_aktiv": 3484,
-        "Krh_N_belegt": 228,
-        "Krh_N_frei": 44,
-        "Krh_I_belegt": 69,
-        "Krh_I_frei": 12,
-        "Fallzahl_aktiv_Zuwachs": 135,
-        "Krh_N": 272,
-        "Krh_I": 81
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.12.2020",
+        "Fallzahl": 10439,
+        "ObjectId": 283,
+        "Sterbefall": 155,
+        "Genesungsfall": 6558,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 580,
+        "Zuwachs_Fallzahl": 441,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 195,
+        "BelegteBetten": null,
+        "Inzidenz": 389,
+        "Datum_neu": 1607904000000,
+        "F\u00e4lle_Meldedatum": 85,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 322.4,
+        "Fallzahl_aktiv": 3726,
+        "Krh_N_belegt": 247,
+        "Krh_N_frei": 34,
+        "Krh_I_belegt": 76,
+        "Krh_I_frei": 8,
+        "Fallzahl_aktiv_Zuwachs": 242,
+        "Krh_N": 281,
+        "Krh_I": 84
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
