### PR TITLE
New data set: 2020-12-23T111904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-22T111703Z.json
+pjson/2020-12-23T111904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-23T111403Z.json pjson/2020-12-23T111904Z.json```:
```
--- pjson/2020-12-23T111403Z.json	2020-12-23 11:14:03.740060385 +0000
+++ pjson/2020-12-23T111904Z.json	2020-12-23 11:19:04.134283045 +0000
@@ -9564,7 +9564,7 @@
         "Zuwachs_Genesung": 377,
         "BelegteBetten": null,
         "Inzidenz": 388.663385897482,
-        "Datum_neu": 1640217600000,
+        "Datum_neu": 1608681600000,
         "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": "16.12.2020 - 22.12.2020",
         "SterbeF_Meldedatum": 3,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
