### PR TITLE
New data set: 2020-12-19T110303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-18T112203Z.json
+pjson/2020-12-19T110303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-18T112203Z.json pjson/2020-12-19T110303Z.json```:
```
--- pjson/2020-12-18T112203Z.json	2020-12-18 11:22:03.864677100 +0000
+++ pjson/2020-12-19T110303Z.json	2020-12-19 11:03:04.022023858 +0000
@@ -7357,7 +7357,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602720000000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7901,7 +7901,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604188800000,
-        "F\u00e4lle_Meldedatum": 35,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 258,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
@@ -8925,7 +8925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 286,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 28,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 323,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 20,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 455,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -9179,7 +9179,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 220,
         "BelegteBetten": null,
-        "Inzidenz": 319.9,
+        "Inzidenz": null,
         "Datum_neu": 1607644800000,
         "F\u00e4lle_Meldedatum": 320,
         "Zeitraum": null,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": 321.3,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": 389,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 402,
+        "F\u00e4lle_Meldedatum": 404,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 18,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": 397.643593519882,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 378,
+        "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 31,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": 401.1,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 320,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 25,
@@ -9362,28 +9362,28 @@
         "Datum": "17.12.2020",
         "Fallzahl": 11386,
         "ObjectId": 286,
-        "Sterbefall": 169,
-        "Genesungsfall": 7385,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 644,
-        "Zuwachs_Fallzahl": 273,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 22,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 271,
         "BelegteBetten": null,
         "Inzidenz": 370.343762347785,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 377,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 18,
+        "SterbeF_Meldedatum": 12,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 335.3,
-        "Fallzahl_aktiv": 3832,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9396,28 +9396,60 @@
         "ObjectId": 287,
         "Sterbefall": 186,
         "Genesungsfall": 7544,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 685,
-        "Zuwachs_Fallzahl": 554,
-        "Zuwachs_Sterbefall": 17,
-        "Zuwachs_Krankenhauseinweisung": 41,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 159,
         "BelegteBetten": null,
-        "Inzidenz": 384.712094543626,
+        "Inzidenz": 384.7,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 65,
-        "Zeitraum": "11.12.2020 - 17.12.2020",
+        "F\u00e4lle_Meldedatum": 149,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 295.8,
         "Fallzahl_aktiv": 4210,
-        "Krh_N_belegt": 276,
-        "Krh_N_frei": 53,
-        "Krh_I_belegt": 82,
-        "Krh_I_frei": 12,
-        "Fallzahl_aktiv_Zuwachs": 378,
-        "Krh_N": 329,
-        "Krh_I": 94,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.12.2020",
+        "Fallzahl": 12164,
+        "ObjectId": 288,
+        "Sterbefall": 187,
+        "Genesungsfall": 7637,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 706,
+        "Zuwachs_Fallzahl": 224,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 93,
+        "BelegteBetten": null,
+        "Inzidenz": 371.960199719818,
+        "Datum_neu": 1608336000000,
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": "12.12.2020 - 18.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 338.7,
+        "Fallzahl_aktiv": 4340,
+        "Krh_N_belegt": 260,
+        "Krh_N_frei": 65,
+        "Krh_I_belegt": 76,
+        "Krh_I_frei": 17,
+        "Fallzahl_aktiv_Zuwachs": 130,
+        "Krh_N": 325,
+        "Krh_I": 93,
         "Vorz_akt_Faelle": "+"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
