### PR TITLE
New data set: 2020-12-30T110603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-29T111104Z.json
+pjson/2020-12-30T110603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-29T111104Z.json pjson/2020-12-30T110603Z.json```:
```
--- pjson/2020-12-29T111104Z.json	2020-12-29 11:11:04.294344303 +0000
+++ pjson/2020-12-30T110603Z.json	2020-12-30 11:06:04.110592417 +0000
@@ -7613,7 +7613,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603411200000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -8669,7 +8669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 15,
@@ -8733,7 +8733,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 232,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 9,
@@ -8925,7 +8925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 295,
+        "F\u00e4lle_Meldedatum": 296,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 26,
@@ -8957,7 +8957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 331,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 406,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 37,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 496,
+        "F\u00e4lle_Meldedatum": 505,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 30,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 443,
+        "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 412,
+        "F\u00e4lle_Meldedatum": 430,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9531,13 +9531,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 283,
         "BelegteBetten": null,
-        "Inzidenz": 380.2,
+        "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 459,
+        "F\u00e4lle_Meldedatum": 472,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 304.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9565,10 +9565,10 @@
         "BelegteBetten": null,
         "Inzidenz": 388.7,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 363,
+        "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 22,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 310.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": 371.4,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
@@ -9629,7 +9629,7 @@
         "BelegteBetten": null,
         "Inzidenz": 299,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -9661,7 +9661,7 @@
         "BelegteBetten": null,
         "Inzidenz": 231.5,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8,
@@ -9714,10 +9714,10 @@
         "Datum": "28.12.2020",
         "Fallzahl": 14509,
         "ObjectId": 297,
-        "Sterbefall": 234,
-        "Genesungsfall": 10462,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 865,
+        "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
@@ -9725,12 +9725,12 @@
         "BelegteBetten": null,
         "Inzidenz": 255.576708933511,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 346,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": 214.8,
-        "Fallzahl_aktiv": 3813,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
@@ -9748,7 +9748,7 @@
         "ObjectId": 298,
         "Sterbefall": 263,
         "Genesungsfall": 10837,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 903,
         "Zuwachs_Fallzahl": 491,
         "Zuwachs_Sterbefall": 29,
@@ -9757,19 +9757,51 @@
         "BelegteBetten": null,
         "Inzidenz": 262.581270878983,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 171,
-        "Zeitraum": "22.12.2020 - 28.12.2020",
+        "F\u00e4lle_Meldedatum": 372,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 210.9,
         "Fallzahl_aktiv": 3900,
-        "Krh_N_belegt": 301,
-        "Krh_N_frei": 49,
-        "Krh_I_belegt": 90,
-        "Krh_I_frei": 13,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 87,
-        "Krh_N": 350,
-        "Krh_I": 103,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.12.2020",
+        "Fallzahl": 15420,
+        "ObjectId": 299,
+        "Sterbefall": 263,
+        "Genesungsfall": 11172,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 916,
+        "Zuwachs_Fallzahl": 420,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 335,
+        "BelegteBetten": null,
+        "Inzidenz": 258.989187830023,
+        "Datum_neu": 1609286400000,
+        "F\u00e4lle_Meldedatum": 102,
+        "Zeitraum": "23.12.2020 - 29.12.2020",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 222.9,
+        "Fallzahl_aktiv": 3985,
+        "Krh_N_belegt": 307,
+        "Krh_N_frei": 53,
+        "Krh_I_belegt": 94,
+        "Krh_I_frei": 10,
+        "Fallzahl_aktiv_Zuwachs": 85,
+        "Krh_N": 360,
+        "Krh_I": 104,
         "Vorz_akt_Faelle": "+"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
