### PR TITLE
New data set: 2021-01-30T110404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-29T110803Z.json
+pjson/2021-01-30T110404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-29T110803Z.json pjson/2021-01-30T110404Z.json```:
```
--- pjson/2021-01-29T110803Z.json	2021-01-29 11:08:04.021113275 +0000
+++ pjson/2021-01-30T110404Z.json	2021-01-30 11:04:04.823321069 +0000
@@ -7947,7 +7947,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -8817,7 +8817,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 458,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -8967,7 +8967,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 440,
+        "F\u00e4lle_Meldedatum": 439,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -9357,7 +9357,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 244,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9807,7 +9807,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -9837,7 +9837,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -9865,12 +9865,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 192,
         "BelegteBetten": null,
-        "Inzidenz": 131.829447896835,
+        "Inzidenz": null,
         "Datum_neu": 1611273600000,
         "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 115.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10036,25 +10036,25 @@
         "Datum": "28.01.2021",
         "Fallzahl": 20368,
         "ObjectId": 328,
-        "Sterbefall": 676,
-        "Genesungsfall": 17970,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1706,
-        "Zuwachs_Fallzahl": 98,
-        "Zuwachs_Sterbefall": 16,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 104,
-        "Fallzahl_aktiv": 1722,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -62,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -10068,7 +10068,7 @@
         "ObjectId": 329,
         "Sterbefall": 691,
         "Genesungsfall": 18126,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1726,
         "Zuwachs_Fallzahl": 88,
         "Zuwachs_Sterbefall": 15,
@@ -10077,9 +10077,9 @@
         "BelegteBetten": null,
         "Inzidenz": 115.844678328963,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "22.01.2021 - 28.01.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 103.6,
         "Fallzahl_aktiv": 1639,
         "Krh_I_belegt": 232,
@@ -10087,9 +10087,39 @@
         "Fallzahl_aktiv_Zuwachs": -83,
         "Krh_I": 282,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 54,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.01.2021",
+        "Fallzahl": 20530,
+        "ObjectId": 330,
+        "Sterbefall": 691,
+        "Genesungsfall": 18210,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1731,
+        "Zuwachs_Fallzahl": 74,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 84,
+        "BelegteBetten": null,
+        "Inzidenz": 99.3210963037465,
+        "Datum_neu": 1611964800000,
+        "F\u00e4lle_Meldedatum": 50,
+        "Zeitraum": "23.01.2021 - 29.01.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 97.5,
+        "Fallzahl_aktiv": 1629,
+        "Krh_I_belegt": 231,
+        "Krh_I_frei": 51,
+        "Fallzahl_aktiv_Zuwachs": -10,
+        "Krh_I": 282,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 47,
+        "SterbeF_Sterbedatum": 0
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
