### PR TITLE
New data set: 2021-01-07T110603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-06T112803Z.json
+pjson/2021-01-07T110603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-06T112803Z.json pjson/2021-01-07T110603Z.json```:
```
--- pjson/2021-01-06T112803Z.json	2021-01-06 11:28:03.394540921 +0000
+++ pjson/2021-01-07T110603Z.json	2021-01-07 11:06:03.952161952 +0000
@@ -8829,7 +8829,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 23,
@@ -8861,7 +8861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 23,
@@ -8925,7 +8925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 296,
+        "F\u00e4lle_Meldedatum": 295,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 26,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 326,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 343,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 27,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 512,
+        "F\u00e4lle_Meldedatum": 513,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 30,
@@ -9408,7 +9408,7 @@
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9533,7 +9533,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 17,
@@ -9565,10 +9565,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 432,
+        "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9600,7 +9600,7 @@
         "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9632,7 +9632,7 @@
         "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9757,10 +9757,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9787,13 +9787,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 335,
         "BelegteBetten": null,
-        "Inzidenz": 259,
+        "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 431,
+        "F\u00e4lle_Meldedatum": 440,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 222.9,
+        "Hosp_Meldedatum": 19,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9824,7 +9824,7 @@
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 204.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9885,10 +9885,10 @@
         "BelegteBetten": null,
         "Inzidenz": 240.489960127878,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 218,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9917,10 +9917,10 @@
         "BelegteBetten": null,
         "Inzidenz": 278.925248751751,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 3,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 234.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9949,10 +9949,10 @@
         "BelegteBetten": null,
         "Inzidenz": 280.182477818887,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 161,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 7,
+        "SterbeF_Meldedatum": 6,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 257.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9970,28 +9970,28 @@
         "Datum": "05.01.2021",
         "Fallzahl": 16448,
         "ObjectId": 305,
-        "Sterbefall": 277,
-        "Genesungsfall": 13302,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 989,
-        "Zuwachs_Fallzahl": 220,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 472,
         "BelegteBetten": null,
         "Inzidenz": 235.101835554438,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 248,
+        "F\u00e4lle_Meldedatum": 303,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 213.5,
-        "Fallzahl_aktiv": 2869,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -252,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -10002,32 +10002,64 @@
         "Datum": "06.01.2021",
         "Fallzahl": 16773,
         "ObjectId": 306,
-        "Sterbefall": 278,
-        "Genesungsfall": 13724,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1009,
-        "Zuwachs_Fallzahl": 325,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 422,
         "BelegteBetten": null,
         "Inzidenz": 193.254068034053,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 64,
-        "Zeitraum": "30.12.2020 - 05.01.2021",
+        "F\u00e4lle_Meldedatum": 258,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 150.3,
-        "Fallzahl_aktiv": 2771,
-        "Krh_N_belegt": 283,
-        "Krh_N_frei": 83,
-        "Krh_I_belegt": 94,
-        "Krh_I_frei": 17,
-        "Fallzahl_aktiv_Zuwachs": -98,
-        "Krh_N": 366,
-        "Krh_I": 111,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.01.2021",
+        "Fallzahl": 17191,
+        "ObjectId": 307,
+        "Sterbefall": 285,
+        "Genesungsfall": 13834,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1065,
+        "Zuwachs_Fallzahl": 418,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 56,
+        "Zuwachs_Genesung": 110,
+        "BelegteBetten": null,
+        "Inzidenz": 183.555443801861,
+        "Datum_neu": 1609977600000,
+        "F\u00e4lle_Meldedatum": 86,
+        "Zeitraum": "31.12.2020 - 06.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 122.8,
+        "Fallzahl_aktiv": 3072,
+        "Krh_N_belegt": 277,
+        "Krh_N_frei": 91,
+        "Krh_I_belegt": 92,
+        "Krh_I_frei": 19,
+        "Fallzahl_aktiv_Zuwachs": 301,
+        "Krh_N": 368,
+        "Krh_I": 111,
+        "Vorz_akt_Faelle": "+"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
