### PR TITLE
New data set: 2021-01-04T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-03T111105Z.json
+pjson/2021-01-04T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-03T111105Z.json pjson/2021-01-04T110203Z.json```:
```
--- pjson/2021-01-03T111105Z.json	2021-01-03 11:11:05.137768445 +0000
+++ pjson/2021-01-04T110203Z.json	2021-01-04 11:02:03.211715965 +0000
@@ -7965,7 +7965,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 165,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 5,
@@ -8029,7 +8029,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
@@ -8413,7 +8413,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 276,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 11,
@@ -8861,7 +8861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 323,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 23,
@@ -8893,7 +8893,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 23,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 384,
+        "F\u00e4lle_Meldedatum": 385,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 22,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 414,
+        "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 23,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 37,
@@ -9341,10 +9341,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 340,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 445,
+        "F\u00e4lle_Meldedatum": 446,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
@@ -9469,7 +9469,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 3,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 431,
+        "F\u00e4lle_Meldedatum": 434,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9533,7 +9533,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 477,
+        "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 15,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 421,
+        "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 23,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
@@ -9629,7 +9629,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -9661,7 +9661,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 8,
@@ -9691,13 +9691,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
-        "Inzidenz": 221.1,
+        "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 204.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9725,10 +9725,10 @@
         "BelegteBetten": null,
         "Inzidenz": 255.6,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 376,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": 214.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9757,10 +9757,10 @@
         "BelegteBetten": null,
         "Inzidenz": 262.6,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 516,
+        "F\u00e4lle_Meldedatum": 532,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 210.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9789,10 +9789,10 @@
         "BelegteBetten": null,
         "Inzidenz": 259,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 403,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 222.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9821,10 +9821,10 @@
         "BelegteBetten": null,
         "Inzidenz": 221.8,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 204.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9856,7 +9856,7 @@
         "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 217.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9874,28 +9874,28 @@
         "Datum": "02.01.2021",
         "Fallzahl": 15767,
         "ObjectId": 302,
-        "Sterbefall": 277,
-        "Genesungsfall": 12206,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 936,
-        "Zuwachs_Fallzahl": 143,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 176,
         "BelegteBetten": null,
         "Inzidenz": 240.489960127878,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 218,
-        "Fallzahl_aktiv": 3284,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -33,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9908,7 +9908,7 @@
         "ObjectId": 303,
         "Sterbefall": 277,
         "Genesungsfall": 12327,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 957,
         "Zuwachs_Fallzahl": 297,
         "Zuwachs_Sterbefall": 0,
@@ -9917,20 +9917,52 @@
         "BelegteBetten": null,
         "Inzidenz": 278.925248751751,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "27.12.2020 - 02.01.2021",
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 234.7,
         "Fallzahl_aktiv": 3460,
-        "Krh_N_belegt": 276,
-        "Krh_N_frei": 88,
-        "Krh_I_belegt": 84,
-        "Krh_I_frei": 21,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 176,
-        "Krh_N": 364,
-        "Krh_I": 105,
-        "Vorz_akt_Faelle": "+"
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.01.2021",
+        "Fallzahl": 16228,
+        "ObjectId": 304,
+        "Sterbefall": 277,
+        "Genesungsfall": 12830,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 976,
+        "Zuwachs_Fallzahl": 164,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 503,
+        "BelegteBetten": null,
+        "Inzidenz": 280.182477818887,
+        "Datum_neu": 1609718400000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "28.12.2020 - 03.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 257.6,
+        "Fallzahl_aktiv": 3121,
+        "Krh_N_belegt": 300,
+        "Krh_N_frei": 75,
+        "Krh_I_belegt": 97,
+        "Krh_I_frei": 19,
+        "Fallzahl_aktiv_Zuwachs": -339,
+        "Krh_N": 375,
+        "Krh_I": 116,
+        "Vorz_akt_Faelle": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
