### PR TITLE
New data set: 2021-01-19T125503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-19T110803Z.json
+pjson/2021-01-19T125503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-19T125404Z.json pjson/2021-01-19T125503Z.json```:
```
--- pjson/2021-01-19T125404Z.json	2021-01-19 12:54:04.214177601 +0000
+++ pjson/2021-01-19T125503Z.json	2021-01-19 12:55:03.783471290 +0000
@@ -11092,7 +11092,7 @@
         "Krh_I_belegt": 233,
         "Krh_I_frei": 41,
         "Fallzahl_aktiv_Zuwachs": -228,
-        "Krh_N": null,
+        "Krh_N": 358,
         "Krh_I": 274,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 75,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
