### PR TITLE
New data set: 2021-01-24T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-23T110203Z.json
+pjson/2021-01-24T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-23T110203Z.json pjson/2021-01-24T110403Z.json```:
```
--- pjson/2021-01-23T110203Z.json	2021-01-23 11:02:03.478022677 +0000
+++ pjson/2021-01-24T110403Z.json	2021-01-24 11:04:03.991647870 +0000
@@ -9029,7 +9029,7 @@
         "Datum_neu": 1608854400000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9089,7 +9089,7 @@
         "Datum_neu": 1609027200000,
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9419,7 +9419,7 @@
         "Datum_neu": 1609977600000,
         "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9477,7 +9477,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -9685,12 +9685,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 156,
         "BelegteBetten": null,
-        "Inzidenz": 178.346923380869,
+        "Inzidenz": null,
         "Datum_neu": 1610755200000,
         "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 160.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9719,7 +9719,7 @@
         "Datum_neu": 1610841600000,
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 171.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9749,7 +9749,7 @@
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 178.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9807,7 +9807,7 @@
         "BelegteBetten": null,
         "Inzidenz": 163.080570422788,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 143.7,
@@ -9837,7 +9837,7 @@
         "BelegteBetten": null,
         "Inzidenz": 144.94055102554,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 128.6,
@@ -9856,29 +9856,29 @@
         "Datum": "22.01.2021",
         "Fallzahl": 19655,
         "ObjectId": 322,
-        "Sterbefall": 607,
-        "Genesungsfall": 17045,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1547,
-        "Zuwachs_Fallzahl": 34,
-        "Zuwachs_Sterbefall": 23,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 192,
         "BelegteBetten": null,
         "Inzidenz": 131.829447896835,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 115.7,
-        "Fallzahl_aktiv": 2003,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -181,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -9888,7 +9888,7 @@
         "ObjectId": 323,
         "Sterbefall": 607,
         "Genesungsfall": 17135,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1587,
         "Zuwachs_Fallzahl": 218,
         "Zuwachs_Sterbefall": 0,
@@ -9897,17 +9897,47 @@
         "BelegteBetten": null,
         "Inzidenz": 125.902510866051,
         "Datum_neu": 1611360000000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "16.01.2021 - 22.01.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 108.5,
         "Fallzahl_aktiv": 2131,
-        "Krh_I_belegt": 227,
-        "Krh_I_frei": 51,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 128,
-        "Krh_I": 278,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.01.2021",
+        "Fallzahl": 19900,
+        "ObjectId": 324,
+        "Sterbefall": 608,
+        "Genesungsfall": 17145,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1593,
+        "Zuwachs_Fallzahl": 27,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 10,
+        "BelegteBetten": null,
+        "Inzidenz": 124.824885951363,
+        "Datum_neu": 1611446400000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "17.01.2021 - 23.01.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 120,
+        "Fallzahl_aktiv": 2147,
+        "Krh_I_belegt": 223,
+        "Krh_I_frei": 54,
+        "Fallzahl_aktiv_Zuwachs": 16,
+        "Krh_I": 277,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 64,
+        "Krh_I_covid": 59,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
