### PR TITLE
New data set: 2020-12-18T112203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-17T113404Z.json
+pjson/2020-12-18T112203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-18T063604Z.json pjson/2020-12-18T112203Z.json```:
```
--- pjson/2020-12-18T063604Z.json	2020-12-18 06:36:04.758303212 +0000
+++ pjson/2020-12-18T112203Z.json	2020-12-18 11:22:03.864677100 +0000
@@ -8413,7 +8413,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -8637,9 +8637,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8669,7 +8669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 272,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -8733,7 +8733,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 5,
@@ -8864,7 +8864,7 @@
         "F\u00e4lle_Meldedatum": 321,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8928,7 +8928,7 @@
         "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8957,10 +8957,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 200,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9056,7 +9056,7 @@
         "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9117,10 +9117,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9147,9 +9147,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 240,
         "BelegteBetten": null,
-        "Inzidenz": 273.357520025863,
+        "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 453,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -9181,10 +9181,10 @@
         "BelegteBetten": null,
         "Inzidenz": 319.9,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 314,
+        "F\u00e4lle_Meldedatum": 320,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 239.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": 321.3,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
@@ -9277,10 +9277,10 @@
         "BelegteBetten": null,
         "Inzidenz": 389,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 15,
+        "SterbeF_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 322.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9309,10 +9309,10 @@
         "BelegteBetten": null,
         "Inzidenz": 397.643593519882,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 378,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 26,
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9341,10 +9341,10 @@
         "BelegteBetten": null,
         "Inzidenz": 401.1,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 344.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9364,7 +9364,7 @@
         "ObjectId": 286,
         "Sterbefall": 169,
         "Genesungsfall": 7385,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 644,
         "Zuwachs_Fallzahl": 273,
         "Zuwachs_Sterbefall": 0,
@@ -9373,19 +9373,51 @@
         "BelegteBetten": null,
         "Inzidenz": 370.343762347785,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 58,
-        "Zeitraum": "10.12.2020 - 16.12.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 293,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 335.3,
         "Fallzahl_aktiv": 3832,
-        "Krh_N_belegt": 275,
-        "Krh_N_frei": 51,
-        "Krh_I_belegt": 86,
-        "Krh_I_frei": 2,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 2,
-        "Krh_N": 326,
-        "Krh_I": 88,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.12.2020",
+        "Fallzahl": 11940,
+        "ObjectId": 287,
+        "Sterbefall": 186,
+        "Genesungsfall": 7544,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 685,
+        "Zuwachs_Fallzahl": 554,
+        "Zuwachs_Sterbefall": 17,
+        "Zuwachs_Krankenhauseinweisung": 41,
+        "Zuwachs_Genesung": 159,
+        "BelegteBetten": null,
+        "Inzidenz": 384.712094543626,
+        "Datum_neu": 1608249600000,
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": "11.12.2020 - 17.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 295.8,
+        "Fallzahl_aktiv": 4210,
+        "Krh_N_belegt": 276,
+        "Krh_N_frei": 53,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": 12,
+        "Fallzahl_aktiv_Zuwachs": 378,
+        "Krh_N": 329,
+        "Krh_I": 94,
         "Vorz_akt_Faelle": "+"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
