### PR TITLE
New data set: 2021-01-17T111404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-16T111703Z.json
+pjson/2021-01-17T111404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-16T111703Z.json pjson/2021-01-17T111404Z.json```:
```
--- pjson/2021-01-16T111703Z.json	2021-01-16 11:17:03.329974301 +0000
+++ pjson/2021-01-17T111404Z.json	2021-01-17 11:14:04.185332947 +0000
@@ -9504,7 +9504,7 @@
         "F\u00e4lle_Meldedatum": 444,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 16,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9568,7 +9568,7 @@
         "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 21,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9728,7 +9728,7 @@
         "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9824,7 +9824,7 @@
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9984,7 +9984,7 @@
         "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10048,7 +10048,7 @@
         "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 26,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10075,13 +10075,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
-        "Inzidenz": 247.9,
+        "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 206,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
-        "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 178.2,
+        "Hosp_Meldedatum": 20,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -10113,7 +10113,7 @@
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 253.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -10175,7 +10175,7 @@
         "Datum_neu": 1610323200000,
         "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 14,
+        "SterbeF_Meldedatum": 15,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": 267.4,
         "Fallzahl_aktiv": null,
@@ -10205,7 +10205,7 @@
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 252,
+        "F\u00e4lle_Meldedatum": 253,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 30,
@@ -10237,7 +10237,7 @@
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 22,
@@ -10269,7 +10269,7 @@
         "BelegteBetten": null,
         "Inzidenz": 208.879629297029,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 42,
         "Hosp_Meldedatum": 8,
@@ -10290,30 +10290,30 @@
         "Datum": "15.01.2021",
         "Fallzahl": 18855,
         "ObjectId": 315,
-        "Sterbefall": 495,
-        "Genesungsfall": 15512,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1354,
-        "Zuwachs_Fallzahl": 201,
-        "Zuwachs_Sterbefall": 74,
-        "Zuwachs_Krankenhauseinweisung": 29,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 16,
         "BelegteBetten": null,
         "Inzidenz": 190.380401594885,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 15,
+        "SterbeF_Meldedatum": 2,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 164.3,
-        "Fallzahl_aktiv": 2848,
-        "Krh_N_belegt": 234,
-        "Krh_N_frei": 133,
-        "Krh_I_belegt": 92,
-        "Krh_I_frei": 16,
-        "Fallzahl_aktiv_Zuwachs": 111,
-        "Krh_N": 367,
-        "Krh_I": 108,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
     },
@@ -10324,7 +10324,7 @@
         "ObjectId": 316,
         "Sterbefall": 495,
         "Genesungsfall": 15668,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1364,
         "Zuwachs_Fallzahl": 155,
         "Zuwachs_Sterbefall": 0,
@@ -10333,10 +10333,10 @@
         "BelegteBetten": null,
         "Inzidenz": 178.346923380869,
         "Datum_neu": 1610755200000,
-        "F\u00e4lle_Meldedatum": 49,
-        "Zeitraum": "09.01.2021 - 15.01.2021",
+        "F\u00e4lle_Meldedatum": 85,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 160.7,
         "Fallzahl_aktiv": 2847,
         "Krh_N_belegt": 219,
@@ -10348,6 +10348,38 @@
         "Krh_I": 109,
         "Vorz_akt_Faelle": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.01.2021",
+        "Fallzahl": 19097,
+        "ObjectId": 317,
+        "Sterbefall": 498,
+        "Genesungsfall": 15727,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1374,
+        "Zuwachs_Fallzahl": 87,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 59,
+        "BelegteBetten": null,
+        "Inzidenz": 186.249506088581,
+        "Datum_neu": 1610841600000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "10.01.2021 - 16.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 171.9,
+        "Fallzahl_aktiv": 2872,
+        "Krh_N_belegt": 219,
+        "Krh_N_frei": 140,
+        "Krh_I_belegt": 93,
+        "Krh_I_frei": 16,
+        "Fallzahl_aktiv_Zuwachs": 25,
+        "Krh_N": 359,
+        "Krh_I": 109,
+        "Vorz_akt_Faelle": "+"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
