### PR TITLE
New data set: 2021-01-03T111105Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-02T112004Z.json
+pjson/2021-01-03T111105Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-02T112004Z.json pjson/2021-01-03T111105Z.json```:
```
--- pjson/2021-01-02T112004Z.json	2021-01-02 11:20:04.632931019 +0000
+++ pjson/2021-01-03T111105Z.json	2021-01-03 11:11:05.137768445 +0000
@@ -4573,7 +4573,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1595203200000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -6269,7 +6269,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599782400000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -6813,7 +6813,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601251200000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7965,7 +7965,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 5,
@@ -8669,7 +8669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 272,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 15,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 11,
@@ -8832,7 +8832,7 @@
         "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8861,7 +8861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 323,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 23,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 23,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 411,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 37,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 339,
+        "F\u00e4lle_Meldedatum": 340,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 26,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 507,
+        "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 30,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 430,
+        "F\u00e4lle_Meldedatum": 431,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9533,7 +9533,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 471,
+        "F\u00e4lle_Meldedatum": 477,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 15,
@@ -9565,10 +9565,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 414,
+        "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9659,13 +9659,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 305,
         "BelegteBetten": null,
-        "Inzidenz": 231.5,
+        "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 224.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9725,7 +9725,7 @@
         "BelegteBetten": null,
         "Inzidenz": 255.6,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 372,
+        "F\u00e4lle_Meldedatum": 376,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 36,
@@ -9757,10 +9757,10 @@
         "BelegteBetten": null,
         "Inzidenz": 262.6,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 438,
+        "F\u00e4lle_Meldedatum": 516,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 210.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9789,10 +9789,10 @@
         "BelegteBetten": null,
         "Inzidenz": 259,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 222.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9821,10 +9821,10 @@
         "BelegteBetten": null,
         "Inzidenz": 221.8,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 204.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9842,10 +9842,10 @@
         "Datum": "01.01.2021",
         "Fallzahl": 15624,
         "ObjectId": 301,
-        "Sterbefall": 277,
-        "Genesungsfall": 12030,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 923,
+        "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
@@ -9853,12 +9853,12 @@
         "BelegteBetten": null,
         "Inzidenz": 223.966378102662,
         "Datum_neu": 1609459200000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 217.1,
-        "Fallzahl_aktiv": 3317,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
@@ -9876,7 +9876,7 @@
         "ObjectId": 302,
         "Sterbefall": 277,
         "Genesungsfall": 12206,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 936,
         "Zuwachs_Fallzahl": 143,
         "Zuwachs_Sterbefall": 0,
@@ -9885,20 +9885,52 @@
         "BelegteBetten": null,
         "Inzidenz": 240.489960127878,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "26.12.2020 - 01.01.2021",
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 218,
         "Fallzahl_aktiv": 3284,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -33,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.01.2021",
+        "Fallzahl": 16064,
+        "ObjectId": 303,
+        "Sterbefall": 277,
+        "Genesungsfall": 12327,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 957,
+        "Zuwachs_Fallzahl": 297,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 121,
+        "BelegteBetten": null,
+        "Inzidenz": 278.925248751751,
+        "Datum_neu": 1609632000000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "27.12.2020 - 02.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 234.7,
+        "Fallzahl_aktiv": 3460,
         "Krh_N_belegt": 276,
         "Krh_N_frei": 88,
         "Krh_I_belegt": 84,
         "Krh_I_frei": 21,
-        "Fallzahl_aktiv_Zuwachs": -33,
+        "Fallzahl_aktiv_Zuwachs": 176,
         "Krh_N": 364,
         "Krh_I": 105,
-        "Vorz_akt_Faelle": null
+        "Vorz_akt_Faelle": "+"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
