### PR TITLE
New data set: 2020-12-27T114403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-26T111903Z.json
+pjson/2020-12-27T114403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-26T111903Z.json pjson/2020-12-27T114403Z.json```:
```
--- pjson/2020-12-26T111903Z.json	2020-12-26 11:19:03.980632387 +0000
+++ pjson/2020-12-27T114403Z.json	2020-12-27 11:44:03.600044545 +0000
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 395,
+        "F\u00e4lle_Meldedatum": 394,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 21,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 416,
+        "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 26,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 484,
+        "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 30,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 401,
+        "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 22,
@@ -9435,13 +9435,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 93,
         "BelegteBetten": null,
-        "Inzidenz": 372,
+        "Inzidenz": null,
         "Datum_neu": 1608336000000,
         "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 338.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": 379.3,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 21,
@@ -9533,7 +9533,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.2,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 368,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 12,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": 388.7,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 20,
         "Hosp_Meldedatum": 14,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": 371.4,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -9629,10 +9629,10 @@
         "BelegteBetten": null,
         "Inzidenz": 299,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 279.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9650,31 +9650,63 @@
         "Datum": "26.12.2020",
         "Fallzahl": 13908,
         "ObjectId": 295,
-        "Sterbefall": 232,
-        "Genesungsfall": 9941,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 828,
-        "Zuwachs_Fallzahl": 31,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 305,
         "BelegteBetten": null,
         "Inzidenz": 231.5,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "19.12.2020 - 25.12.2020",
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 224.7,
-        "Fallzahl_aktiv": 3735,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.12.2020",
+        "Fallzahl": 14088,
+        "ObjectId": 296,
+        "Sterbefall": 232,
+        "Genesungsfall": 10067,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 829,
+        "Zuwachs_Fallzahl": 180,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 126,
+        "BelegteBetten": null,
+        "Inzidenz": 221.1,
+        "Datum_neu": 1609027200000,
+        "F\u00e4lle_Meldedatum": 73,
+        "Zeitraum": "20.12.2020 - 26.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 204.9,
+        "Fallzahl_aktiv": 3789,
         "Krh_N_belegt": 291,
         "Krh_N_frei": 61,
         "Krh_I_belegt": 90,
         "Krh_I_frei": 15,
-        "Fallzahl_aktiv_Zuwachs": -279,
+        "Fallzahl_aktiv_Zuwachs": 54,
         "Krh_N": 352,
         "Krh_I": 105,
-        "Vorz_akt_Faelle": null
+        "Vorz_akt_Faelle": "+"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
