### PR TITLE
New data set: 2021-01-05T111103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-04T110203Z.json
+pjson/2021-01-05T111103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-04T110203Z.json pjson/2021-01-05T111103Z.json```:
```
--- pjson/2021-01-04T110203Z.json	2021-01-04 11:02:03.211715965 +0000
+++ pjson/2021-01-05T111103Z.json	2021-01-05 11:11:03.831114774 +0000
@@ -7901,7 +7901,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604188800000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -8445,7 +8445,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605657600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -8669,7 +8669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 276,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 15,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 11,
@@ -8733,7 +8733,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 9,
@@ -8893,7 +8893,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 23,
@@ -8957,7 +8957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 385,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 22,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 340,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9277,10 +9277,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 415,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 412,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 37,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 27,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 509,
+        "F\u00e4lle_Meldedatum": 510,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 30,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 446,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
@@ -9437,7 +9437,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 434,
+        "F\u00e4lle_Meldedatum": 433,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9533,10 +9533,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 470,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 430,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 23,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 6,
@@ -9629,10 +9629,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9693,7 +9693,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 4,
@@ -9725,7 +9725,7 @@
         "BelegteBetten": null,
         "Inzidenz": 255.6,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 373,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 39,
@@ -9757,10 +9757,10 @@
         "BelegteBetten": null,
         "Inzidenz": 262.6,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 532,
+        "F\u00e4lle_Meldedatum": 538,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 210.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9789,10 +9789,10 @@
         "BelegteBetten": null,
         "Inzidenz": 259,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 410,
+        "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 222.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9821,10 +9821,10 @@
         "BelegteBetten": null,
         "Inzidenz": 221.8,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 204.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9853,10 +9853,10 @@
         "BelegteBetten": null,
         "Inzidenz": 223.966378102662,
         "Datum_neu": 1609459200000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 217.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9885,7 +9885,7 @@
         "BelegteBetten": null,
         "Inzidenz": 240.489960127878,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
@@ -9906,28 +9906,28 @@
         "Datum": "03.01.2021",
         "Fallzahl": 16064,
         "ObjectId": 303,
-        "Sterbefall": 277,
-        "Genesungsfall": 12327,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 957,
-        "Zuwachs_Fallzahl": 297,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 121,
         "BelegteBetten": null,
         "Inzidenz": 278.925248751751,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 234.7,
-        "Fallzahl_aktiv": 3460,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 176,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9940,7 +9940,7 @@
         "ObjectId": 304,
         "Sterbefall": 277,
         "Genesungsfall": 12830,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 976,
         "Zuwachs_Fallzahl": 164,
         "Zuwachs_Sterbefall": 0,
@@ -9949,19 +9949,51 @@
         "BelegteBetten": null,
         "Inzidenz": 280.182477818887,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "28.12.2020 - 03.01.2021",
+        "F\u00e4lle_Meldedatum": 72,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 257.6,
         "Fallzahl_aktiv": 3121,
-        "Krh_N_belegt": 300,
-        "Krh_N_frei": 75,
-        "Krh_I_belegt": 97,
-        "Krh_I_frei": 19,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -339,
-        "Krh_N": 375,
-        "Krh_I": 116,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.01.2021",
+        "Fallzahl": 16448,
+        "ObjectId": 305,
+        "Sterbefall": 277,
+        "Genesungsfall": 13302,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 989,
+        "Zuwachs_Fallzahl": 220,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 472,
+        "BelegteBetten": null,
+        "Inzidenz": 235.101835554438,
+        "Datum_neu": 1609804800000,
+        "F\u00e4lle_Meldedatum": 70,
+        "Zeitraum": "29.12.2020 - 04.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 213.5,
+        "Fallzahl_aktiv": 2869,
+        "Krh_N_belegt": 305,
+        "Krh_N_frei": 65,
+        "Krh_I_belegt": 94,
+        "Krh_I_frei": 18,
+        "Fallzahl_aktiv_Zuwachs": -252,
+        "Krh_N": 370,
+        "Krh_I": 112,
         "Vorz_akt_Faelle": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
