### PR TITLE
New data set: 2021-01-11T110404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-10T110103Z.json
+pjson/2021-01-11T110404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-10T110103Z.json pjson/2021-01-11T110404Z.json```:
```
--- pjson/2021-01-10T110103Z.json	2021-01-10 11:01:03.438647628 +0000
+++ pjson/2021-01-11T110404Z.json	2021-01-11 11:04:04.322624439 +0000
@@ -6013,7 +6013,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599091200000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -6269,7 +6269,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599782400000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -6493,7 +6493,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600387200000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 22,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 456,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 25,
@@ -9277,7 +9277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 417,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 24,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 414,
+        "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 39,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 451,
+        "F\u00e4lle_Meldedatum": 452,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 435,
+        "F\u00e4lle_Meldedatum": 438,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 25,
@@ -9533,7 +9533,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 486,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 17,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 430,
+        "F\u00e4lle_Meldedatum": 431,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 25,
@@ -9725,7 +9725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 372,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 39,
@@ -9757,7 +9757,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 547,
+        "F\u00e4lle_Meldedatum": 551,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9821,7 +9821,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 27,
@@ -9855,7 +9855,7 @@
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9915,13 +9915,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 121,
         "BelegteBetten": null,
-        "Inzidenz": 278.9,
+        "Inzidenz": null,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 234.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9949,7 +9949,7 @@
         "BelegteBetten": null,
         "Inzidenz": 280.2,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 242,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 28,
@@ -9981,7 +9981,7 @@
         "BelegteBetten": null,
         "Inzidenz": 235.1,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 23,
@@ -10013,7 +10013,7 @@
         "BelegteBetten": null,
         "Inzidenz": 193.3,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 331,
+        "F\u00e4lle_Meldedatum": 334,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 14,
@@ -10045,7 +10045,7 @@
         "BelegteBetten": null,
         "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 247,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 15,
@@ -10077,10 +10077,10 @@
         "BelegteBetten": null,
         "Inzidenz": 247.9,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 178.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10109,10 +10109,10 @@
         "BelegteBetten": null,
         "Inzidenz": 266.7,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 253.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10130,31 +10130,63 @@
         "Datum": "10.01.2021",
         "Fallzahl": 17929,
         "ObjectId": 310,
-        "Sterbefall": 325,
-        "Genesungsfall": 14021,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1143,
-        "Zuwachs_Fallzahl": 136,
-        "Zuwachs_Sterbefall": 25,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 96,
         "BelegteBetten": null,
         "Inzidenz": 270.3,
         "Datum_neu": 1610236800000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "03.01.2021 - 09.01.2021",
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 252.2,
-        "Fallzahl_aktiv": 3583,
-        "Krh_N_belegt": 259,
-        "Krh_N_frei": 102,
-        "Krh_I_belegt": 95,
-        "Krh_I_frei": 17,
-        "Fallzahl_aktiv_Zuwachs": 15,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.01.2021",
+        "Fallzahl": 17983,
+        "ObjectId": 311,
+        "Sterbefall": 326,
+        "Genesungsfall": 14500,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1175,
+        "Zuwachs_Fallzahl": 54,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 32,
+        "Zuwachs_Genesung": 479,
+        "BelegteBetten": null,
+        "Inzidenz": 271.381874348935,
+        "Datum_neu": 1610323200000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "04.01.2021 - 10.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 15,
+        "Inzidenz_RKI": 267.4,
+        "Fallzahl_aktiv": 3157,
+        "Krh_N_belegt": 270,
+        "Krh_N_frei": 91,
+        "Krh_I_belegt": 99,
+        "Krh_I_frei": 15,
+        "Fallzahl_aktiv_Zuwachs": -426,
         "Krh_N": 361,
-        "Krh_I": 112,
-        "Vorz_akt_Faelle": "+"
+        "Krh_I": 114,
+        "Vorz_akt_Faelle": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
