### PR TITLE
New data set: 2021-01-19T125803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-19T110803Z.json
+pjson/2021-01-19T125803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-19T125605Z.json pjson/2021-01-19T125803Z.json```:
```
--- pjson/2021-01-19T125605Z.json	2021-01-19 12:56:05.732742899 +0000
+++ pjson/2021-01-19T125803Z.json	2021-01-19 12:58:03.398980816 +0000
@@ -11087,8 +11087,8 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 157.7,
         "Fallzahl_aktiv": 2464,
-        "Krh_N_belegt": null,
-        "Krh_N_frei": null,
+        "Krh_N_belegt": 221,
+        "Krh_N_frei": 137,
         "Krh_I_belegt": 233,
         "Krh_I_frei": 41,
         "Fallzahl_aktiv_Zuwachs": -228,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
