### PR TITLE
New data set: 2020-12-29T111104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-28T112004Z.json
+pjson/2020-12-29T111104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-28T112004Z.json pjson/2020-12-29T111104Z.json```:
```
--- pjson/2020-12-28T112004Z.json	2020-12-28 11:20:04.383310935 +0000
+++ pjson/2020-12-29T111104Z.json	2020-12-29 11:11:04.294344303 +0000
@@ -4573,7 +4573,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1595203200000,
-        "F\u00e4lle_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -5117,7 +5117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1596672000000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -6493,7 +6493,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600387200000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7327,7 +7327,7 @@
         "Datum_neu": 1602633600000,
         "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -7485,7 +7485,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7997,7 +7997,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
@@ -8384,7 +8384,7 @@
         "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8477,7 +8477,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 11,
@@ -8733,7 +8733,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 9,
@@ -8829,7 +8829,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -9056,7 +9056,7 @@
         "F\u00e4lle_Meldedatum": 368,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9120,7 +9120,7 @@
         "F\u00e4lle_Meldedatum": 394,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9149,10 +9149,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 462,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9181,10 +9181,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 323,
+        "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 9,
+        "SterbeF_Meldedatum": 4,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -9280,7 +9280,7 @@
         "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9311,8 +9311,8 @@
         "Datum_neu": 1607990400000,
         "F\u00e4lle_Meldedatum": 406,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 36,
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9343,7 +9343,7 @@
         "Datum_neu": 1608076800000,
         "F\u00e4lle_Meldedatum": 339,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9373,9 +9373,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 495,
+        "F\u00e4lle_Meldedatum": 496,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 12,
+        "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9405,9 +9405,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 435,
+        "F\u00e4lle_Meldedatum": 443,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9499,13 +9499,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 358,
         "BelegteBetten": null,
-        "Inzidenz": 379.3,
+        "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 401,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 14,
-        "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 306.6,
+        "SterbeF_Meldedatum": 17,
+        "Hosp_Meldedatum": 24,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9526,24 +9526,24 @@
         "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": 461,
-        "Zuwachs_Sterbefall": 14,
-        "Zuwachs_Krankenhauseinweisung": 33,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 283,
         "BelegteBetten": null,
         "Inzidenz": 380.2,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 439,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 7,
-        "Hosp_Meldedatum": 12,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 304.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 164,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9558,24 +9558,24 @@
         "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": 464,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 55,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 377,
         "BelegteBetten": null,
         "Inzidenz": 388.7,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 321,
+        "F\u00e4lle_Meldedatum": 363,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 20,
-        "Hosp_Meldedatum": 19,
+        "SterbeF_Meldedatum": 22,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 310.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 79,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9590,24 +9590,24 @@
         "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": 189,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 515,
         "BelegteBetten": null,
         "Inzidenz": 371.4,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 329.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -329,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9621,25 +9621,25 @@
         "Sterbefall": null,
         "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 825,
-        "Zuwachs_Fallzahl": 46,
-        "Zuwachs_Sterbefall": 11,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 307,
         "BelegteBetten": null,
         "Inzidenz": 299,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 279.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -272,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9650,28 +9650,28 @@
         "Datum": "26.12.2020",
         "Fallzahl": 13908,
         "ObjectId": 295,
-        "Sterbefall": 232,
-        "Genesungsfall": 9941,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 828,
-        "Zuwachs_Fallzahl": 31,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 305,
         "BelegteBetten": null,
         "Inzidenz": 231.5,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 4,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 224.7,
-        "Fallzahl_aktiv": 3735,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -279,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9682,30 +9682,30 @@
         "Datum": "27.12.2020",
         "Fallzahl": 14088,
         "ObjectId": 296,
-        "Sterbefall": 232,
-        "Genesungsfall": 10067,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 829,
-        "Zuwachs_Fallzahl": 180,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
         "Inzidenz": 221.092711663494,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 3,
+        "SterbeF_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 204.9,
-        "Fallzahl_aktiv": 3789,
-        "Krh_N_belegt": 291,
-        "Krh_N_frei": 61,
-        "Krh_I_belegt": 90,
-        "Krh_I_frei": 15,
-        "Fallzahl_aktiv_Zuwachs": 54,
-        "Krh_N": 352,
-        "Krh_I": 105,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
     },
@@ -9716,27 +9716,59 @@
         "ObjectId": 297,
         "Sterbefall": 234,
         "Genesungsfall": 10462,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 865,
-        "Zuwachs_Fallzahl": 421,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 36,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 395,
         "BelegteBetten": null,
         "Inzidenz": 255.576708933511,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 156,
-        "Zeitraum": "21.12.2020 - 27.12.2020",
-        "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 346,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 6,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 214.8,
         "Fallzahl_aktiv": 3813,
-        "Krh_N_belegt": 288,
-        "Krh_N_frei": 59,
-        "Krh_I_belegt": 91,
-        "Krh_I_frei": 12,
-        "Fallzahl_aktiv_Zuwachs": 24,
-        "Krh_N": 347,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.12.2020",
+        "Fallzahl": 15000,
+        "ObjectId": 298,
+        "Sterbefall": 263,
+        "Genesungsfall": 10837,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 903,
+        "Zuwachs_Fallzahl": 491,
+        "Zuwachs_Sterbefall": 29,
+        "Zuwachs_Krankenhauseinweisung": 38,
+        "Zuwachs_Genesung": 375,
+        "BelegteBetten": null,
+        "Inzidenz": 262.581270878983,
+        "Datum_neu": 1609200000000,
+        "F\u00e4lle_Meldedatum": 171,
+        "Zeitraum": "22.12.2020 - 28.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 210.9,
+        "Fallzahl_aktiv": 3900,
+        "Krh_N_belegt": 301,
+        "Krh_N_frei": 49,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": 13,
+        "Fallzahl_aktiv_Zuwachs": 87,
+        "Krh_N": 350,
         "Krh_I": 103,
         "Vorz_akt_Faelle": "+"
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
