### PR TITLE
New data set: 2020-12-16T110604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-15T112404Z.json
+pjson/2020-12-16T110604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-15T112404Z.json pjson/2020-12-16T110604Z.json```:
```
--- pjson/2020-12-15T112404Z.json	2020-12-15 11:24:04.836423152 +0000
+++ pjson/2020-12-16T110604Z.json	2020-12-16 11:06:04.430770507 +0000
@@ -8583,7 +8583,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 323,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 22,
@@ -8769,7 +8769,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 350,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 15,
@@ -8798,13 +8798,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 253,
         "BelegteBetten": null,
-        "Inzidenz": 263.299687488775,
+        "Inzidenz": null,
         "Datum_neu": 1607385600000,
         "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
-        "Inzidenz_RKI": 227.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -8831,10 +8831,10 @@
         "BelegteBetten": null,
         "Inzidenz": 253.6,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 211.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8862,10 +8862,10 @@
         "BelegteBetten": null,
         "Inzidenz": 273.4,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 203.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8893,9 +8893,9 @@
         "BelegteBetten": null,
         "Inzidenz": 319.9,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 303,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 239.6,
         "Fallzahl_aktiv": null,
@@ -8924,7 +8924,7 @@
         "BelegteBetten": null,
         "Inzidenz": 321.3,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 307,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
@@ -8955,7 +8955,7 @@
         "BelegteBetten": null,
         "Inzidenz": 344.5,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -8986,10 +8986,10 @@
         "BelegteBetten": null,
         "Inzidenz": 389,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 9,
-        "Hosp_Meldedatum": 7,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 322.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9006,29 +9006,60 @@
         "Datum": "15.12.2020",
         "Fallzahl": 10787,
         "ObjectId": 284,
-        "Sterbefall": 164,
-        "Genesungsfall": 6848,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 590,
-        "Zuwachs_Fallzahl": 348,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 290,
         "BelegteBetten": null,
         "Inzidenz": 397.6,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 254,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 19,
+        "Inzidenz_RKI": 260.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.12.2020",
+        "Fallzahl": 11113,
+        "ObjectId": 285,
+        "Sterbefall": 169,
+        "Genesungsfall": 7114,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 622,
+        "Zuwachs_Fallzahl": 326,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 32,
+        "Zuwachs_Genesung": 266,
+        "BelegteBetten": null,
+        "Inzidenz": 401.1,
+        "Datum_neu": 1608076800000,
+        "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 3775,
-        "Krh_N_belegt": 282,
-        "Krh_N_frei": 17,
-        "Krh_I_belegt": 79,
-        "Krh_I_frei": 8,
-        "Fallzahl_aktiv_Zuwachs": 49,
-        "Krh_N": 299,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 344.5,
+        "Fallzahl_aktiv": 3830,
+        "Krh_N_belegt": 363,
+        "Krh_N_frei": 37,
+        "Krh_I_belegt": 87,
+        "Krh_I_frei": 0,
+        "Fallzahl_aktiv_Zuwachs": 55,
+        "Krh_N": 400,
         "Krh_I": 87
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
