### PR TITLE
New data set: 2021-01-08T110603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-07T110603Z.json
+pjson/2021-01-08T110603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-07T110603Z.json pjson/2021-01-08T110603Z.json```:
```
--- pjson/2021-01-07T110603Z.json	2021-01-07 11:06:03.952161952 +0000
+++ pjson/2021-01-08T110603Z.json	2021-01-08 11:06:03.921235979 +0000
@@ -8893,7 +8893,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 290,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 23,
@@ -8925,7 +8925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 295,
+        "F\u00e4lle_Meldedatum": 296,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 26,
@@ -8957,7 +8957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 22,
@@ -9085,7 +9085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 29,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 22,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -9312,7 +9312,7 @@
         "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9373,9 +9373,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 513,
+        "F\u00e4lle_Meldedatum": 514,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 13,
+        "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9440,7 +9440,7 @@
         "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9472,7 +9472,7 @@
         "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 430,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 25,
@@ -9725,7 +9725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 370,
+        "F\u00e4lle_Meldedatum": 372,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 39,
@@ -9757,7 +9757,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 547,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9789,7 +9789,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 440,
+        "F\u00e4lle_Meldedatum": 442,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 19,
@@ -9819,13 +9819,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 440,
         "BelegteBetten": null,
-        "Inzidenz": 221.8,
+        "Inzidenz": null,
         "Datum_neu": 1609372800000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 26,
-        "Inzidenz_RKI": 204.7,
+        "Hosp_Meldedatum": 27,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9851,13 +9851,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 418,
         "BelegteBetten": null,
-        "Inzidenz": 223.966378102662,
+        "Inzidenz": null,
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 217.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9883,12 +9883,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 176,
         "BelegteBetten": null,
-        "Inzidenz": 240.489960127878,
+        "Inzidenz": 240.5,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 218,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9915,12 +9915,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 121,
         "BelegteBetten": null,
-        "Inzidenz": 278.925248751751,
+        "Inzidenz": 278.9,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 234.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9947,12 +9947,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 503,
         "BelegteBetten": null,
-        "Inzidenz": 280.182477818887,
+        "Inzidenz": 280.2,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 161,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 257.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9979,12 +9979,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 472,
         "BelegteBetten": null,
-        "Inzidenz": 235.101835554438,
+        "Inzidenz": 235.1,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 303,
+        "F\u00e4lle_Meldedatum": 376,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 213.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10011,12 +10011,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 422,
         "BelegteBetten": null,
-        "Inzidenz": 193.254068034053,
+        "Inzidenz": 193.3,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 258,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 150.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10034,29 +10034,61 @@
         "Datum": "07.01.2021",
         "Fallzahl": 17191,
         "ObjectId": 307,
-        "Sterbefall": 285,
-        "Genesungsfall": 13834,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1065,
-        "Zuwachs_Fallzahl": 418,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 56,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 183.555443801861,
+        "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 86,
-        "Zeitraum": "31.12.2020 - 06.01.2021",
+        "F\u00e4lle_Meldedatum": 237,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 122.8,
-        "Fallzahl_aktiv": 3072,
-        "Krh_N_belegt": 277,
-        "Krh_N_frei": 91,
-        "Krh_I_belegt": 92,
-        "Krh_I_frei": 19,
-        "Fallzahl_aktiv_Zuwachs": 301,
-        "Krh_N": 368,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.01.2021",
+        "Fallzahl": 17655,
+        "ObjectId": 308,
+        "Sterbefall": 286,
+        "Genesungsfall": 13885,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1114,
+        "Zuwachs_Fallzahl": 464,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 49,
+        "Zuwachs_Genesung": 51,
+        "BelegteBetten": null,
+        "Inzidenz": 247.9,
+        "Datum_neu": 1610064000000,
+        "F\u00e4lle_Meldedatum": 70,
+        "Zeitraum": "01.01.2021 - 07.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 178.2,
+        "Fallzahl_aktiv": 3484,
+        "Krh_N_belegt": 270,
+        "Krh_N_frei": 97,
+        "Krh_I_belegt": 95,
+        "Krh_I_frei": 16,
+        "Fallzahl_aktiv_Zuwachs": 412,
+        "Krh_N": 367,
         "Krh_I": 111,
         "Vorz_akt_Faelle": "+"
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
