### PR TITLE
New data set: 2021-01-19T110803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-18T114303Z.json
+pjson/2021-01-19T110803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-18T114303Z.json pjson/2021-01-19T110803Z.json```:
```
--- pjson/2021-01-18T114303Z.json	2021-01-18 11:43:03.966292812 +0000
+++ pjson/2021-01-19T110803Z.json	2021-01-19 11:08:03.249131292 +0000
@@ -8960,7 +8960,7 @@
         "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 14,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9152,7 +9152,7 @@
         "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9312,7 +9312,7 @@
         "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9344,7 +9344,7 @@
         "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9568,7 +9568,7 @@
         "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 19,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9600,7 +9600,7 @@
         "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9824,7 +9824,7 @@
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9887,8 +9887,8 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 18,
-        "Hosp_Meldedatum": 10,
+        "SterbeF_Meldedatum": 22,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9919,7 +9919,7 @@
         "Datum_neu": 1609632000000,
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 46,
+        "SterbeF_Meldedatum": 50,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9951,7 +9951,7 @@
         "Datum_neu": 1609718400000,
         "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 34,
+        "SterbeF_Meldedatum": 35,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10045,9 +10045,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 267,
+        "F\u00e4lle_Meldedatum": 269,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 27,
+        "SterbeF_Meldedatum": 30,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10077,9 +10077,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 14,
+        "SterbeF_Meldedatum": 16,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10109,7 +10109,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 4,
@@ -10173,9 +10173,9 @@
         "BelegteBetten": null,
         "Inzidenz": 271.4,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 16,
+        "SterbeF_Meldedatum": 19,
         "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": 267.4,
         "Fallzahl_aktiv": null,
@@ -10205,10 +10205,10 @@
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 258,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
-        "Hosp_Meldedatum": 31,
+        "SterbeF_Meldedatum": 4,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 229,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10237,9 +10237,9 @@
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 196.3,
         "Fallzahl_aktiv": null,
@@ -10269,10 +10269,10 @@
         "BelegteBetten": null,
         "Inzidenz": 208.879629297029,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 41,
-        "Hosp_Meldedatum": 8,
+        "SterbeF_Meldedatum": 42,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 183,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10301,10 +10301,10 @@
         "BelegteBetten": null,
         "Inzidenz": 190.380401594885,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 164.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10354,28 +10354,28 @@
         "Datum": "17.01.2021",
         "Fallzahl": 19097,
         "ObjectId": 317,
-        "Sterbefall": 498,
-        "Genesungsfall": 15727,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1374,
-        "Zuwachs_Fallzahl": 87,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
         "Inzidenz": 186.249506088581,
         "Datum_neu": 1610841600000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 0,
+        "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 171.9,
-        "Fallzahl_aktiv": 2872,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 25,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null
@@ -10388,7 +10388,7 @@
         "ObjectId": 318,
         "Sterbefall": 513,
         "Genesungsfall": 15927,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1417,
         "Zuwachs_Fallzahl": 35,
         "Zuwachs_Sterbefall": 15,
@@ -10397,18 +10397,50 @@
         "BelegteBetten": null,
         "Inzidenz": 188.584360070405,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 11,
-        "Zeitraum": "11.01.2021 - 17.01.2021",
-        "SterbeF_Meldedatum": 0,
-        "Hosp_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 153,
+        "Zeitraum": null,
+        "SterbeF_Meldedatum": 20,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 178.9,
         "Fallzahl_aktiv": 2692,
-        "Krh_N_belegt": 221,
-        "Krh_N_frei": 141,
-        "Krh_I_belegt": 90,
-        "Krh_I_frei": 23,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -180,
-        "Krh_N": 362,
+        "Krh_N": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.01.2021",
+        "Fallzahl": 19316,
+        "ObjectId": 319,
+        "Sterbefall": 554,
+        "Genesungsfall": 16298,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1465,
+        "Zuwachs_Fallzahl": 184,
+        "Zuwachs_Sterbefall": 41,
+        "Zuwachs_Krankenhauseinweisung": 48,
+        "Zuwachs_Genesung": 371,
+        "BelegteBetten": null,
+        "Inzidenz": 187.865943460613,
+        "Datum_neu": 1611014400000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "12.01.2021 - 18.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 157.7,
+        "Fallzahl_aktiv": 2464,
+        "Krh_N_belegt": 221,
+        "Krh_N_frei": 137,
+        "Krh_I_belegt": 87,
+        "Krh_I_frei": 26,
+        "Fallzahl_aktiv_Zuwachs": -228,
+        "Krh_N": 358,
         "Krh_I": 113,
         "Vorz_akt_Faelle": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
