### PR TITLE
New data set: 2021-01-12T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-11T110404Z.json
+pjson/2021-01-12T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-11T110404Z.json pjson/2021-01-12T110403Z.json```:
```
--- pjson/2021-01-11T110404Z.json	2021-01-11 11:04:04.322624439 +0000
+++ pjson/2021-01-12T110403Z.json	2021-01-12 11:04:03.809668796 +0000
@@ -9183,7 +9183,7 @@
         "Datum_neu": 1607644800000,
         "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
+        "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9373,7 +9373,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 514,
+        "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 31,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 452,
+        "F\u00e4lle_Meldedatum": 455,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 438,
+        "F\u00e4lle_Meldedatum": 441,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 17,
         "Hosp_Meldedatum": 25,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 431,
+        "F\u00e4lle_Meldedatum": 434,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 25,
@@ -9757,7 +9757,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 551,
+        "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9888,7 +9888,7 @@
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9919,7 +9919,7 @@
         "Datum_neu": 1609632000000,
         "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9947,13 +9947,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 503,
         "BelegteBetten": null,
-        "Inzidenz": 280.2,
+        "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
-        "Hosp_Meldedatum": 28,
-        "Inzidenz_RKI": 257.6,
+        "Hosp_Meldedatum": 29,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -9981,7 +9981,7 @@
         "BelegteBetten": null,
         "Inzidenz": 235.1,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 390,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 23,
@@ -10013,7 +10013,7 @@
         "BelegteBetten": null,
         "Inzidenz": 193.3,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 334,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 14,
@@ -10045,9 +10045,9 @@
         "BelegteBetten": null,
         "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 122.8,
         "Fallzahl_aktiv": null,
@@ -10077,9 +10077,9 @@
         "BelegteBetten": null,
         "Inzidenz": 247.9,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 178.2,
         "Fallzahl_aktiv": null,
@@ -10109,7 +10109,7 @@
         "BelegteBetten": null,
         "Inzidenz": 266.7,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4,
@@ -10162,30 +10162,62 @@
         "Datum": "11.01.2021",
         "Fallzahl": 17983,
         "ObjectId": 311,
-        "Sterbefall": 326,
-        "Genesungsfall": 14500,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1175,
-        "Zuwachs_Fallzahl": 54,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 32,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 479,
         "BelegteBetten": null,
-        "Inzidenz": 271.381874348935,
+        "Inzidenz": 271.4,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "04.01.2021 - 10.01.2021",
+        "F\u00e4lle_Meldedatum": 158,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 267.4,
-        "Fallzahl_aktiv": 3157,
-        "Krh_N_belegt": 270,
-        "Krh_N_frei": 91,
-        "Krh_I_belegt": 99,
-        "Krh_I_frei": 15,
-        "Fallzahl_aktiv_Zuwachs": -426,
-        "Krh_N": 361,
-        "Krh_I": 114,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.01.2021",
+        "Fallzahl": 18205,
+        "ObjectId": 312,
+        "Sterbefall": 335,
+        "Genesungsfall": 15020,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1202,
+        "Zuwachs_Fallzahl": 222,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 27,
+        "Zuwachs_Genesung": 520,
+        "BelegteBetten": null,
+        "Inzidenz": 258.3,
+        "Datum_neu": 1610409600000,
+        "F\u00e4lle_Meldedatum": 50,
+        "Zeitraum": "05.01.2021 - 11.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 229,
+        "Fallzahl_aktiv": 2850,
+        "Krh_N_belegt": 275,
+        "Krh_N_frei": 89,
+        "Krh_I_belegt": 97,
+        "Krh_I_frei": 16,
+        "Fallzahl_aktiv_Zuwachs": -307,
+        "Krh_N": 364,
+        "Krh_I": 113,
         "Vorz_akt_Faelle": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
