### PR TITLE
New data set: 2021-01-21T111303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-20T112402Z.json
+pjson/2021-01-21T111303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-21T065103Z.json pjson/2021-01-21T111303Z.json```:
```
--- pjson/2021-01-21T065103Z.json	2021-01-21 06:51:03.247668093 +0000
+++ pjson/2021-01-21T111303Z.json	2021-01-21 11:13:03.462552211 +0000
@@ -7137,7 +7137,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603411200000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -7257,7 +7257,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -7407,7 +7407,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604188800000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -7439,7 +7439,7 @@
         "Datum_neu": 1604275200000,
         "F\u00e4lle_Meldedatum": 187,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7467,7 +7467,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -7527,7 +7527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -7587,7 +7587,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604707200000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -7887,7 +7887,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8187,7 +8187,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -8279,7 +8279,7 @@
         "Datum_neu": 1606694400000,
         "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8339,7 +8339,7 @@
         "Datum_neu": 1606867200000,
         "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8399,7 +8399,7 @@
         "Datum_neu": 1607040000000,
         "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8427,7 +8427,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -8579,7 +8579,7 @@
         "Datum_neu": 1607558400000,
         "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8727,7 +8727,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -8877,7 +8877,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 449,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
         "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
@@ -8937,7 +8937,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -8948,7 +8948,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -9029,7 +9029,7 @@
         "Datum_neu": 1608854400000,
         "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9057,7 +9057,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 363,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -9147,9 +9147,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 557,
+        "F\u00e4lle_Meldedatum": 556,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9177,9 +9177,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9207,7 +9207,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -9218,7 +9218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9327,7 +9327,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 251,
+        "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -9338,7 +9338,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -9368,7 +9368,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13
+        "SterbeF_Sterbedatum": 14
       }
     },
     {
@@ -9387,7 +9387,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 348,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9398,7 +9398,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -9417,7 +9417,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 270,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -9518,7 +9518,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 9
       }
     },
     {
@@ -9535,12 +9535,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 479,
         "BelegteBetten": null,
-        "Inzidenz": 271.4,
+        "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 46,
-        "Inzidenz_RKI": 267.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9548,7 +9548,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -9565,12 +9565,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 520,
         "BelegteBetten": null,
-        "Inzidenz": 258.3,
+        "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
-        "Inzidenz_RKI": 229,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9578,7 +9578,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": 233.7,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 196.3,
@@ -9638,7 +9638,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -9657,9 +9657,9 @@
         "BelegteBetten": null,
         "Inzidenz": 190.380401594885,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 164.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -9698,7 +9698,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -9747,7 +9747,7 @@
         "BelegteBetten": null,
         "Inzidenz": 188.584360070405,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 178.9,
@@ -9758,7 +9758,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -9766,25 +9766,25 @@
         "Datum": "19.01.2021",
         "Fallzahl": 19316,
         "ObjectId": 319,
-        "Sterbefall": 554,
-        "Genesungsfall": 16298,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1465,
-        "Zuwachs_Fallzahl": 184,
-        "Zuwachs_Sterbefall": 41,
-        "Zuwachs_Krankenhauseinweisung": 48,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 371,
         "BelegteBetten": null,
         "Inzidenz": 187.865943460613,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 157.7,
-        "Fallzahl_aktiv": 2464,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -228,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -9798,7 +9798,7 @@
         "ObjectId": 320,
         "Sterbefall": 570,
         "Genesungsfall": 16656,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1488,
         "Zuwachs_Fallzahl": 170,
         "Zuwachs_Sterbefall": 16,
@@ -9807,17 +9807,47 @@
         "BelegteBetten": null,
         "Inzidenz": 163.080570422788,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 52,
-        "Zeitraum": "13.01.2021 - 19.01.2021",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 126,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 143.7,
         "Fallzahl_aktiv": 2260,
-        "Krh_I_belegt": 239,
-        "Krh_I_frei": 38,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -204,
-        "Krh_I": 277,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.01.2021",
+        "Fallzahl": 19621,
+        "ObjectId": 321,
+        "Sterbefall": 584,
+        "Genesungsfall": 16853,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1530,
+        "Zuwachs_Fallzahl": 135,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 42,
+        "Zuwachs_Genesung": 197,
+        "BelegteBetten": null,
+        "Inzidenz": 144.94055102554,
+        "Datum_neu": 1611187200000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "14.01.2021 - 20.01.2021",
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 128.6,
+        "Fallzahl_aktiv": 2184,
+        "Krh_I_belegt": 234,
+        "Krh_I_frei": 42,
+        "Fallzahl_aktiv_Zuwachs": -76,
+        "Krh_I": 276,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 72,
+        "Krh_I_covid": 71,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
