### PR TITLE
New data set: 2021-01-20T112402Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-19T110803Z.json
+pjson/2021-01-20T112402Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-19T125903Z.json pjson/2021-01-20T112402Z.json```:
```
--- pjson/2021-01-19T125903Z.json	2021-01-19 12:59:03.956055076 +0000
+++ pjson/2021-01-20T112402Z.json	2021-01-20 11:24:03.193557592 +0000
@@ -9415,7 +9415,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 327,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 25,
@@ -9449,7 +9449,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 29,
@@ -9587,7 +9587,7 @@
         "Datum_neu": 1607212800000,
         "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 3,
+        "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9600,7 +9600,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -9619,7 +9619,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 373,
+        "F\u00e4lle_Meldedatum": 375,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 7,
         "Hosp_Meldedatum": 22,
@@ -9757,7 +9757,7 @@
         "Datum_neu": 1607644800000,
         "F\u00e4lle_Meldedatum": 340,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 9,
+        "SterbeF_Meldedatum": 10,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -9770,7 +9770,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -9857,7 +9857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 9,
         "Hosp_Meldedatum": 28,
@@ -9891,7 +9891,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 16,
         "Hosp_Meldedatum": 39,
@@ -9925,7 +9925,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 353,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 27,
@@ -9993,7 +9993,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 456,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 22,
         "Hosp_Meldedatum": 26,
@@ -10027,7 +10027,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 9,
@@ -10095,7 +10095,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 444,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 42,
@@ -10129,7 +10129,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 486,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 10,
         "Hosp_Meldedatum": 32,
@@ -10163,7 +10163,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 436,
+        "F\u00e4lle_Meldedatum": 442,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 8,
         "Hosp_Meldedatum": 29,
@@ -10197,7 +10197,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 12,
         "Hosp_Meldedatum": 13,
@@ -10265,7 +10265,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 9,
         "Hosp_Meldedatum": 10,
@@ -10299,9 +10299,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 18,
+        "SterbeF_Meldedatum": 21,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10314,7 +10314,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 18
+        "SterbeF_Sterbedatum": 21
       }
     },
     {
@@ -10333,7 +10333,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 363,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 13,
         "Hosp_Meldedatum": 40,
@@ -10403,7 +10403,7 @@
         "Datum_neu": 1609286400000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 15,
+        "SterbeF_Meldedatum": 16,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10416,7 +10416,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15
+        "SterbeF_Sterbedatum": 16
       }
     },
     {
@@ -10505,7 +10505,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 13,
+        "SterbeF_Meldedatum": 14,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10518,7 +10518,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13
+        "SterbeF_Sterbedatum": 14
       }
     },
     {
@@ -10571,9 +10571,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 10,
+        "SterbeF_Meldedatum": 11,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10586,7 +10586,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -10607,8 +10607,8 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 12,
-        "Hosp_Meldedatum": 24,
+        "SterbeF_Meldedatum": 13,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10620,7 +10620,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -10639,9 +10639,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 343,
+        "F\u00e4lle_Meldedatum": 348,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 8,
+        "SterbeF_Meldedatum": 9,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
@@ -10654,7 +10654,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 9
       }
     },
     {
@@ -10673,10 +10673,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 269,
+        "F\u00e4lle_Meldedatum": 270,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 10,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10707,7 +10707,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 6,
         "Hosp_Meldedatum": 20,
@@ -10809,9 +10809,9 @@
         "BelegteBetten": null,
         "Inzidenz": 271.4,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 8,
+        "SterbeF_Meldedatum": 10,
         "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": 267.4,
         "Fallzahl_aktiv": null,
@@ -10824,7 +10824,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -10843,7 +10843,7 @@
         "BelegteBetten": null,
         "Inzidenz": 258.3,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 258,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 32,
@@ -10877,9 +10877,9 @@
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 1,
+        "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 196.3,
         "Fallzahl_aktiv": null,
@@ -10892,7 +10892,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -10911,7 +10911,7 @@
         "BelegteBetten": null,
         "Inzidenz": 208.879629297029,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 182,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 1,
         "Hosp_Meldedatum": 13,
@@ -10945,9 +10945,9 @@
         "BelegteBetten": null,
         "Inzidenz": 190.380401594885,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 4,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 164.3,
         "Fallzahl_aktiv": null,
@@ -10960,7 +10960,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -10979,7 +10979,7 @@
         "BelegteBetten": null,
         "Inzidenz": 178.346923380869,
         "Datum_neu": 1610755200000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 2,
         "Hosp_Meldedatum": 2,
@@ -11013,7 +11013,7 @@
         "BelegteBetten": null,
         "Inzidenz": 186.249506088581,
         "Datum_neu": 1610841600000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "SterbeF_Meldedatum": 0,
         "Hosp_Meldedatum": 2,
@@ -11036,33 +11036,33 @@
         "Datum": "18.01.2021",
         "Fallzahl": 19132,
         "ObjectId": 318,
-        "Sterbefall": 513,
-        "Genesungsfall": 15927,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1417,
-        "Zuwachs_Fallzahl": 35,
-        "Zuwachs_Sterbefall": 15,
-        "Zuwachs_Krankenhauseinweisung": 43,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 200,
         "BelegteBetten": null,
         "Inzidenz": 188.584360070405,
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "SterbeF_Meldedatum": 2,
+        "SterbeF_Meldedatum": 3,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 178.9,
-        "Fallzahl_aktiv": 2692,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_N_frei": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -180,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_N": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -11072,7 +11072,7 @@
         "ObjectId": 319,
         "Sterbefall": 554,
         "Genesungsfall": 16298,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1465,
         "Zuwachs_Fallzahl": 184,
         "Zuwachs_Sterbefall": 41,
@@ -11081,23 +11081,57 @@
         "BelegteBetten": null,
         "Inzidenz": 187.865943460613,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "12.01.2021 - 18.01.2021",
+        "F\u00e4lle_Meldedatum": 113,
+        "Zeitraum": null,
         "SterbeF_Meldedatum": 4,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 157.7,
         "Fallzahl_aktiv": 2464,
-        "Krh_N_belegt": 221,
-        "Krh_N_frei": 137,
-        "Krh_I_belegt": 233,
-        "Krh_I_frei": 41,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -228,
-        "Krh_N": 358,
-        "Krh_I": 274,
+        "Krh_N": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 75,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.01.2021",
+        "Fallzahl": 19486,
+        "ObjectId": 320,
+        "Sterbefall": 570,
+        "Genesungsfall": 16656,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1488,
+        "Zuwachs_Fallzahl": 170,
+        "Zuwachs_Sterbefall": 16,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 358,
+        "BelegteBetten": null,
+        "Inzidenz": 163.080570422788,
+        "Datum_neu": 1611100800000,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": "13.01.2021 - 19.01.2021",
+        "SterbeF_Meldedatum": 0,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 143.7,
+        "Fallzahl_aktiv": 2260,
+        "Krh_N_belegt": null,
+        "Krh_N_frei": null,
+        "Krh_I_belegt": 239,
+        "Krh_I_frei": 38,
+        "Fallzahl_aktiv_Zuwachs": -204,
+        "Krh_N": null,
+        "Krh_I": 277,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 72,
+        "SterbeF_Sterbedatum": 0
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
