### PR TITLE
New data set: 2021-01-13T110703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-12T110403Z.json
+pjson/2021-01-13T110703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-12T110403Z.json pjson/2021-01-13T110703Z.json```:
```
--- pjson/2021-01-12T110403Z.json	2021-01-12 11:04:03.809668796 +0000
+++ pjson/2021-01-13T110703Z.json	2021-01-13 11:07:03.866772437 +0000
@@ -8960,7 +8960,7 @@
         "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9056,7 +9056,7 @@
         "F\u00e4lle_Meldedatum": 368,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9088,7 +9088,7 @@
         "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9119,8 +9119,8 @@
         "Datum_neu": 1607472000000,
         "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 22,
+        "SterbeF_Meldedatum": 20,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9215,8 +9215,8 @@
         "Datum_neu": 1607731200000,
         "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 13,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9247,7 +9247,7 @@
         "Datum_neu": 1607817600000,
         "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9279,8 +9279,8 @@
         "Datum_neu": 1607904000000,
         "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 18,
-        "Hosp_Meldedatum": 24,
+        "SterbeF_Meldedatum": 16,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9312,7 +9312,7 @@
         "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9375,7 +9375,7 @@
         "Datum_neu": 1608163200000,
         "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 14,
+        "SterbeF_Meldedatum": 15,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9503,8 +9503,8 @@
         "Datum_neu": 1608508800000,
         "F\u00e4lle_Meldedatum": 441,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 17,
-        "Hosp_Meldedatum": 25,
+        "SterbeF_Meldedatum": 16,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9535,8 +9535,8 @@
         "Datum_neu": 1608595200000,
         "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 17,
+        "SterbeF_Meldedatum": 10,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9600,7 +9600,7 @@
         "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9759,7 +9759,7 @@
         "Datum_neu": 1609200000000,
         "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 5,
+        "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9792,7 +9792,7 @@
         "F\u00e4lle_Meldedatum": 443,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9823,8 +9823,8 @@
         "Datum_neu": 1609372800000,
         "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 27,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9887,7 +9887,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9919,7 +9919,7 @@
         "Datum_neu": 1609632000000,
         "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 5,
+        "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9951,7 +9951,7 @@
         "Datum_neu": 1609718400000,
         "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 18,
+        "SterbeF_Meldedatum": 21,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9979,13 +9979,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 472,
         "BelegteBetten": null,
-        "Inzidenz": 235.1,
+        "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 5,
+        "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 23,
-        "Inzidenz_RKI": 213.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -10013,10 +10013,10 @@
         "BelegteBetten": null,
         "Inzidenz": 193.3,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 333,
+        "F\u00e4lle_Meldedatum": 334,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 150.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10045,10 +10045,10 @@
         "BelegteBetten": null,
         "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 15,
+        "SterbeF_Meldedatum": 10,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 122.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10079,8 +10079,8 @@
         "Datum_neu": 1610064000000,
         "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 12,
+        "SterbeF_Meldedatum": 4,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 178.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10109,7 +10109,7 @@
         "BelegteBetten": null,
         "Inzidenz": 266.7,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4,
@@ -10143,7 +10143,7 @@
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 252.2,
         "Fallzahl_aktiv": null,
@@ -10173,10 +10173,10 @@
         "BelegteBetten": null,
         "Inzidenz": 271.4,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 34,
+        "SterbeF_Meldedatum": 4,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": 267.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10194,29 +10194,61 @@
         "Datum": "12.01.2021",
         "Fallzahl": 18205,
         "ObjectId": 312,
-        "Sterbefall": 335,
-        "Genesungsfall": 15020,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1202,
-        "Zuwachs_Fallzahl": 222,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 27,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 520,
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 50,
-        "Zeitraum": "05.01.2021 - 11.01.2021",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 234,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 229,
-        "Fallzahl_aktiv": 2850,
-        "Krh_N_belegt": 275,
-        "Krh_N_frei": 89,
-        "Krh_I_belegt": 97,
-        "Krh_I_frei": 16,
-        "Fallzahl_aktiv_Zuwachs": -307,
-        "Krh_N": 364,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.01.2021",
+        "Fallzahl": 18466,
+        "ObjectId": 313,
+        "Sterbefall": 368,
+        "Genesungsfall": 15429,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1254,
+        "Zuwachs_Fallzahl": 261,
+        "Zuwachs_Sterbefall": 33,
+        "Zuwachs_Krankenhauseinweisung": 52,
+        "Zuwachs_Genesung": 409,
+        "BelegteBetten": null,
+        "Inzidenz": 233.7,
+        "Datum_neu": 1610496000000,
+        "F\u00e4lle_Meldedatum": 56,
+        "Zeitraum": "06.01.2021 - 12.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 196.3,
+        "Fallzahl_aktiv": 2669,
+        "Krh_N_belegt": 258,
+        "Krh_N_frei": 109,
+        "Krh_I_belegt": 94,
+        "Krh_I_frei": 19,
+        "Fallzahl_aktiv_Zuwachs": -181,
+        "Krh_N": 367,
         "Krh_I": 113,
         "Vorz_akt_Faelle": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
