### PR TITLE
New data set: 2021-01-31T110303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-30T110404Z.json
+pjson/2021-01-31T110303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-30T110404Z.json pjson/2021-01-31T110303Z.json```:
```
--- pjson/2021-01-30T110404Z.json	2021-01-30 11:04:04.823321069 +0000
+++ pjson/2021-01-31T110303Z.json	2021-01-31 11:03:03.630863257 +0000
@@ -8307,7 +8307,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 329,
+        "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -8937,7 +8937,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 482,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 249,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9657,7 +9657,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9747,7 +9747,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9867,7 +9867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -9895,12 +9895,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 90,
         "BelegteBetten": null,
-        "Inzidenz": 125.902510866051,
+        "Inzidenz": null,
         "Datum_neu": 1611360000000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 108.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10066,26 +10066,26 @@
         "Datum": "29.01.2021",
         "Fallzahl": 20456,
         "ObjectId": 329,
-        "Sterbefall": 691,
-        "Genesungsfall": 18126,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1726,
-        "Zuwachs_Fallzahl": 88,
-        "Zuwachs_Sterbefall": 15,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 156,
         "BelegteBetten": null,
         "Inzidenz": 115.844678328963,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 103.6,
-        "Fallzahl_aktiv": 1639,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 50,
-        "Fallzahl_aktiv_Zuwachs": -83,
-        "Krh_I": 282,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1
@@ -10098,7 +10098,7 @@
         "ObjectId": 330,
         "Sterbefall": 691,
         "Genesungsfall": 18210,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1731,
         "Zuwachs_Fallzahl": 74,
         "Zuwachs_Sterbefall": 0,
@@ -10107,17 +10107,47 @@
         "BelegteBetten": null,
         "Inzidenz": 99.3210963037465,
         "Datum_neu": 1611964800000,
-        "F\u00e4lle_Meldedatum": 50,
-        "Zeitraum": "23.01.2021 - 29.01.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": 1629,
-        "Krh_I_belegt": 231,
-        "Krh_I_frei": 51,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -10,
-        "Krh_I": 282,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 47,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.01.2021",
+        "Fallzahl": 20569,
+        "ObjectId": 331,
+        "Sterbefall": 691,
+        "Genesungsfall": 18233,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1745,
+        "Zuwachs_Fallzahl": 39,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 23,
+        "BelegteBetten": null,
+        "Inzidenz": 101.476346133123,
+        "Datum_neu": 1612051200000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "24.01.2021 - 30.01.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 96.1,
+        "Fallzahl_aktiv": 1645,
+        "Krh_I_belegt": 234,
+        "Krh_I_frei": 48,
+        "Fallzahl_aktiv_Zuwachs": 16,
+        "Krh_I": 282,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 48,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
