### PR TITLE
New data set: 2020-12-31T111504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2020-12-30T110603Z.json
+pjson/2020-12-31T111504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2020-12-30T110603Z.json pjson/2020-12-31T111504Z.json```:
```
--- pjson/2020-12-30T110603Z.json	2020-12-30 11:06:04.110592417 +0000
+++ pjson/2020-12-31T111504Z.json	2020-12-31 11:15:04.647713798 +0000
@@ -9533,7 +9533,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 472,
+        "F\u00e4lle_Meldedatum": 471,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 14,
@@ -9563,13 +9563,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 377,
         "BelegteBetten": null,
-        "Inzidenz": 388.7,
+        "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 402,
+        "F\u00e4lle_Meldedatum": 404,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 22,
+        "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 310.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9597,9 +9597,9 @@
         "BelegteBetten": null,
         "Inzidenz": 371.4,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 329.2,
         "Fallzahl_aktiv": null,
@@ -9691,11 +9691,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
-        "Inzidenz": 221.092711663494,
+        "Inzidenz": 221.1,
         "Datum_neu": 1609027200000,
         "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 5,
+        "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 204.9,
         "Fallzahl_aktiv": null,
@@ -9723,11 +9723,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 395,
         "BelegteBetten": null,
-        "Inzidenz": 255.576708933511,
+        "Inzidenz": 255.6,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 372,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
+        "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": 214.8,
         "Fallzahl_aktiv": null,
@@ -9746,28 +9746,28 @@
         "Datum": "29.12.2020",
         "Fallzahl": 15000,
         "ObjectId": 298,
-        "Sterbefall": 263,
-        "Genesungsfall": 10837,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 903,
-        "Zuwachs_Fallzahl": 491,
-        "Zuwachs_Sterbefall": 29,
-        "Zuwachs_Krankenhauseinweisung": 38,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 375,
         "BelegteBetten": null,
-        "Inzidenz": 262.581270878983,
+        "Inzidenz": 262.6,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 372,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 10,
+        "SterbeF_Meldedatum": 5,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 210.9,
-        "Fallzahl_aktiv": 3900,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 87,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9778,31 +9778,63 @@
         "Datum": "30.12.2020",
         "Fallzahl": 15420,
         "ObjectId": 299,
-        "Sterbefall": 263,
-        "Genesungsfall": 11172,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 916,
-        "Zuwachs_Fallzahl": 420,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 335,
         "BelegteBetten": null,
-        "Inzidenz": 258.989187830023,
+        "Inzidenz": 259,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 102,
-        "Zeitraum": "23.12.2020 - 29.12.2020",
+        "F\u00e4lle_Meldedatum": 150,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 222.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.12.2020",
+        "Fallzahl": 15591,
+        "ObjectId": 300,
+        "Sterbefall": 275,
+        "Genesungsfall": 11612,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 921,
+        "Zuwachs_Fallzahl": 171,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 440,
+        "BelegteBetten": null,
+        "Inzidenz": 221.8,
+        "Datum_neu": 1609372800000,
+        "F\u00e4lle_Meldedatum": 77,
+        "Zeitraum": "24.12.2020 - 30.12.2020",
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 222.9,
-        "Fallzahl_aktiv": 3985,
-        "Krh_N_belegt": 307,
-        "Krh_N_frei": 53,
+        "Inzidenz_RKI": 204.7,
+        "Fallzahl_aktiv": 3704,
+        "Krh_N_belegt": 319,
+        "Krh_N_frei": 49,
         "Krh_I_belegt": 94,
         "Krh_I_frei": 10,
-        "Fallzahl_aktiv_Zuwachs": 85,
-        "Krh_N": 360,
+        "Fallzahl_aktiv_Zuwachs": -281,
+        "Krh_N": 368,
         "Krh_I": 104,
-        "Vorz_akt_Faelle": "+"
+        "Vorz_akt_Faelle": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
