### PR TITLE
New data set: 2020-12-24T112303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-23T111904Z.json
+pjson/2020-12-24T112303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-23T111904Z.json pjson/2020-12-24T112303Z.json```:
```
--- pjson/2020-12-23T111904Z.json	2020-12-23 11:19:04.134283045 +0000
+++ pjson/2020-12-24T112303Z.json	2020-12-24 11:23:04.100727122 +0000
@@ -8477,7 +8477,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -9053,7 +9053,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 367,
+        "F\u00e4lle_Meldedatum": 368,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 18,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 415,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9307,9 +9307,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 290,
         "BelegteBetten": null,
-        "Inzidenz": 397.643593519882,
+        "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 404,
+        "F\u00e4lle_Meldedatum": 405,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 35,
@@ -9339,13 +9339,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 266,
         "BelegteBetten": null,
-        "Inzidenz": 401.1,
+        "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 335,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 26,
-        "Inzidenz_RKI": 344.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": 370.343762347785,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 480,
+        "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 30,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": 384.7,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 398,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 22,
@@ -9435,9 +9435,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 93,
         "BelegteBetten": null,
-        "Inzidenz": 371.960199719818,
+        "Inzidenz": 372,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
@@ -9469,7 +9469,7 @@
         "BelegteBetten": null,
         "Inzidenz": 343.2,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": 379.3,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 383,
+        "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 21,
@@ -9522,30 +9522,30 @@
         "Datum": "22.12.2020",
         "Fallzahl": 13178,
         "ObjectId": 291,
-        "Sterbefall": 205,
-        "Genesungsfall": 8437,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 754,
-        "Zuwachs_Fallzahl": 461,
-        "Zuwachs_Sterbefall": 14,
-        "Zuwachs_Krankenhauseinweisung": 33,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 283,
         "BelegteBetten": null,
-        "Inzidenz": 380.221990732426,
+        "Inzidenz": 380.2,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 319,
+        "F\u00e4lle_Meldedatum": 345,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 304.1,
-        "Fallzahl_aktiv": 4536,
-        "Krh_N_belegt": 304,
-        "Krh_N_frei": 34,
-        "Krh_I_belegt": 88,
-        "Krh_I_frei": 7,
-        "Fallzahl_aktiv_Zuwachs": 164,
-        "Krh_N": 338,
-        "Krh_I": 95,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
     },
@@ -9554,31 +9554,63 @@
         "Datum": "23.12.2020",
         "Fallzahl": 13642,
         "ObjectId": 292,
-        "Sterbefall": 213,
-        "Genesungsfall": 8814,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 809,
-        "Zuwachs_Fallzahl": 464,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 55,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 377,
         "BelegteBetten": null,
-        "Inzidenz": 388.663385897482,
+        "Inzidenz": 388.7,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 92,
-        "Zeitraum": "16.12.2020 - 22.12.2020",
-        "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 199,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 6,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 310.4,
-        "Fallzahl_aktiv": 4615,
-        "Krh_N_belegt": 301,
-        "Krh_N_frei": 44,
-        "Krh_I_belegt": 87,
-        "Krh_I_frei": 18,
-        "Fallzahl_aktiv_Zuwachs": 79,
-        "Krh_N": 345,
-        "Krh_I": 105,
-        "Vorz_akt_Faelle": "+"
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.12.2020",
+        "Fallzahl": 13831,
+        "ObjectId": 293,
+        "Sterbefall": 216,
+        "Genesungsfall": 9329,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 821,
+        "Zuwachs_Fallzahl": 189,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 515,
+        "BelegteBetten": null,
+        "Inzidenz": 371.4,
+        "Datum_neu": 1608768000000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "17.12.2020 - 23.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 329.2,
+        "Fallzahl_aktiv": 4286,
+        "Krh_N_belegt": 296,
+        "Krh_N_frei": 53,
+        "Krh_I_belegt": 95,
+        "Krh_I_frei": 11,
+        "Fallzahl_aktiv_Zuwachs": -329,
+        "Krh_N": 349,
+        "Krh_I": 106,
+        "Vorz_akt_Faelle": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
