### PR TITLE
New data set: 2021-01-27T111904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-26T110903Z.json
+pjson/2021-01-27T111904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-26T110903Z.json pjson/2021-01-27T111904Z.json```:
```
--- pjson/2021-01-26T110903Z.json	2021-01-26 11:09:04.108720121 +0000
+++ pjson/2021-01-27T111904Z.json	2021-01-27 11:19:04.747917173 +0000
@@ -4169,7 +4169,7 @@
         "Datum_neu": 1594857600000,
         "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -6177,7 +6177,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600646400000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -6899,7 +6899,7 @@
         "Datum_neu": 1602720000000,
         "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7049,7 +7049,7 @@
         "Datum_neu": 1603152000000,
         "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7227,7 +7227,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -7259,7 +7259,7 @@
         "Datum_neu": 1603756800000,
         "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7317,7 +7317,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603929600000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -7349,7 +7349,7 @@
         "Datum_neu": 1604016000000,
         "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7559,7 +7559,7 @@
         "Datum_neu": 1604620800000,
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7647,7 +7647,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604880000000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -7767,7 +7767,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -7799,7 +7799,7 @@
         "Datum_neu": 1605312000000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7859,7 +7859,7 @@
         "Datum_neu": 1605484800000,
         "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7919,7 +7919,7 @@
         "Datum_neu": 1605657600000,
         "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7949,7 +7949,7 @@
         "Datum_neu": 1605744000000,
         "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8069,7 +8069,7 @@
         "Datum_neu": 1606089600000,
         "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8099,7 +8099,7 @@
         "Datum_neu": 1606176000000,
         "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8129,7 +8129,7 @@
         "Datum_neu": 1606262400000,
         "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8309,7 +8309,7 @@
         "Datum_neu": 1606780800000,
         "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8489,7 +8489,7 @@
         "Datum_neu": 1607299200000,
         "F\u00e4lle_Meldedatum": 375,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8577,7 +8577,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 461,
+        "F\u00e4lle_Meldedatum": 462,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -8609,7 +8609,7 @@
         "Datum_neu": 1607644800000,
         "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8637,7 +8637,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -8757,7 +8757,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -8787,9 +8787,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 518,
+        "F\u00e4lle_Meldedatum": 519,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8847,7 +8847,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -8858,7 +8858,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 9
       }
     },
     {
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 455,
+        "F\u00e4lle_Meldedatum": 456,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -9098,7 +9098,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 21
+        "SterbeF_Sterbedatum": 22
       }
     },
     {
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 366,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -9147,7 +9147,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 555,
+        "F\u00e4lle_Meldedatum": 556,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -9177,7 +9177,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 449,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -9218,7 +9218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13
+        "SterbeF_Sterbedatum": 14
       }
     },
     {
@@ -9248,7 +9248,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9267,7 +9267,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -9359,7 +9359,7 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9368,7 +9368,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15
+        "SterbeF_Sterbedatum": 14
       }
     },
     {
@@ -9447,7 +9447,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9509,7 +9509,7 @@
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 269,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 242,
+        "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9627,7 +9627,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9698,7 +9698,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -9728,7 +9728,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 1
       }
     },
     {
@@ -9749,7 +9749,7 @@
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9758,7 +9758,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -9775,12 +9775,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 371,
         "BelegteBetten": null,
-        "Inzidenz": 187.865943460613,
+        "Inzidenz": null,
         "Datum_neu": 1611014400000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 157.7,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9807,9 +9807,9 @@
         "BelegteBetten": null,
         "Inzidenz": 163.080570422788,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 143.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9837,7 +9837,7 @@
         "BelegteBetten": null,
         "Inzidenz": 144.94055102554,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 128.6,
@@ -9848,7 +9848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -9867,9 +9867,9 @@
         "BelegteBetten": null,
         "Inzidenz": 131.829447896835,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 115.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9908,7 +9908,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -9927,7 +9927,7 @@
         "BelegteBetten": null,
         "Inzidenz": 124.824885951363,
         "Datum_neu": 1611446400000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 120,
@@ -9938,7 +9938,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -9946,25 +9946,25 @@
         "Datum": "25.01.2021",
         "Fallzahl": 19939,
         "ObjectId": 325,
-        "Sterbefall": 629,
-        "Genesungsfall": 17328,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1638,
-        "Zuwachs_Fallzahl": 39,
-        "Zuwachs_Sterbefall": 21,
-        "Zuwachs_Krankenhauseinweisung": 45,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 183,
         "BelegteBetten": null,
         "Inzidenz": 126.620927475843,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 121.6,
-        "Fallzahl_aktiv": 1982,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -165,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -9978,7 +9978,7 @@
         "ObjectId": 326,
         "Sterbefall": 650,
         "Genesungsfall": 17570,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1659,
         "Zuwachs_Fallzahl": 165,
         "Zuwachs_Sterbefall": 21,
@@ -9987,17 +9987,47 @@
         "BelegteBetten": null,
         "Inzidenz": 118.897948920579,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 48,
-        "Zeitraum": "19.01.2021 - 25.01.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 113,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 99.5,
         "Fallzahl_aktiv": 1884,
-        "Krh_I_belegt": 237,
-        "Krh_I_frei": 45,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -98,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.01.2021",
+        "Fallzahl": 20270,
+        "ObjectId": 327,
+        "Sterbefall": 660,
+        "Genesungsfall": 17826,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1693,
+        "Zuwachs_Fallzahl": 166,
+        "Zuwachs_Sterbefall": 10,
+        "Zuwachs_Krankenhauseinweisung": 34,
+        "Zuwachs_Genesung": 256,
+        "BelegteBetten": null,
+        "Inzidenz": 119.257157225475,
+        "Datum_neu": 1611705600000,
+        "F\u00e4lle_Meldedatum": 58,
+        "Zeitraum": "20.01.2021 - 26.01.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 102.9,
+        "Fallzahl_aktiv": 1784,
+        "Krh_I_belegt": 232,
+        "Krh_I_frei": 50,
+        "Fallzahl_aktiv_Zuwachs": -100,
         "Krh_I": 282,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 58,
+        "Krh_I_covid": 50,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
