### PR TITLE
New data set: 2020-12-28T112004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-27T114403Z.json
+pjson/2020-12-28T112004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-28T111503Z.json pjson/2020-12-28T112004Z.json```:
```
--- pjson/2020-12-28T111503Z.json	2020-12-28 11:15:03.857384225 +0000
+++ pjson/2020-12-28T112004Z.json	2020-12-28 11:20:04.383310935 +0000
@@ -9499,13 +9499,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 358,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 379.3,
         "Datum_neu": 1608508800000,
         "F\u00e4lle_Meldedatum": 401,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": null,
+        "Inzidenz_RKI": 306.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
