### PR TITLE
New data set: 2021-01-15T113704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-14T112003Z.json
+pjson/2021-01-15T113704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-14T112003Z.json pjson/2021-01-15T113704Z.json```:
```
--- pjson/2021-01-14T112003Z.json	2021-01-14 11:20:03.626083763 +0000
+++ pjson/2021-01-15T113704Z.json	2021-01-15 11:37:04.252825610 +0000
@@ -8573,7 +8573,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606003200000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
@@ -8605,7 +8605,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 24,
@@ -8637,7 +8637,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 14,
@@ -8669,7 +8669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 15,
@@ -8733,7 +8733,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 233,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 9,
@@ -8925,9 +8925,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 297,
+        "F\u00e4lle_Meldedatum": 298,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 8,
+        "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9053,7 +9053,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 372,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 22,
@@ -9184,7 +9184,7 @@
         "F\u00e4lle_Meldedatum": 340,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 14,
@@ -9245,7 +9245,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 7,
@@ -9280,7 +9280,7 @@
         "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 16,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9309,7 +9309,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 417,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 40,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9437,7 +9437,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 9,
@@ -9533,9 +9533,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 10,
+        "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9567,8 +9567,8 @@
         "Datum_neu": 1608681600000,
         "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 24,
-        "Hosp_Meldedatum": 25,
+        "SterbeF_Meldedatum": 21,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9693,9 +9693,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
+        "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9725,9 +9725,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 370,
+        "F\u00e4lle_Meldedatum": 368,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 8,
+        "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9757,10 +9757,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 553,
+        "F\u00e4lle_Meldedatum": 558,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9789,7 +9789,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 443,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 21,
@@ -9887,7 +9887,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 15,
+        "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9917,10 +9917,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 36,
-        "Hosp_Meldedatum": 18,
+        "SterbeF_Meldedatum": 46,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9951,8 +9951,8 @@
         "Datum_neu": 1609718400000,
         "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 26,
-        "Hosp_Meldedatum": 29,
+        "SterbeF_Meldedatum": 33,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10011,9 +10011,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 422,
         "BelegteBetten": null,
-        "Inzidenz": 193.3,
+        "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 340,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 27,
@@ -10045,11 +10045,11 @@
         "BelegteBetten": null,
         "Inzidenz": 183.6,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 265,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 16,
+        "SterbeF_Meldedatum": 26,
         "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 122.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -10079,7 +10079,7 @@
         "Datum_neu": 1610064000000,
         "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 10,
+        "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 178.2,
         "Fallzahl_aktiv": null,
@@ -10143,7 +10143,7 @@
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 252.2,
         "Fallzahl_aktiv": null,
@@ -10173,9 +10173,9 @@
         "BelegteBetten": null,
         "Inzidenz": 271.4,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 176,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 11,
+        "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": 267.4,
         "Fallzahl_aktiv": null,
@@ -10205,10 +10205,10 @@
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 243,
+        "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 29,
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 229,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10237,10 +10237,10 @@
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 196.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10260,19 +10260,19 @@
         "ObjectId": 314,
         "Sterbefall": 421,
         "Genesungsfall": 15496,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1325,
         "Zuwachs_Fallzahl": 188,
         "Zuwachs_Sterbefall": 53,
         "Zuwachs_Krankenhauseinweisung": 71,
         "Zuwachs_Genesung": 67,
         "BelegteBetten": null,
-        "Inzidenz": 208.9,
+        "Inzidenz": 208.879629297029,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "07.01.2021 - 13.01.2021",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 116,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 42,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 183,
         "Fallzahl_aktiv": 2737,
         "Krh_N_belegt": 232,
@@ -10282,6 +10282,38 @@
         "Fallzahl_aktiv_Zuwachs": 68,
         "Krh_N": 368,
         "Krh_I": 115,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.01.2021",
+        "Fallzahl": 18855,
+        "ObjectId": 315,
+        "Sterbefall": 495,
+        "Genesungsfall": 15512,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1354,
+        "Zuwachs_Fallzahl": 201,
+        "Zuwachs_Sterbefall": 74,
+        "Zuwachs_Krankenhauseinweisung": 29,
+        "Zuwachs_Genesung": 16,
+        "BelegteBetten": null,
+        "Inzidenz": 190.380401594885,
+        "Datum_neu": 1610668800000,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": "08.01.2021 - 14.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": 164.3,
+        "Fallzahl_aktiv": 2848,
+        "Krh_N_belegt": 234,
+        "Krh_N_frei": 133,
+        "Krh_I_belegt": 92,
+        "Krh_I_frei": 16,
+        "Fallzahl_aktiv_Zuwachs": 111,
+        "Krh_N": 367,
+        "Krh_I": 108,
         "Vorz_akt_Faelle": "+"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
