### PR TITLE
New data set: 2021-01-09T110604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-08T111103Z.json
+pjson/2021-01-09T110604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-08T111103Z.json pjson/2021-01-09T110604Z.json```:
```
--- pjson/2021-01-08T111103Z.json	2021-01-08 11:11:03.788144866 +0000
+++ pjson/2021-01-09T110604Z.json	2021-01-09 11:06:04.755750930 +0000
@@ -8832,7 +8832,7 @@
         "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8864,7 +8864,7 @@
         "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8896,7 +8896,7 @@
         "F\u00e4lle_Meldedatum": 290,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8928,7 +8928,7 @@
         "F\u00e4lle_Meldedatum": 296,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9088,7 +9088,7 @@
         "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9152,7 +9152,7 @@
         "F\u00e4lle_Meldedatum": 456,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9344,7 +9344,7 @@
         "F\u00e4lle_Meldedatum": 343,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9376,7 +9376,7 @@
         "F\u00e4lle_Meldedatum": 514,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 449,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9440,7 +9440,7 @@
         "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9501,10 +9501,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 434,
+        "F\u00e4lle_Meldedatum": 435,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9533,7 +9533,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 17,
@@ -9600,7 +9600,7 @@
         "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9789,7 +9789,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 442,
+        "F\u00e4lle_Meldedatum": 443,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 19,
@@ -9851,13 +9851,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 418,
         "BelegteBetten": null,
-        "Inzidenz": 224,
+        "Inzidenz": null,
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 217.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9885,10 +9885,10 @@
         "BelegteBetten": null,
         "Inzidenz": 240.5,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 218,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9917,10 +9917,10 @@
         "BelegteBetten": null,
         "Inzidenz": 278.9,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 234.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9949,10 +9949,10 @@
         "BelegteBetten": null,
         "Inzidenz": 280.2,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 26,
+        "SterbeF_Meldedatum": 13,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 257.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9981,10 +9981,10 @@
         "BelegteBetten": null,
         "Inzidenz": 235.1,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 376,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 213.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10013,10 +10013,10 @@
         "BelegteBetten": null,
         "Inzidenz": 193.3,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 12,
+        "SterbeF_Meldedatum": 6,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 150.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10045,10 +10045,10 @@
         "BelegteBetten": null,
         "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 122.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10066,30 +10066,62 @@
         "Datum": "08.01.2021",
         "Fallzahl": 17655,
         "ObjectId": 308,
-        "Sterbefall": 286,
-        "Genesungsfall": 13885,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1114,
-        "Zuwachs_Fallzahl": 464,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 49,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": 247.9,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 70,
-        "Zeitraum": "01.01.2021 - 07.01.2021",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 108,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 178.2,
-        "Fallzahl_aktiv": 3484,
-        "Krh_N_belegt": 270,
-        "Krh_N_frei": 97,
-        "Krh_I_belegt": 95,
-        "Krh_I_frei": 16,
-        "Fallzahl_aktiv_Zuwachs": 412,
-        "Krh_N": 367,
-        "Krh_I": 111,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.01.2021",
+        "Fallzahl": 17793,
+        "ObjectId": 309,
+        "Sterbefall": 300,
+        "Genesungsfall": 13925,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1143,
+        "Zuwachs_Fallzahl": 138,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 29,
+        "Zuwachs_Genesung": 40,
+        "BelegteBetten": null,
+        "Inzidenz": 266.7,
+        "Datum_neu": 1610150400000,
+        "F\u00e4lle_Meldedatum": 53,
+        "Zeitraum": "02.01.2021 - 08.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 253.2,
+        "Fallzahl_aktiv": 3568,
+        "Krh_N_belegt": 272,
+        "Krh_N_frei": 102,
+        "Krh_I_belegt": 99,
+        "Krh_I_frei": 13,
+        "Fallzahl_aktiv_Zuwachs": 84,
+        "Krh_N": 374,
+        "Krh_I": 112,
         "Vorz_akt_Faelle": "+"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
