### PR TITLE
New data set: 2021-01-29T110803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-28T112603Z.json
+pjson/2021-01-29T110803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-28T112603Z.json pjson/2021-01-29T110803Z.json```:
```
--- pjson/2021-01-28T112603Z.json	2021-01-28 11:26:03.517776152 +0000
+++ pjson/2021-01-29T110803Z.json	2021-01-29 11:08:04.021113275 +0000
@@ -7197,7 +7197,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603584000000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -8367,7 +8367,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 298,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -8577,7 +8577,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 462,
+        "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -8678,7 +8678,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 456,
+        "F\u00e4lle_Meldedatum": 457,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -8967,7 +8967,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 441,
+        "F\u00e4lle_Meldedatum": 440,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -9147,9 +9147,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 556,
+        "F\u00e4lle_Meldedatum": 558,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9269,7 +9269,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9417,7 +9417,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 279,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9458,7 +9458,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7
+        "SterbeF_Sterbedatum": 8
       }
     },
     {
@@ -9518,7 +9518,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13
+        "SterbeF_Sterbedatum": 14
       }
     },
     {
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9627,9 +9627,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9698,7 +9698,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6
+        "SterbeF_Sterbedatum": 8
       }
     },
     {
@@ -9717,7 +9717,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610841600000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -9747,7 +9747,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 156,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9788,7 +9788,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -9805,9 +9805,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 358,
         "BelegteBetten": null,
-        "Inzidenz": 163.080570422788,
+        "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -9818,7 +9818,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -9835,12 +9835,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
-        "Inzidenz": 144.94055102554,
+        "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
-        "Inzidenz_RKI": 128.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9848,7 +9848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7
+        "SterbeF_Sterbedatum": 9
       }
     },
     {
@@ -9957,9 +9957,9 @@
         "BelegteBetten": null,
         "Inzidenz": 126.620927475843,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 121.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9968,7 +9968,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 1
       }
     },
     {
@@ -9987,9 +9987,9 @@
         "BelegteBetten": null,
         "Inzidenz": 118.897948920579,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 99.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9998,7 +9998,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -10006,25 +10006,25 @@
         "Datum": "27.01.2021",
         "Fallzahl": 20270,
         "ObjectId": 327,
-        "Sterbefall": 660,
-        "Genesungsfall": 17826,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1693,
-        "Zuwachs_Fallzahl": 166,
-        "Zuwachs_Sterbefall": 10,
-        "Zuwachs_Krankenhauseinweisung": 34,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 256,
         "BelegteBetten": null,
         "Inzidenz": 119.257157225475,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 102.9,
-        "Fallzahl_aktiv": 1784,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -100,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -10038,7 +10038,7 @@
         "ObjectId": 328,
         "Sterbefall": 676,
         "Genesungsfall": 17970,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1706,
         "Zuwachs_Fallzahl": 98,
         "Zuwachs_Sterbefall": 16,
@@ -10047,18 +10047,48 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 14,
-        "Zeitraum": "21.01.2021 - 27.01.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 74,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 104,
         "Fallzahl_aktiv": 1722,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 46,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -62,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.01.2021",
+        "Fallzahl": 20456,
+        "ObjectId": 329,
+        "Sterbefall": 691,
+        "Genesungsfall": 18126,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1726,
+        "Zuwachs_Fallzahl": 88,
+        "Zuwachs_Sterbefall": 15,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 156,
+        "BelegteBetten": null,
+        "Inzidenz": 115.844678328963,
+        "Datum_neu": 1611878400000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "22.01.2021 - 28.01.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 103.6,
+        "Fallzahl_aktiv": 1639,
+        "Krh_I_belegt": 232,
+        "Krh_I_frei": 50,
+        "Fallzahl_aktiv_Zuwachs": -83,
         "Krh_I": 282,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 50,
-        "SterbeF_Sterbedatum": 3
+        "Krh_I_covid": 54,
+        "SterbeF_Sterbedatum": 1
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
