### PR TITLE
New data set: 2021-01-26T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-25T111903Z.json
+pjson/2021-01-26T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-25T111903Z.json pjson/2021-01-26T110903Z.json```:
```
--- pjson/2021-01-25T111903Z.json	2021-01-25 11:19:03.476008297 +0000
+++ pjson/2021-01-26T110903Z.json	2021-01-26 11:09:04.108720121 +0000
@@ -6807,7 +6807,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602460800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -7767,7 +7767,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 201,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -7947,7 +7947,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -7977,7 +7977,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8307,7 +8307,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -8607,7 +8607,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 340,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -9027,7 +9027,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9188,7 +9188,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 17
+        "SterbeF_Sterbedatum": 18
       }
     },
     {
@@ -9368,7 +9368,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 14
+        "SterbeF_Sterbedatum": 15
       }
     },
     {
@@ -9447,7 +9447,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 215,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9458,7 +9458,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6
+        "SterbeF_Sterbedatum": 7
       }
     },
     {
@@ -9477,7 +9477,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -9488,7 +9488,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -9509,7 +9509,7 @@
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9539,7 +9539,7 @@
         "Datum_neu": 1610323200000,
         "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 46,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9567,9 +9567,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 269,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9608,7 +9608,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 7
       }
     },
     {
@@ -9627,7 +9627,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9638,7 +9638,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7
+        "SterbeF_Sterbedatum": 8
       }
     },
     {
@@ -9659,7 +9659,7 @@
         "Datum_neu": 1610668800000,
         "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -9715,12 +9715,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
-        "Inzidenz": 186.249506088581,
+        "Inzidenz": null,
         "Datum_neu": 1610841600000,
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 171.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9745,12 +9745,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 200,
         "BelegteBetten": null,
-        "Inzidenz": 188.584360070405,
+        "Inzidenz": null,
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
-        "Inzidenz_RKI": 178.9,
+        "Hosp_Meldedatum": 29,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9758,7 +9758,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -9777,9 +9777,9 @@
         "BelegteBetten": null,
         "Inzidenz": 187.865943460613,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 157.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9807,9 +9807,9 @@
         "BelegteBetten": null,
         "Inzidenz": 163.080570422788,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 143.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9837,9 +9837,9 @@
         "BelegteBetten": null,
         "Inzidenz": 144.94055102554,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 128.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9867,9 +9867,9 @@
         "BelegteBetten": null,
         "Inzidenz": 131.829447896835,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 115.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9897,7 +9897,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.902510866051,
         "Datum_neu": 1611360000000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 108.5,
@@ -9916,29 +9916,29 @@
         "Datum": "24.01.2021",
         "Fallzahl": 19900,
         "ObjectId": 324,
-        "Sterbefall": 608,
-        "Genesungsfall": 17145,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1593,
-        "Zuwachs_Fallzahl": 27,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
         "Inzidenz": 124.824885951363,
         "Datum_neu": 1611446400000,
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 120,
-        "Fallzahl_aktiv": 2147,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 16,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -9948,7 +9948,7 @@
         "ObjectId": 325,
         "Sterbefall": 629,
         "Genesungsfall": 17328,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1638,
         "Zuwachs_Fallzahl": 39,
         "Zuwachs_Sterbefall": 21,
@@ -9957,15 +9957,45 @@
         "BelegteBetten": null,
         "Inzidenz": 126.620927475843,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "18.01.2021 - 24.01.2021",
-        "Hosp_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 94,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 121.6,
         "Fallzahl_aktiv": 1982,
-        "Krh_I_belegt": 228,
-        "Krh_I_frei": 55,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -165,
-        "Krh_I": 283,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.01.2021",
+        "Fallzahl": 20104,
+        "ObjectId": 326,
+        "Sterbefall": 650,
+        "Genesungsfall": 17570,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1659,
+        "Zuwachs_Fallzahl": 165,
+        "Zuwachs_Sterbefall": 21,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 242,
+        "BelegteBetten": null,
+        "Inzidenz": 118.897948920579,
+        "Datum_neu": 1611619200000,
+        "F\u00e4lle_Meldedatum": 48,
+        "Zeitraum": "19.01.2021 - 25.01.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 99.5,
+        "Fallzahl_aktiv": 1884,
+        "Krh_I_belegt": 237,
+        "Krh_I_frei": 45,
+        "Fallzahl_aktiv_Zuwachs": -98,
+        "Krh_I": 282,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 58,
         "SterbeF_Sterbedatum": 0
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
