### PR TITLE
New data set: 2021-01-23T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-22T112603Z.json
+pjson/2021-01-23T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-22T112603Z.json pjson/2021-01-23T110203Z.json```:
```
--- pjson/2021-01-22T112603Z.json	2021-01-22 11:26:03.895549904 +0000
+++ pjson/2021-01-23T110203Z.json	2021-01-23 11:02:03.478022677 +0000
@@ -4347,7 +4347,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1595376000000,
-        "F\u00e4lle_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -8217,7 +8217,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -8879,7 +8879,7 @@
         "Datum_neu": 1608422400000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9027,7 +9027,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 367,
+        "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -9149,7 +9149,7 @@
         "Datum_neu": 1609200000000,
         "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9179,7 +9179,7 @@
         "Datum_neu": 1609286400000,
         "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9239,7 +9239,7 @@
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9269,7 +9269,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9359,7 +9359,7 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9417,9 +9417,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9447,7 +9447,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 166,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -9599,7 +9599,7 @@
         "Datum_neu": 1610496000000,
         "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9625,9 +9625,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 67,
         "BelegteBetten": null,
-        "Inzidenz": 208.879629297029,
+        "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9655,12 +9655,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 16,
         "BelegteBetten": null,
-        "Inzidenz": 190.380401594885,
+        "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 164.3,
+        "Hosp_Meldedatum": 20,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": 187.865943460613,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 157.7,
@@ -9807,9 +9807,9 @@
         "BelegteBetten": null,
         "Inzidenz": 163.080570422788,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 143.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9826,25 +9826,25 @@
         "Datum": "21.01.2021",
         "Fallzahl": 19621,
         "ObjectId": 321,
-        "Sterbefall": 584,
-        "Genesungsfall": 16853,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1530,
-        "Zuwachs_Fallzahl": 135,
-        "Zuwachs_Sterbefall": 14,
-        "Zuwachs_Krankenhauseinweisung": 42,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
         "Inzidenz": 144.94055102554,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 128.6,
-        "Fallzahl_aktiv": 2184,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -76,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -9858,7 +9858,7 @@
         "ObjectId": 322,
         "Sterbefall": 607,
         "Genesungsfall": 17045,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1547,
         "Zuwachs_Fallzahl": 34,
         "Zuwachs_Sterbefall": 23,
@@ -9867,19 +9867,49 @@
         "BelegteBetten": null,
         "Inzidenz": 131.829447896835,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "15.01.2021 - 21.01.2021",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 107,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 115.7,
         "Fallzahl_aktiv": 2003,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 45,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -181,
-        "Krh_I": 277,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 65,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.01.2021",
+        "Fallzahl": 19873,
+        "ObjectId": 323,
+        "Sterbefall": 607,
+        "Genesungsfall": 17135,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1587,
+        "Zuwachs_Fallzahl": 218,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 40,
+        "Zuwachs_Genesung": 90,
+        "BelegteBetten": null,
+        "Inzidenz": 125.902510866051,
+        "Datum_neu": 1611360000000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "16.01.2021 - 22.01.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 108.5,
+        "Fallzahl_aktiv": 2131,
+        "Krh_I_belegt": 227,
+        "Krh_I_frei": 51,
+        "Fallzahl_aktiv_Zuwachs": 128,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 64,
+        "SterbeF_Sterbedatum": 0
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
