### PR TITLE
New data set: 2020-12-14T155003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-14T111203Z.json
+pjson/2020-12-14T155003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-14T111203Z.json pjson/2020-12-14T155003Z.json```:
```
--- pjson/2020-12-14T111203Z.json	2020-12-14 11:12:03.967281130 +0000
+++ pjson/2020-12-14T155003Z.json	2020-12-14 15:50:03.631339260 +0000
@@ -8987,7 +8987,7 @@
         "Inzidenz": 389,
         "Datum_neu": 1607904000000,
         "F\u00e4lle_Meldedatum": 85,
-        "Zeitraum": null,
+        "Zeitraum": "07.12.2020 - 13.12.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 322.4,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
