### PR TITLE
New data set: 2021-01-06T112803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-05T111103Z.json
+pjson/2021-01-06T112803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-05T111103Z.json pjson/2021-01-06T112803Z.json```:
```
--- pjson/2021-01-05T111103Z.json	2021-01-05 11:11:03.831114774 +0000
+++ pjson/2021-01-06T112803Z.json	2021-01-06 11:28:03.394540921 +0000
@@ -8605,7 +8605,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 24,
@@ -8701,7 +8701,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 277,
+        "F\u00e4lle_Meldedatum": 276,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 11,
@@ -8957,7 +8957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 22,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 453,
+        "F\u00e4lle_Meldedatum": 456,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 340,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9245,7 +9245,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 7,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 416,
+        "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 24,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 37,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 510,
+        "F\u00e4lle_Meldedatum": 512,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 30,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 433,
+        "F\u00e4lle_Meldedatum": 434,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 24,
@@ -9533,10 +9533,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 478,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9565,10 +9565,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 430,
+        "F\u00e4lle_Meldedatum": 432,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9597,10 +9597,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9664,7 +9664,7 @@
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9693,10 +9693,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9723,13 +9723,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 395,
         "BelegteBetten": null,
-        "Inzidenz": 255.6,
+        "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 39,
-        "Inzidenz_RKI": 214.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9755,13 +9755,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 375,
         "BelegteBetten": null,
-        "Inzidenz": 262.6,
+        "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 538,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 210.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9789,7 +9789,7 @@
         "BelegteBetten": null,
         "Inzidenz": 259,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 431,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 13,
@@ -9821,7 +9821,7 @@
         "BelegteBetten": null,
         "Inzidenz": 221.8,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 25,
@@ -9885,10 +9885,10 @@
         "BelegteBetten": null,
         "Inzidenz": 240.489960127878,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 218,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9917,10 +9917,10 @@
         "BelegteBetten": null,
         "Inzidenz": 278.925248751751,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 234.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9938,28 +9938,28 @@
         "Datum": "04.01.2021",
         "Fallzahl": 16228,
         "ObjectId": 304,
-        "Sterbefall": 277,
-        "Genesungsfall": 12830,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 976,
-        "Zuwachs_Fallzahl": 164,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 503,
         "BelegteBetten": null,
         "Inzidenz": 280.182477818887,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 257.6,
-        "Fallzahl_aktiv": 3121,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -339,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -9972,7 +9972,7 @@
         "ObjectId": 305,
         "Sterbefall": 277,
         "Genesungsfall": 13302,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 989,
         "Zuwachs_Fallzahl": 220,
         "Zuwachs_Sterbefall": 0,
@@ -9981,19 +9981,51 @@
         "BelegteBetten": null,
         "Inzidenz": 235.101835554438,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 70,
-        "Zeitraum": "29.12.2020 - 04.01.2021",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 248,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 213.5,
         "Fallzahl_aktiv": 2869,
-        "Krh_N_belegt": 305,
-        "Krh_N_frei": 65,
-        "Krh_I_belegt": 94,
-        "Krh_I_frei": 18,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -252,
-        "Krh_N": 370,
-        "Krh_I": 112,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.01.2021",
+        "Fallzahl": 16773,
+        "ObjectId": 306,
+        "Sterbefall": 278,
+        "Genesungsfall": 13724,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1009,
+        "Zuwachs_Fallzahl": 325,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 422,
+        "BelegteBetten": null,
+        "Inzidenz": 193.254068034053,
+        "Datum_neu": 1609891200000,
+        "F\u00e4lle_Meldedatum": 64,
+        "Zeitraum": "30.12.2020 - 05.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 150.3,
+        "Fallzahl_aktiv": 2771,
+        "Krh_N_belegt": 283,
+        "Krh_N_frei": 83,
+        "Krh_I_belegt": 94,
+        "Krh_I_frei": 17,
+        "Fallzahl_aktiv_Zuwachs": -98,
+        "Krh_N": 366,
+        "Krh_I": 111,
         "Vorz_akt_Faelle": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
