### PR TITLE
New data set: 2021-01-25T111903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-24T110403Z.json
+pjson/2021-01-25T111903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-24T110403Z.json pjson/2021-01-25T111903Z.json```:
```
--- pjson/2021-01-24T110403Z.json	2021-01-24 11:04:03.991647870 +0000
+++ pjson/2021-01-25T111903Z.json	2021-01-25 11:19:03.476008297 +0000
@@ -8729,7 +8729,7 @@
         "Datum_neu": 1607990400000,
         "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8759,7 +8759,7 @@
         "Datum_neu": 1608076800000,
         "F\u00e4lle_Meldedatum": 353,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8847,7 +8847,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -8907,9 +8907,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 453,
+        "F\u00e4lle_Meldedatum": 455,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 42,
+        "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8939,7 +8939,7 @@
         "Datum_neu": 1608595200000,
         "F\u00e4lle_Meldedatum": 482,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8969,7 +8969,7 @@
         "Datum_neu": 1608681600000,
         "F\u00e4lle_Meldedatum": 441,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8978,7 +8978,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -9029,7 +9029,7 @@
         "Datum_neu": 1608854400000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9038,7 +9038,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -9119,7 +9119,7 @@
         "Datum_neu": 1609113600000,
         "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9128,7 +9128,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13
+        "SterbeF_Sterbedatum": 14
       }
     },
     {
@@ -9147,9 +9147,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 553,
+        "F\u00e4lle_Meldedatum": 555,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9177,9 +9177,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9297,9 +9297,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9327,7 +9327,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 253,
+        "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9338,7 +9338,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9428,7 +9428,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -9447,7 +9447,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9548,7 +9548,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15
+        "SterbeF_Sterbedatum": 17
       }
     },
     {
@@ -9569,7 +9569,7 @@
         "Datum_neu": 1610409600000,
         "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9578,7 +9578,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 9
       }
     },
     {
@@ -9638,7 +9638,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 7
       }
     },
     {
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 8
       }
     },
     {
@@ -9758,7 +9758,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -9779,7 +9779,7 @@
         "Datum_neu": 1611014400000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 157.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9848,7 +9848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 1
       }
     },
     {
@@ -9867,9 +9867,9 @@
         "BelegteBetten": null,
         "Inzidenz": 131.829447896835,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 115.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9878,7 +9878,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -9886,29 +9886,29 @@
         "Datum": "23.01.2021",
         "Fallzahl": 19873,
         "ObjectId": 323,
-        "Sterbefall": 607,
-        "Genesungsfall": 17135,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1587,
-        "Zuwachs_Fallzahl": 218,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 40,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 90,
         "BelegteBetten": null,
         "Inzidenz": 125.902510866051,
         "Datum_neu": 1611360000000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 108.5,
-        "Fallzahl_aktiv": 2131,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 128,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 1
       }
     },
     {
@@ -9918,7 +9918,7 @@
         "ObjectId": 324,
         "Sterbefall": 608,
         "Genesungsfall": 17145,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1593,
         "Zuwachs_Fallzahl": 27,
         "Zuwachs_Sterbefall": 1,
@@ -9927,17 +9927,47 @@
         "BelegteBetten": null,
         "Inzidenz": 124.824885951363,
         "Datum_neu": 1611446400000,
-        "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "17.01.2021 - 23.01.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 120,
         "Fallzahl_aktiv": 2147,
-        "Krh_I_belegt": 223,
-        "Krh_I_frei": 54,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 16,
-        "Krh_I": 277,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 59,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.01.2021",
+        "Fallzahl": 19939,
+        "ObjectId": 325,
+        "Sterbefall": 629,
+        "Genesungsfall": 17328,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1638,
+        "Zuwachs_Fallzahl": 39,
+        "Zuwachs_Sterbefall": 21,
+        "Zuwachs_Krankenhauseinweisung": 45,
+        "Zuwachs_Genesung": 183,
+        "BelegteBetten": null,
+        "Inzidenz": 126.620927475843,
+        "Datum_neu": 1611532800000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "18.01.2021 - 24.01.2021",
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": 121.6,
+        "Fallzahl_aktiv": 1982,
+        "Krh_I_belegt": 228,
+        "Krh_I_frei": 55,
+        "Fallzahl_aktiv_Zuwachs": -165,
+        "Krh_I": 283,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 58,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
