### PR TITLE
New data set: 2020-12-20T124103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-19T110303Z.json
+pjson/2020-12-20T124103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-19T110303Z.json pjson/2020-12-20T124103Z.json```:
```
--- pjson/2020-12-19T110303Z.json	2020-12-19 11:03:04.022023858 +0000
+++ pjson/2020-12-20T124103Z.json	2020-12-20 12:41:03.205850851 +0000
@@ -7965,7 +7965,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 161,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 5,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 258,
+        "F\u00e4lle_Meldedatum": 261,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
@@ -8829,7 +8829,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 23,
@@ -8957,7 +8957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 201,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 455,
+        "F\u00e4lle_Meldedatum": 456,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -9211,7 +9211,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 137,
         "BelegteBetten": null,
-        "Inzidenz": 321.3,
+        "Inzidenz": null,
         "Datum_neu": 1607731200000,
         "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": 389,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 404,
+        "F\u00e4lle_Meldedatum": 406,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 18,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": 370.343762347785,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 377,
+        "F\u00e4lle_Meldedatum": 400,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 26,
@@ -9394,10 +9394,10 @@
         "Datum": "18.12.2020",
         "Fallzahl": 11940,
         "ObjectId": 287,
-        "Sterbefall": 186,
-        "Genesungsfall": 7544,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 685,
+        "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
@@ -9405,12 +9405,12 @@
         "BelegteBetten": null,
         "Inzidenz": 384.7,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 295.8,
-        "Fallzahl_aktiv": 4210,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
@@ -9426,31 +9426,63 @@
         "Datum": "19.12.2020",
         "Fallzahl": 12164,
         "ObjectId": 288,
-        "Sterbefall": 187,
-        "Genesungsfall": 7637,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 706,
-        "Zuwachs_Fallzahl": 224,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 93,
         "BelegteBetten": null,
         "Inzidenz": 371.960199719818,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 36,
-        "Zeitraum": "12.12.2020 - 18.12.2020",
+        "F\u00e4lle_Meldedatum": 94,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 338.7,
-        "Fallzahl_aktiv": 4340,
-        "Krh_N_belegt": 260,
-        "Krh_N_frei": 65,
-        "Krh_I_belegt": 76,
-        "Krh_I_frei": 17,
-        "Fallzahl_aktiv_Zuwachs": 130,
-        "Krh_N": 325,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.12.2020",
+        "Fallzahl": 12303,
+        "ObjectId": 289,
+        "Sterbefall": 187,
+        "Genesungsfall": 7796,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 708,
+        "Zuwachs_Fallzahl": 139,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 159,
+        "BelegteBetten": null,
+        "Inzidenz": 343.223535328137,
+        "Datum_neu": 1608422400000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "13.12.2020 - 19.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 318.1,
+        "Fallzahl_aktiv": 4320,
+        "Krh_N_belegt": 264,
+        "Krh_N_frei": 66,
+        "Krh_I_belegt": 78,
+        "Krh_I_frei": 15,
+        "Fallzahl_aktiv_Zuwachs": -20,
+        "Krh_N": 330,
         "Krh_I": 93,
-        "Vorz_akt_Faelle": "+"
+        "Vorz_akt_Faelle": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
