### PR TITLE
New data set: 2021-01-10T110103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-09T110604Z.json
+pjson/2021-01-10T110103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-09T110604Z.json pjson/2021-01-10T110103Z.json```:
```
--- pjson/2021-01-09T110604Z.json	2021-01-09 11:06:04.755750930 +0000
+++ pjson/2021-01-10T110103Z.json	2021-01-10 11:01:03.438647628 +0000
@@ -7901,7 +7901,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604188800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7965,7 +7965,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 165,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 5,
@@ -8029,7 +8029,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
@@ -8413,7 +8413,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -8477,7 +8477,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 6,
@@ -9727,7 +9727,7 @@
         "Datum_neu": 1609113600000,
         "F\u00e4lle_Meldedatum": 372,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 7,
+        "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9883,13 +9883,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 176,
         "BelegteBetten": null,
-        "Inzidenz": 240.5,
+        "Inzidenz": null,
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 218,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9949,9 +9949,9 @@
         "BelegteBetten": null,
         "Inzidenz": 280.2,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 13,
+        "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 257.6,
         "Fallzahl_aktiv": null,
@@ -9983,7 +9983,7 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 213.5,
         "Fallzahl_aktiv": null,
@@ -10015,7 +10015,7 @@
         "Datum_neu": 1609891200000,
         "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
+        "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 150.3,
         "Fallzahl_aktiv": null,
@@ -10045,9 +10045,9 @@
         "BelegteBetten": null,
         "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 245,
+        "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 122.8,
         "Fallzahl_aktiv": null,
@@ -10077,7 +10077,7 @@
         "BelegteBetten": null,
         "Inzidenz": 247.9,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 9,
@@ -10098,29 +10098,61 @@
         "Datum": "09.01.2021",
         "Fallzahl": 17793,
         "ObjectId": 309,
-        "Sterbefall": 300,
-        "Genesungsfall": 13925,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1143,
-        "Zuwachs_Fallzahl": 138,
-        "Zuwachs_Sterbefall": 14,
-        "Zuwachs_Krankenhauseinweisung": 29,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
         "Inzidenz": 266.7,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 53,
-        "Zeitraum": "02.01.2021 - 08.01.2021",
+        "F\u00e4lle_Meldedatum": 106,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 253.2,
-        "Fallzahl_aktiv": 3568,
-        "Krh_N_belegt": 272,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.01.2021",
+        "Fallzahl": 17929,
+        "ObjectId": 310,
+        "Sterbefall": 325,
+        "Genesungsfall": 14021,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1143,
+        "Zuwachs_Fallzahl": 136,
+        "Zuwachs_Sterbefall": 25,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 96,
+        "BelegteBetten": null,
+        "Inzidenz": 270.3,
+        "Datum_neu": 1610236800000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "03.01.2021 - 09.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 252.2,
+        "Fallzahl_aktiv": 3583,
+        "Krh_N_belegt": 259,
         "Krh_N_frei": 102,
-        "Krh_I_belegt": 99,
-        "Krh_I_frei": 13,
-        "Fallzahl_aktiv_Zuwachs": 84,
-        "Krh_N": 374,
+        "Krh_I_belegt": 95,
+        "Krh_I_frei": 17,
+        "Fallzahl_aktiv_Zuwachs": 15,
+        "Krh_N": 361,
         "Krh_I": 112,
         "Vorz_akt_Faelle": "+"
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
