### PR TITLE
New data set: 2020-12-21T111503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-20T124103Z.json
+pjson/2020-12-21T111503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-20T124103Z.json pjson/2020-12-21T111503Z.json```:
```
--- pjson/2020-12-20T124103Z.json	2020-12-20 12:41:03.205850851 +0000
+++ pjson/2020-12-21T111503Z.json	2020-12-21 11:15:03.749326356 +0000
@@ -8639,7 +8639,7 @@
         "Datum_neu": 1606176000000,
         "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 261,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
@@ -8861,7 +8861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 321,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 23,
@@ -8925,7 +8925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 28,
@@ -8957,7 +8957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
@@ -9053,7 +9053,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 16,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 20,
@@ -9149,11 +9149,11 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 456,
+        "F\u00e4lle_Meldedatum": 457,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 203.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9181,11 +9181,11 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 320,
+        "F\u00e4lle_Meldedatum": 321,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 239.6,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9243,7 +9243,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 86,
         "BelegteBetten": null,
-        "Inzidenz": 344.5,
+        "Inzidenz": null,
         "Datum_neu": 1607817600000,
         "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
@@ -9309,10 +9309,10 @@
         "BelegteBetten": null,
         "Inzidenz": 397.643593519882,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 381,
+        "F\u00e4lle_Meldedatum": 398,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": 401.1,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 320,
+        "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 25,
@@ -9373,10 +9373,10 @@
         "BelegteBetten": null,
         "Inzidenz": 370.343762347785,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 400,
+        "F\u00e4lle_Meldedatum": 462,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 335.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9405,10 +9405,10 @@
         "BelegteBetten": null,
         "Inzidenz": 384.7,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 14,
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 295.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9426,10 +9426,10 @@
         "Datum": "19.12.2020",
         "Fallzahl": 12164,
         "ObjectId": 288,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 187,
+        "Genesungsfall": 7637,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
+        "Hospitalisierung": 706,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
@@ -9437,12 +9437,12 @@
         "BelegteBetten": null,
         "Inzidenz": 371.960199719818,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 338.7,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 4340,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
@@ -9460,30 +9460,62 @@
         "ObjectId": 289,
         "Sterbefall": 187,
         "Genesungsfall": 7796,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 708,
         "Zuwachs_Fallzahl": 139,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 2,
         "Zuwachs_Genesung": 159,
         "BelegteBetten": null,
-        "Inzidenz": 343.223535328137,
+        "Inzidenz": 389.381802507274,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "13.12.2020 - 19.12.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 318.1,
         "Fallzahl_aktiv": 4320,
-        "Krh_N_belegt": 264,
-        "Krh_N_frei": 66,
-        "Krh_I_belegt": 78,
-        "Krh_I_frei": 15,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -20,
-        "Krh_N": 330,
-        "Krh_I": 93,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.12.2020",
+        "Fallzahl": 12717,
+        "ObjectId": 290,
+        "Sterbefall": 191,
+        "Genesungsfall": 8154,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 721,
+        "Zuwachs_Fallzahl": 414,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 358,
+        "BelegteBetten": null,
+        "Inzidenz": 379.323969970186,
+        "Datum_neu": 1608508800000,
+        "F\u00e4lle_Meldedatum": 70,
+        "Zeitraum": "14.12.2020 - 20.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 306.6,
+        "Fallzahl_aktiv": 4372,
+        "Krh_N_belegt": 264,
+        "Krh_N_frei": 55,
+        "Krh_I_belegt": 88,
+        "Krh_I_frei": 7,
+        "Fallzahl_aktiv_Zuwachs": 52,
+        "Krh_N": 319,
+        "Krh_I": 95,
+        "Vorz_akt_Faelle": "+"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
