### PR TITLE
New data set: 2020-12-26T111903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-25T110903Z.json
+pjson/2020-12-26T111903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-25T110903Z.json pjson/2020-12-26T111903Z.json```:
```
--- pjson/2020-12-25T110903Z.json	2020-12-25 11:09:04.111963408 +0000
+++ pjson/2020-12-26T111903Z.json	2020-12-26 11:19:03.980632387 +0000
@@ -9403,13 +9403,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 159,
         "BelegteBetten": null,
-        "Inzidenz": 384.7,
+        "Inzidenz": null,
         "Datum_neu": 1608249600000,
         "F\u00e4lle_Meldedatum": 401,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 22,
-        "Inzidenz_RKI": 295.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9533,10 +9533,10 @@
         "BelegteBetten": null,
         "Inzidenz": 380.2,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 360,
+        "F\u00e4lle_Meldedatum": 368,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 304.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9565,9 +9565,9 @@
         "BelegteBetten": null,
         "Inzidenz": 388.7,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 15,
+        "SterbeF_Meldedatum": 20,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 310.4,
         "Fallzahl_aktiv": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": 371.4,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -9618,30 +9618,62 @@
         "Datum": "25.12.2020",
         "Fallzahl": 13877,
         "ObjectId": 294,
-        "Sterbefall": 227,
-        "Genesungsfall": 9636,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 825,
-        "Zuwachs_Fallzahl": 46,
-        "Zuwachs_Sterbefall": 11,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 307,
         "BelegteBetten": null,
         "Inzidenz": 299,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "18.12.2020 - 24.12.2020",
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 279.3,
-        "Fallzahl_aktiv": 4014,
-        "Krh_N_belegt": 296,
-        "Krh_N_frei": 53,
-        "Krh_I_belegt": 95,
-        "Krh_I_frei": 11,
-        "Fallzahl_aktiv_Zuwachs": -272,
-        "Krh_N": 349,
-        "Krh_I": 106,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.12.2020",
+        "Fallzahl": 13908,
+        "ObjectId": 295,
+        "Sterbefall": 232,
+        "Genesungsfall": 9941,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 828,
+        "Zuwachs_Fallzahl": 31,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 305,
+        "BelegteBetten": null,
+        "Inzidenz": 231.5,
+        "Datum_neu": 1608940800000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "19.12.2020 - 25.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 224.7,
+        "Fallzahl_aktiv": 3735,
+        "Krh_N_belegt": 291,
+        "Krh_N_frei": 61,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": 15,
+        "Fallzahl_aktiv_Zuwachs": -279,
+        "Krh_N": 352,
+        "Krh_I": 105,
         "Vorz_akt_Faelle": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
