### PR TITLE
New data set: 2020-12-15T112404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-14T111203Z.json
+pjson/2020-12-15T112404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-14T155003Z.json pjson/2020-12-15T112404Z.json```:
```
--- pjson/2020-12-14T155003Z.json	2020-12-14 15:50:03.631339260 +0000
+++ pjson/2020-12-15T112404Z.json	2020-12-15 11:24:04.836423152 +0000
@@ -8583,7 +8583,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 323,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 22,
@@ -8645,7 +8645,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 29,
@@ -8676,10 +8676,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8707,7 +8707,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 14,
@@ -8738,7 +8738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607212800000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 11,
@@ -8767,13 +8767,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 204,
         "BelegteBetten": null,
-        "Inzidenz": 262.401666726535,
+        "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 344,
+        "F\u00e4lle_Meldedatum": 350,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 228.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -8800,7 +8800,7 @@
         "BelegteBetten": null,
         "Inzidenz": 263.299687488775,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 320,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -8831,7 +8831,7 @@
         "BelegteBetten": null,
         "Inzidenz": 253.6,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 385,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 17,
@@ -8862,7 +8862,7 @@
         "BelegteBetten": null,
         "Inzidenz": 273.4,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 444,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 22,
@@ -8893,7 +8893,7 @@
         "BelegteBetten": null,
         "Inzidenz": 319.9,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 303,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 5,
@@ -8924,10 +8924,10 @@
         "BelegteBetten": null,
         "Inzidenz": 321.3,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 297,
+        "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 300.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8955,10 +8955,10 @@
         "BelegteBetten": null,
         "Inzidenz": 344.5,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 311.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8975,30 +8975,61 @@
         "Datum": "14.12.2020",
         "Fallzahl": 10439,
         "ObjectId": 283,
-        "Sterbefall": 155,
-        "Genesungsfall": 6558,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 580,
-        "Zuwachs_Fallzahl": 441,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 195,
         "BelegteBetten": null,
         "Inzidenz": 389,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 85,
-        "Zeitraum": "07.12.2020 - 13.12.2020",
+        "F\u00e4lle_Meldedatum": 325,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": 322.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.12.2020",
+        "Fallzahl": 10787,
+        "ObjectId": 284,
+        "Sterbefall": 164,
+        "Genesungsfall": 6848,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 590,
+        "Zuwachs_Fallzahl": 348,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 290,
+        "BelegteBetten": null,
+        "Inzidenz": 397.6,
+        "Datum_neu": 1607990400000,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 322.4,
-        "Fallzahl_aktiv": 3726,
-        "Krh_N_belegt": 247,
-        "Krh_N_frei": 34,
-        "Krh_I_belegt": 76,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": 3775,
+        "Krh_N_belegt": 282,
+        "Krh_N_frei": 17,
+        "Krh_I_belegt": 79,
         "Krh_I_frei": 8,
-        "Fallzahl_aktiv_Zuwachs": 242,
-        "Krh_N": 281,
-        "Krh_I": 84
+        "Fallzahl_aktiv_Zuwachs": 49,
+        "Krh_N": 299,
+        "Krh_I": 87
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
