### PR TITLE
New data set: 2020-12-23T110503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-22T111703Z.json
+pjson/2020-12-23T110503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-22T111703Z.json pjson/2020-12-23T110503Z.json```:
```
--- pjson/2020-12-22T111703Z.json	2020-12-22 11:17:04.004702414 +0000
+++ pjson/2020-12-23T110503Z.json	2020-12-23 11:05:03.772166548 +0000
@@ -7037,7 +7037,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601856000000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7069,7 +7069,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601942400000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7133,7 +7133,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602115200000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -7261,7 +7261,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602460800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7325,7 +7325,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602633600000,
-        "F\u00e4lle_Meldedatum": 29,
+        "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7549,7 +7549,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603238400000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 5,
@@ -7613,7 +7613,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603411200000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -7677,7 +7677,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603584000000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7709,7 +7709,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
@@ -8384,7 +8384,7 @@
         "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8605,10 +8605,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 197,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8640,7 +8640,7 @@
         "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8672,7 +8672,7 @@
         "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8701,10 +8701,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 265,
+        "F\u00e4lle_Meldedatum": 268,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8768,7 +8768,7 @@
         "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8832,7 +8832,7 @@
         "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8896,7 +8896,7 @@
         "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8925,10 +8925,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8989,7 +8989,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 14,
@@ -9053,10 +9053,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 366,
+        "F\u00e4lle_Meldedatum": 367,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9117,10 +9117,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 395,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 410,
+        "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": 397.643593519882,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 402,
+        "F\u00e4lle_Meldedatum": 404,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 35,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": 401.1,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 26,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": 370.343762347785,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 475,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 30,
@@ -9405,10 +9405,10 @@
         "BelegteBetten": null,
         "Inzidenz": 384.7,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 377,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 295.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9437,7 +9437,7 @@
         "BelegteBetten": null,
         "Inzidenz": 371.960199719818,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
@@ -9469,10 +9469,10 @@
         "BelegteBetten": null,
         "Inzidenz": 343.2,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 318.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9490,30 +9490,30 @@
         "Datum": "21.12.2020",
         "Fallzahl": 12717,
         "ObjectId": 290,
-        "Sterbefall": 191,
-        "Genesungsfall": 8154,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 721,
-        "Zuwachs_Fallzahl": 414,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 358,
         "BelegteBetten": null,
         "Inzidenz": 379.3,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 284,
+        "F\u00e4lle_Meldedatum": 383,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 13,
+        "SterbeF_Meldedatum": 14,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 306.6,
-        "Fallzahl_aktiv": 4372,
-        "Krh_N_belegt": 264,
-        "Krh_N_frei": 55,
-        "Krh_I_belegt": 88,
-        "Krh_I_frei": 7,
-        "Fallzahl_aktiv_Zuwachs": 52,
-        "Krh_N": 319,
-        "Krh_I": 95,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
     },
@@ -9524,7 +9524,7 @@
         "ObjectId": 291,
         "Sterbefall": 205,
         "Genesungsfall": 8437,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 754,
         "Zuwachs_Fallzahl": 461,
         "Zuwachs_Sterbefall": 14,
@@ -9533,10 +9533,10 @@
         "BelegteBetten": null,
         "Inzidenz": 380.221990732426,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 97,
-        "Zeitraum": "15.12.2020 - 21.12.2020",
-        "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 319,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 304.1,
         "Fallzahl_aktiv": 4536,
         "Krh_N_belegt": 304,
@@ -9546,6 +9546,38 @@
         "Fallzahl_aktiv_Zuwachs": 164,
         "Krh_N": 338,
         "Krh_I": 95,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.12.2021",
+        "Fallzahl": 13642,
+        "ObjectId": 292,
+        "Sterbefall": 213,
+        "Genesungsfall": 8814,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 809,
+        "Zuwachs_Fallzahl": 464,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 55,
+        "Zuwachs_Genesung": 377,
+        "BelegteBetten": null,
+        "Inzidenz": 388.663385897482,
+        "Datum_neu": 1640217600000,
+        "F\u00e4lle_Meldedatum": 92,
+        "Zeitraum": "16.12.2020 - 22.12.2020",
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 310.4,
+        "Fallzahl_aktiv": 4615,
+        "Krh_N_belegt": 301,
+        "Krh_N_frei": 44,
+        "Krh_I_belegt": 87,
+        "Krh_I_frei": 18,
+        "Fallzahl_aktiv_Zuwachs": 79,
+        "Krh_N": 345,
+        "Krh_I": 105,
         "Vorz_akt_Faelle": "+"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
