### PR TITLE
New data set: 2021-01-02T112004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-01T110903Z.json
+pjson/2021-01-02T112004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-01T110903Z.json pjson/2021-01-02T112004Z.json```:
```
--- pjson/2021-01-01T110903Z.json	2021-01-01 11:09:03.890645192 +0000
+++ pjson/2021-01-02T112004Z.json	2021-01-02 11:20:04.632931019 +0000
@@ -4605,7 +4605,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1595289600000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7485,7 +7485,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -8029,7 +8029,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 22,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 458,
+        "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 340,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 414,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 23,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 505,
+        "F\u00e4lle_Meldedatum": 507,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 30,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 404,
+        "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 21,
@@ -9627,13 +9627,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 307,
         "BelegteBetten": null,
-        "Inzidenz": 299,
+        "Inzidenz": null,
         "Datum_neu": 1608854400000,
         "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 279.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9757,7 +9757,7 @@
         "BelegteBetten": null,
         "Inzidenz": 262.6,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 438,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 13,
@@ -9789,10 +9789,10 @@
         "BelegteBetten": null,
         "Inzidenz": 259,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 222.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9821,10 +9821,10 @@
         "BelegteBetten": null,
         "Inzidenz": 221.8,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 204.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9844,28 +9844,60 @@
         "ObjectId": 301,
         "Sterbefall": 277,
         "Genesungsfall": 12030,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 923,
-        "Zuwachs_Fallzahl": 33,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 418,
         "BelegteBetten": null,
-        "Inzidenz": 224,
+        "Inzidenz": 223.966378102662,
         "Datum_neu": 1609459200000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "25.12.2020 - 31.12.2020",
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 217.1,
         "Fallzahl_aktiv": 3317,
-        "Krh_N_belegt": 319,
-        "Krh_N_frei": 49,
-        "Krh_I_belegt": 94,
-        "Krh_I_frei": 10,
-        "Fallzahl_aktiv_Zuwachs": -387,
-        "Krh_N": 368,
-        "Krh_I": 104,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.01.2021",
+        "Fallzahl": 15767,
+        "ObjectId": 302,
+        "Sterbefall": 277,
+        "Genesungsfall": 12206,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 936,
+        "Zuwachs_Fallzahl": 143,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 176,
+        "BelegteBetten": null,
+        "Inzidenz": 240.489960127878,
+        "Datum_neu": 1609545600000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "26.12.2020 - 01.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 218,
+        "Fallzahl_aktiv": 3284,
+        "Krh_N_belegt": 276,
+        "Krh_N_frei": 88,
+        "Krh_I_belegt": 84,
+        "Krh_I_frei": 21,
+        "Fallzahl_aktiv_Zuwachs": -33,
+        "Krh_N": 364,
+        "Krh_I": 105,
         "Vorz_akt_Faelle": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
