### PR TITLE
New data set: 2021-01-16T111703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-15T113704Z.json
+pjson/2021-01-16T111703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-15T113704Z.json pjson/2021-01-16T111703Z.json```:
```
--- pjson/2021-01-15T113704Z.json	2021-01-15 11:37:04.252825610 +0000
+++ pjson/2021-01-16T111703Z.json	2021-01-16 11:17:03.329974301 +0000
@@ -8285,7 +8285,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 10,
@@ -8317,7 +8317,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -8413,7 +8413,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 13,
@@ -8445,7 +8445,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605657600000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -9149,7 +9149,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 25,
@@ -9213,7 +9213,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 14,
@@ -9405,7 +9405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 459,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
         "Hosp_Meldedatum": 26,
@@ -9437,7 +9437,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 9,
@@ -9501,10 +9501,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 441,
+        "F\u00e4lle_Meldedatum": 444,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 16,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9536,7 +9536,7 @@
         "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9725,7 +9725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 368,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 39,
@@ -9757,7 +9757,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 558,
+        "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 28,
@@ -9821,7 +9821,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 28,
@@ -9885,7 +9885,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 18,
         "Hosp_Meldedatum": 10,
@@ -9981,7 +9981,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 23,
@@ -10013,7 +10013,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 340,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 27,
@@ -10043,7 +10043,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 183.6,
+        "Inzidenz": null,
         "Datum_neu": 1609977600000,
         "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
@@ -10077,7 +10077,7 @@
         "BelegteBetten": null,
         "Inzidenz": 247.9,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 201,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 19,
@@ -10205,7 +10205,7 @@
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 247,
+        "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 30,
@@ -10237,7 +10237,7 @@
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 22,
@@ -10258,30 +10258,30 @@
         "Datum": "14.01.2021",
         "Fallzahl": 18654,
         "ObjectId": 314,
-        "Sterbefall": 421,
-        "Genesungsfall": 15496,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1325,
-        "Zuwachs_Fallzahl": 188,
-        "Zuwachs_Sterbefall": 53,
-        "Zuwachs_Krankenhauseinweisung": 71,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 67,
         "BelegteBetten": null,
         "Inzidenz": 208.879629297029,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 42,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 183,
-        "Fallzahl_aktiv": 2737,
-        "Krh_N_belegt": 232,
-        "Krh_N_frei": 136,
-        "Krh_I_belegt": 97,
-        "Krh_I_frei": 18,
-        "Fallzahl_aktiv_Zuwachs": 68,
-        "Krh_N": 368,
-        "Krh_I": 115,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
     },
@@ -10292,7 +10292,7 @@
         "ObjectId": 315,
         "Sterbefall": 495,
         "Genesungsfall": 15512,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1354,
         "Zuwachs_Fallzahl": 201,
         "Zuwachs_Sterbefall": 74,
@@ -10301,10 +10301,10 @@
         "BelegteBetten": null,
         "Inzidenz": 190.380401594885,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 42,
-        "Zeitraum": "08.01.2021 - 14.01.2021",
+        "F\u00e4lle_Meldedatum": 83,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 164.3,
         "Fallzahl_aktiv": 2848,
         "Krh_N_belegt": 234,
@@ -10314,7 +10314,39 @@
         "Fallzahl_aktiv_Zuwachs": 111,
         "Krh_N": 367,
         "Krh_I": 108,
-        "Vorz_akt_Faelle": "+"
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.01.2021",
+        "Fallzahl": 19010,
+        "ObjectId": 316,
+        "Sterbefall": 495,
+        "Genesungsfall": 15668,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1364,
+        "Zuwachs_Fallzahl": 155,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 156,
+        "BelegteBetten": null,
+        "Inzidenz": 178.346923380869,
+        "Datum_neu": 1610755200000,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": "09.01.2021 - 15.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 160.7,
+        "Fallzahl_aktiv": 2847,
+        "Krh_N_belegt": 219,
+        "Krh_N_frei": 141,
+        "Krh_I_belegt": 92,
+        "Krh_I_frei": 17,
+        "Fallzahl_aktiv_Zuwachs": -1,
+        "Krh_N": 360,
+        "Krh_I": 109,
+        "Vorz_akt_Faelle": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
