### PR TITLE
New data set: 2020-12-17T112304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-16T110604Z.json
+pjson/2020-12-17T112304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-16T113203Z.json pjson/2020-12-17T112304Z.json```:
```
--- pjson/2020-12-16T113203Z.json	2020-12-16 11:32:03.771083287 +0000
+++ pjson/2020-12-17T112304Z.json	2020-12-17 11:23:04.182785584 +0000
@@ -6847,7 +6847,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601942400000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7064,7 +7064,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602547200000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -7250,7 +7250,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7312,7 +7312,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603238400000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -7374,7 +7374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603411200000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -7467,7 +7467,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
@@ -7498,7 +7498,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
@@ -7560,7 +7560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603929600000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 9,
@@ -7653,7 +7653,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604188800000,
-        "F\u00e4lle_Meldedatum": 33,
+        "F\u00e4lle_Meldedatum": 35,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7777,7 +7777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
@@ -7808,7 +7808,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604620800000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8,
@@ -7994,7 +7994,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 11,
@@ -8149,7 +8149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -8428,7 +8428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
@@ -8583,7 +8583,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 323,
+        "F\u00e4lle_Meldedatum": 321,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 22,
@@ -8645,7 +8645,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 29,
@@ -8676,7 +8676,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 23,
@@ -8738,7 +8738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607212800000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 11,
@@ -8829,13 +8829,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 270,
         "BelegteBetten": null,
-        "Inzidenz": 253.6,
+        "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 389,
+        "F\u00e4lle_Meldedatum": 390,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 211.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -8860,9 +8860,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 240,
         "BelegteBetten": null,
-        "Inzidenz": 273.4,
+        "Inzidenz": 273.357520025863,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -8893,10 +8893,10 @@
         "BelegteBetten": null,
         "Inzidenz": 319.9,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 314,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 239.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8924,7 +8924,7 @@
         "BelegteBetten": null,
         "Inzidenz": 321.3,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
@@ -8958,7 +8958,7 @@
         "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 311.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8986,10 +8986,10 @@
         "BelegteBetten": null,
         "Inzidenz": 389,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 322.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9015,12 +9015,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 290,
         "BelegteBetten": null,
-        "Inzidenz": 397.6,
+        "Inzidenz": 397.643593519882,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 254,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9037,30 +9037,61 @@
         "Datum": "16.12.2020",
         "Fallzahl": 11113,
         "ObjectId": 285,
-        "Sterbefall": 169,
-        "Genesungsfall": 7114,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 622,
-        "Zuwachs_Fallzahl": 326,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 32,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 266,
         "BelegteBetten": null,
         "Inzidenz": 401.1,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "09.12.2020 - 15.12.2020",
+        "F\u00e4lle_Meldedatum": 126,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 344.5,
-        "Fallzahl_aktiv": 3830,
-        "Krh_N_belegt": 363,
-        "Krh_N_frei": 37,
-        "Krh_I_belegt": 87,
-        "Krh_I_frei": 0,
-        "Fallzahl_aktiv_Zuwachs": 55,
-        "Krh_N": 400,
-        "Krh_I": 87
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.12.2020",
+        "Fallzahl": 11386,
+        "ObjectId": 286,
+        "Sterbefall": 169,
+        "Genesungsfall": 7385,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": 273,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 22,
+        "Zuwachs_Genesung": 271,
+        "BelegteBetten": null,
+        "Inzidenz": 370.343762347785,
+        "Datum_neu": 1608163200000,
+        "F\u00e4lle_Meldedatum": 58,
+        "Zeitraum": "10.12.2020 - 16.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 335.3,
+        "Fallzahl_aktiv": 3832,
+        "Krh_N_belegt": 275,
+        "Krh_N_frei": 51,
+        "Krh_I_belegt": 86,
+        "Krh_I_frei": 2,
+        "Fallzahl_aktiv_Zuwachs": 2,
+        "Krh_N": 326,
+        "Krh_I": 88
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
