### PR TITLE
New data set: 2021-01-08T111103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-08T110603Z.json
+pjson/2021-01-08T111103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-08T110603Z.json pjson/2021-01-08T111103Z.json```:
```
--- pjson/2021-01-08T110603Z.json	2021-01-08 11:06:03.921235979 +0000
+++ pjson/2021-01-08T111103Z.json	2021-01-08 11:11:03.788144866 +0000
@@ -9851,13 +9851,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 418,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 224,
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": null,
+        "Inzidenz_RKI": 217.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
