### PR TITLE
New data set: 2020-12-23T111403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-22T111703Z.json
+pjson/2020-12-23T111403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-23T110503Z.json pjson/2020-12-23T111403Z.json```:
```
--- pjson/2020-12-23T110503Z.json	2020-12-23 11:05:03.772166548 +0000
+++ pjson/2020-12-23T111403Z.json	2020-12-23 11:14:03.740060385 +0000
@@ -9551,7 +9551,7 @@
     },
     {
       "attributes": {
-        "Datum": "23.12.2021",
+        "Datum": "23.12.2020",
         "Fallzahl": 13642,
         "ObjectId": 292,
         "Sterbefall": 213,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
