### PR TITLE
New data set: 2020-12-17T113404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-17T112304Z.json
+pjson/2020-12-17T113404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-17T112304Z.json pjson/2020-12-17T113404Z.json```:
```
--- pjson/2020-12-17T112304Z.json	2020-12-17 11:23:04.182785584 +0000
+++ pjson/2020-12-17T113404Z.json	2020-12-17 11:34:04.586475806 +0000
@@ -9071,7 +9071,7 @@
         "Sterbefall": 169,
         "Genesungsfall": 7385,
         "Anzeige_Indikator": "x",
-        "Hospitalisierung": null,
+        "Hospitalisierung": 644,
         "Zuwachs_Fallzahl": 273,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 22,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
