### PR TITLE
New data set: 2021-01-18T114303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-17T111404Z.json
+pjson/2021-01-18T114303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-17T111404Z.json pjson/2021-01-18T114303Z.json```:
```
--- pjson/2021-01-17T111404Z.json	2021-01-17 11:14:04.185332947 +0000
+++ pjson/2021-01-18T114303Z.json	2021-01-18 11:43:03.966292812 +0000
@@ -767,7 +767,7 @@
         "Datum_neu": 1584921600000,
         "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -799,7 +799,7 @@
         "Datum_neu": 1585008000000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -927,7 +927,7 @@
         "Datum_neu": 1585353600000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -991,7 +991,7 @@
         "Datum_neu": 1585526400000,
         "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -1023,7 +1023,7 @@
         "Datum_neu": 1585612800000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -4573,7 +4573,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1595203200000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 0,
@@ -7261,7 +7261,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602460800000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 1,
@@ -7613,7 +7613,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603411200000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -7741,7 +7741,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 5,
@@ -8253,7 +8253,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 11,
@@ -8605,7 +8605,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 24,
@@ -8829,7 +8829,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 24,
@@ -8896,7 +8896,7 @@
         "F\u00e4lle_Meldedatum": 290,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -8960,7 +8960,7 @@
         "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9024,7 +9024,7 @@
         "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9088,7 +9088,7 @@
         "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 5,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9120,7 +9120,7 @@
         "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 20,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9152,7 +9152,7 @@
         "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9280,7 +9280,7 @@
         "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 16,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9503,8 +9503,8 @@
         "Datum_neu": 1608508800000,
         "F\u00e4lle_Meldedatum": 444,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 16,
-        "Hosp_Meldedatum": 28,
+        "SterbeF_Meldedatum": 15,
+        "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9536,7 +9536,7 @@
         "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9567,7 +9567,7 @@
         "Datum_neu": 1608681600000,
         "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 21,
+        "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9600,7 +9600,7 @@
         "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9664,7 +9664,7 @@
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9759,8 +9759,8 @@
         "Datum_neu": 1609200000000,
         "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 6,
-        "Hosp_Meldedatum": 28,
+        "SterbeF_Meldedatum": 7,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9791,7 +9791,7 @@
         "Datum_neu": 1609286400000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9951,8 +9951,8 @@
         "Datum_neu": 1609718400000,
         "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 33,
-        "Hosp_Meldedatum": 30,
+        "SterbeF_Meldedatum": 34,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9983,7 +9983,7 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
+        "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10013,7 +10013,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 343,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 27,
@@ -10045,9 +10045,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 267,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 26,
+        "SterbeF_Meldedatum": 27,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10077,9 +10077,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 13,
+        "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10107,7 +10107,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
-        "Inzidenz": 266.7,
+        "Inzidenz": null,
         "Datum_neu": 1610150400000,
         "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
@@ -10139,13 +10139,13 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 96,
         "BelegteBetten": null,
-        "Inzidenz": 270.3,
+        "Inzidenz": null,
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 252.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
@@ -10175,8 +10175,8 @@
         "Datum_neu": 1610323200000,
         "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 15,
-        "Hosp_Meldedatum": 47,
+        "SterbeF_Meldedatum": 16,
+        "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": 267.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10205,10 +10205,10 @@
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 253,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 30,
+        "SterbeF_Meldedatum": 3,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 229,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10237,10 +10237,10 @@
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 196.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10269,9 +10269,9 @@
         "BelegteBetten": null,
         "Inzidenz": 208.879629297029,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 176,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 42,
+        "SterbeF_Meldedatum": 41,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 183,
         "Fallzahl_aktiv": null,
@@ -10301,10 +10301,10 @@
         "BelegteBetten": null,
         "Inzidenz": 190.380401594885,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 17,
+        "SterbeF_Meldedatum": 11,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 164.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10322,30 +10322,30 @@
         "Datum": "16.01.2021",
         "Fallzahl": 19010,
         "ObjectId": 316,
-        "Sterbefall": 495,
-        "Genesungsfall": 15668,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1364,
-        "Zuwachs_Fallzahl": 155,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 156,
         "BelegteBetten": null,
         "Inzidenz": 178.346923380869,
         "Datum_neu": 1610755200000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 1,
+        "SterbeF_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 160.7,
-        "Fallzahl_aktiv": 2847,
-        "Krh_N_belegt": 219,
-        "Krh_N_frei": 141,
-        "Krh_I_belegt": 92,
-        "Krh_I_frei": 17,
-        "Fallzahl_aktiv_Zuwachs": -1,
-        "Krh_N": 360,
-        "Krh_I": 109,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null
       }
     },
@@ -10356,7 +10356,7 @@
         "ObjectId": 317,
         "Sterbefall": 498,
         "Genesungsfall": 15727,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1374,
         "Zuwachs_Fallzahl": 87,
         "Zuwachs_Sterbefall": 3,
@@ -10365,20 +10365,52 @@
         "BelegteBetten": null,
         "Inzidenz": 186.249506088581,
         "Datum_neu": 1610841600000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "10.01.2021 - 16.01.2021",
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 171.9,
         "Fallzahl_aktiv": 2872,
-        "Krh_N_belegt": 219,
-        "Krh_N_frei": 140,
-        "Krh_I_belegt": 93,
-        "Krh_I_frei": 16,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 25,
-        "Krh_N": 359,
-        "Krh_I": 109,
-        "Vorz_akt_Faelle": "+"
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.01.2021",
+        "Fallzahl": 19132,
+        "ObjectId": 318,
+        "Sterbefall": 513,
+        "Genesungsfall": 15927,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1417,
+        "Zuwachs_Fallzahl": 35,
+        "Zuwachs_Sterbefall": 15,
+        "Zuwachs_Krankenhauseinweisung": 43,
+        "Zuwachs_Genesung": 200,
+        "BelegteBetten": null,
+        "Inzidenz": 188.584360070405,
+        "Datum_neu": 1610928000000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "11.01.2021 - 17.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": 178.9,
+        "Fallzahl_aktiv": 2692,
+        "Krh_N_belegt": 221,
+        "Krh_N_frei": 141,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": 23,
+        "Fallzahl_aktiv_Zuwachs": -180,
+        "Krh_N": 362,
+        "Krh_I": 113,
+        "Vorz_akt_Faelle": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
