### PR TITLE
New data set: 2021-01-28T112603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-27T111904Z.json
+pjson/2021-01-28T112603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-27T111904Z.json pjson/2021-01-28T112603Z.json```:
```
--- pjson/2021-01-27T111904Z.json	2021-01-27 11:19:04.747917173 +0000
+++ pjson/2021-01-28T112603Z.json	2021-01-28 11:26:03.517776152 +0000
@@ -7017,7 +7017,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -7947,7 +7947,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -8127,7 +8127,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8189,7 +8189,7 @@
         "Datum_neu": 1606435200000,
         "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8258,7 +8258,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -8397,7 +8397,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 212,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8408,7 +8408,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -8427,7 +8427,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -8607,7 +8607,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -8637,7 +8637,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 335,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -8648,7 +8648,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -8708,7 +8708,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9
+        "SterbeF_Sterbedatum": 8
       }
     },
     {
@@ -8738,7 +8738,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 16
+        "SterbeF_Sterbedatum": 17
       }
     },
     {
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 365,
+        "F\u00e4lle_Meldedatum": 364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -9177,9 +9177,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9218,7 +9218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 14
+        "SterbeF_Sterbedatum": 15
       }
     },
     {
@@ -9428,7 +9428,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -9518,7 +9518,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 272,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 245,
+        "F\u00e4lle_Meldedatum": 244,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9629,7 +9629,7 @@
         "Datum_neu": 1610582400000,
         "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -9698,7 +9698,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9807,10 +9807,10 @@
         "BelegteBetten": null,
         "Inzidenz": 163.080570422788,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 143.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9818,7 +9818,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -9837,9 +9837,9 @@
         "BelegteBetten": null,
         "Inzidenz": 144.94055102554,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 128.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9848,7 +9848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 7
       }
     },
     {
@@ -9867,7 +9867,7 @@
         "BelegteBetten": null,
         "Inzidenz": 131.829447896835,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 115.7,
@@ -9897,7 +9897,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.902510866051,
         "Datum_neu": 1611360000000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 108.5,
@@ -9927,7 +9927,7 @@
         "BelegteBetten": null,
         "Inzidenz": 124.824885951363,
         "Datum_neu": 1611446400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 120,
@@ -9957,7 +9957,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.620927475843,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 121.6,
@@ -9976,25 +9976,25 @@
         "Datum": "26.01.2021",
         "Fallzahl": 20104,
         "ObjectId": 326,
-        "Sterbefall": 650,
-        "Genesungsfall": 17570,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1659,
-        "Zuwachs_Fallzahl": 165,
-        "Zuwachs_Sterbefall": 21,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 242,
         "BelegteBetten": null,
         "Inzidenz": 118.897948920579,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 99.5,
-        "Fallzahl_aktiv": 1884,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -98,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -10008,7 +10008,7 @@
         "ObjectId": 327,
         "Sterbefall": 660,
         "Genesungsfall": 17826,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1693,
         "Zuwachs_Fallzahl": 166,
         "Zuwachs_Sterbefall": 10,
@@ -10017,18 +10017,48 @@
         "BelegteBetten": null,
         "Inzidenz": 119.257157225475,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 58,
-        "Zeitraum": "20.01.2021 - 26.01.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 132,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 102.9,
         "Fallzahl_aktiv": 1784,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 50,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -100,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.01.2021",
+        "Fallzahl": 20368,
+        "ObjectId": 328,
+        "Sterbefall": 676,
+        "Genesungsfall": 17970,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1706,
+        "Zuwachs_Fallzahl": 98,
+        "Zuwachs_Sterbefall": 16,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 144,
+        "BelegteBetten": null,
+        "Inzidenz": 122.310427817091,
+        "Datum_neu": 1611792000000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "21.01.2021 - 27.01.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 104,
+        "Fallzahl_aktiv": 1722,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 46,
+        "Fallzahl_aktiv_Zuwachs": -62,
         "Krh_I": 282,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 50,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 3
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
