### PR TITLE
New data set: 2020-12-22T111703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-21T111503Z.json
+pjson/2020-12-22T111703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-21T111503Z.json pjson/2020-12-22T111703Z.json```:
```
--- pjson/2020-12-21T111503Z.json	2020-12-21 11:15:03.749326356 +0000
+++ pjson/2020-12-22T111703Z.json	2020-12-22 11:17:04.004702414 +0000
@@ -7677,7 +7677,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603584000000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7709,7 +7709,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
@@ -7965,7 +7965,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 161,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 5,
@@ -7997,7 +7997,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 204,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
@@ -8095,7 +8095,7 @@
         "Datum_neu": 1604707200000,
         "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -8669,7 +8669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
@@ -8733,7 +8733,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 5,
@@ -8893,7 +8893,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 286,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 22,
@@ -8925,7 +8925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 28,
@@ -8957,7 +8957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 323,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 321,
+        "F\u00e4lle_Meldedatum": 323,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 9,
@@ -9217,7 +9217,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 300.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9245,11 +9245,11 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 311.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9275,13 +9275,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 195,
         "BelegteBetten": null,
-        "Inzidenz": 389,
+        "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 406,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
-        "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 322.4,
+        "Hosp_Meldedatum": 24,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9309,10 +9309,10 @@
         "BelegteBetten": null,
         "Inzidenz": 397.643593519882,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 398,
+        "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9341,10 +9341,10 @@
         "BelegteBetten": null,
         "Inzidenz": 401.1,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 330,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 344.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9373,10 +9373,10 @@
         "BelegteBetten": null,
         "Inzidenz": 370.343762347785,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 462,
+        "F\u00e4lle_Meldedatum": 475,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 335.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9405,10 +9405,10 @@
         "BelegteBetten": null,
         "Inzidenz": 384.7,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 377,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 295.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9426,10 +9426,10 @@
         "Datum": "19.12.2020",
         "Fallzahl": 12164,
         "ObjectId": 288,
-        "Sterbefall": 187,
-        "Genesungsfall": 7637,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 706,
+        "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
@@ -9437,12 +9437,12 @@
         "BelegteBetten": null,
         "Inzidenz": 371.960199719818,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 338.7,
-        "Fallzahl_aktiv": 4340,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
@@ -9458,28 +9458,28 @@
         "Datum": "20.12.2020",
         "Fallzahl": 12303,
         "ObjectId": 289,
-        "Sterbefall": 187,
-        "Genesungsfall": 7796,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 708,
-        "Zuwachs_Fallzahl": 139,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 159,
         "BelegteBetten": null,
-        "Inzidenz": 389.381802507274,
+        "Inzidenz": 343.2,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 318.1,
-        "Fallzahl_aktiv": 4320,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -20,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9492,19 +9492,19 @@
         "ObjectId": 290,
         "Sterbefall": 191,
         "Genesungsfall": 8154,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 721,
         "Zuwachs_Fallzahl": 414,
         "Zuwachs_Sterbefall": 4,
         "Zuwachs_Krankenhauseinweisung": 13,
         "Zuwachs_Genesung": 358,
         "BelegteBetten": null,
-        "Inzidenz": 379.323969970186,
+        "Inzidenz": 379.3,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 70,
-        "Zeitraum": "14.12.2020 - 20.12.2020",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 284,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 306.6,
         "Fallzahl_aktiv": 4372,
         "Krh_N_belegt": 264,
@@ -9514,6 +9514,38 @@
         "Fallzahl_aktiv_Zuwachs": 52,
         "Krh_N": 319,
         "Krh_I": 95,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.12.2020",
+        "Fallzahl": 13178,
+        "ObjectId": 291,
+        "Sterbefall": 205,
+        "Genesungsfall": 8437,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 754,
+        "Zuwachs_Fallzahl": 461,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 33,
+        "Zuwachs_Genesung": 283,
+        "BelegteBetten": null,
+        "Inzidenz": 380.221990732426,
+        "Datum_neu": 1608595200000,
+        "F\u00e4lle_Meldedatum": 97,
+        "Zeitraum": "15.12.2020 - 21.12.2020",
+        "SterbeF_Meldedatum": 4,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 304.1,
+        "Fallzahl_aktiv": 4536,
+        "Krh_N_belegt": 304,
+        "Krh_N_frei": 34,
+        "Krh_I_belegt": 88,
+        "Krh_I_frei": 7,
+        "Fallzahl_aktiv_Zuwachs": 164,
+        "Krh_N": 338,
+        "Krh_I": 95,
         "Vorz_akt_Faelle": "+"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
