### PR TITLE
New data set: 2020-12-16T111503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-15T112404Z.json
+pjson/2020-12-16T111503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-16T110604Z.json pjson/2020-12-16T111503Z.json```:
```
--- pjson/2020-12-16T110604Z.json	2020-12-16 11:06:04.430770507 +0000
+++ pjson/2020-12-16T111503Z.json	2020-12-16 11:15:03.951643101 +0000
@@ -9021,7 +9021,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 260.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
