### PR TITLE
New data set: 2020-12-25T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-24T112303Z.json
+pjson/2020-12-25T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-24T112303Z.json pjson/2020-12-25T110903Z.json```:
```
--- pjson/2020-12-24T112303Z.json	2020-12-24 11:23:04.100727122 +0000
+++ pjson/2020-12-25T110903Z.json	2020-12-25 11:09:04.111963408 +0000
@@ -8736,7 +8736,7 @@
         "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8928,7 +8928,7 @@
         "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9343,7 +9343,7 @@
         "Datum_neu": 1608076800000,
         "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9371,13 +9371,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 271,
         "BelegteBetten": null,
-        "Inzidenz": 370.343762347785,
+        "Inzidenz": null,
         "Datum_neu": 1608163200000,
         "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 30,
-        "Inzidenz_RKI": 335.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": 384.7,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 398,
+        "F\u00e4lle_Meldedatum": 401,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 22,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": 379.3,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 384,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 21,
@@ -9533,9 +9533,9 @@
         "BelegteBetten": null,
         "Inzidenz": 380.2,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 345,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
+        "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 304.1,
         "Fallzahl_aktiv": null,
@@ -9565,9 +9565,9 @@
         "BelegteBetten": null,
         "Inzidenz": 388.7,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
+        "SterbeF_Meldedatum": 15,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 310.4,
         "Fallzahl_aktiv": null,
@@ -9586,28 +9586,60 @@
         "Datum": "24.12.2020",
         "Fallzahl": 13831,
         "ObjectId": 293,
-        "Sterbefall": 216,
-        "Genesungsfall": 9329,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 821,
-        "Zuwachs_Fallzahl": 189,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 515,
         "BelegteBetten": null,
         "Inzidenz": 371.4,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "17.12.2020 - 23.12.2020",
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 329.2,
-        "Fallzahl_aktiv": 4286,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.12.2020",
+        "Fallzahl": 13877,
+        "ObjectId": 294,
+        "Sterbefall": 227,
+        "Genesungsfall": 9636,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 825,
+        "Zuwachs_Fallzahl": 46,
+        "Zuwachs_Sterbefall": 11,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 307,
+        "BelegteBetten": null,
+        "Inzidenz": 299,
+        "Datum_neu": 1608854400000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "18.12.2020 - 24.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 279.3,
+        "Fallzahl_aktiv": 4014,
         "Krh_N_belegt": 296,
         "Krh_N_frei": 53,
         "Krh_I_belegt": 95,
         "Krh_I_frei": 11,
-        "Fallzahl_aktiv_Zuwachs": -329,
+        "Fallzahl_aktiv_Zuwachs": -272,
         "Krh_N": 349,
         "Krh_I": 106,
         "Vorz_akt_Faelle": null
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
