### PR TITLE
New data set: 2021-01-14T112003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-13T110703Z.json
+pjson/2021-01-14T112003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-13T110703Z.json pjson/2021-01-14T112003Z.json```:
```
--- pjson/2021-01-13T110703Z.json	2021-01-13 11:07:03.866772437 +0000
+++ pjson/2021-01-14T112003Z.json	2021-01-14 11:20:03.626083763 +0000
@@ -8861,7 +8861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 25,
@@ -8925,7 +8925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 296,
+        "F\u00e4lle_Meldedatum": 297,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 28,
@@ -9021,7 +9021,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607212800000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 11,
@@ -9053,7 +9053,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 368,
+        "F\u00e4lle_Meldedatum": 372,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 20,
         "Hosp_Meldedatum": 23,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 459,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 25,
@@ -9181,7 +9181,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 340,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 10,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 14,
@@ -9245,7 +9245,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 415,
+        "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 40,
@@ -9341,7 +9341,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 343,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 26,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 455,
+        "F\u00e4lle_Meldedatum": 457,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9565,7 +9565,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 434,
+        "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 24,
         "Hosp_Meldedatum": 25,
@@ -9887,7 +9887,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
+        "SterbeF_Meldedatum": 15,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9919,8 +9919,8 @@
         "Datum_neu": 1609632000000,
         "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 18,
-        "Hosp_Meldedatum": 16,
+        "SterbeF_Meldedatum": 36,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9949,9 +9949,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 249,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 21,
+        "SterbeF_Meldedatum": 26,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10013,11 +10013,11 @@
         "BelegteBetten": null,
         "Inzidenz": 193.3,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 334,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 150.3,
+        "Hosp_Meldedatum": 27,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -10045,10 +10045,10 @@
         "BelegteBetten": null,
         "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 262,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 10,
-        "Hosp_Meldedatum": 17,
+        "SterbeF_Meldedatum": 16,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 122.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10077,10 +10077,10 @@
         "BelegteBetten": null,
         "Inzidenz": 247.9,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 17,
+        "SterbeF_Meldedatum": 10,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 178.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10109,7 +10109,7 @@
         "BelegteBetten": null,
         "Inzidenz": 266.7,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4,
@@ -10141,10 +10141,10 @@
         "BelegteBetten": null,
         "Inzidenz": 270.3,
         "Datum_neu": 1610236800000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 252.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10173,10 +10173,10 @@
         "BelegteBetten": null,
         "Inzidenz": 271.4,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 35,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": 267.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10205,10 +10205,10 @@
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 243,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 229,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10226,32 +10226,64 @@
         "Datum": "13.01.2021",
         "Fallzahl": 18466,
         "ObjectId": 313,
-        "Sterbefall": 368,
-        "Genesungsfall": 15429,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1254,
-        "Zuwachs_Fallzahl": 261,
-        "Zuwachs_Sterbefall": 33,
-        "Zuwachs_Krankenhauseinweisung": 52,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 409,
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 56,
-        "Zeitraum": "06.01.2021 - 12.01.2021",
+        "F\u00e4lle_Meldedatum": 183,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 196.3,
-        "Fallzahl_aktiv": 2669,
-        "Krh_N_belegt": 258,
-        "Krh_N_frei": 109,
-        "Krh_I_belegt": 94,
-        "Krh_I_frei": 19,
-        "Fallzahl_aktiv_Zuwachs": -181,
-        "Krh_N": 367,
-        "Krh_I": 113,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.01.2021",
+        "Fallzahl": 18654,
+        "ObjectId": 314,
+        "Sterbefall": 421,
+        "Genesungsfall": 15496,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1325,
+        "Zuwachs_Fallzahl": 188,
+        "Zuwachs_Sterbefall": 53,
+        "Zuwachs_Krankenhauseinweisung": 71,
+        "Zuwachs_Genesung": 67,
+        "BelegteBetten": null,
+        "Inzidenz": 208.9,
+        "Datum_neu": 1610582400000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "07.01.2021 - 13.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 183,
+        "Fallzahl_aktiv": 2737,
+        "Krh_N_belegt": 232,
+        "Krh_N_frei": 136,
+        "Krh_I_belegt": 97,
+        "Krh_I_frei": 18,
+        "Fallzahl_aktiv_Zuwachs": 68,
+        "Krh_N": 368,
+        "Krh_I": 115,
+        "Vorz_akt_Faelle": "+"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
