### PR TITLE
New data set: 2021-02-01T110104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-01-31T110303Z.json
+pjson/2021-02-01T110104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-01-31T110303Z.json pjson/2021-02-01T110104Z.json```:
```
--- pjson/2021-01-31T110303Z.json	2021-01-31 11:03:03.630863257 +0000
+++ pjson/2021-02-01T110104Z.json	2021-02-01 11:01:04.411204247 +0000
@@ -7107,7 +7107,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603324800000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -7977,7 +7977,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8277,7 +8277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -8397,7 +8397,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8727,7 +8727,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -9548,7 +9548,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 17
+        "SterbeF_Sterbedatum": 18
       }
     },
     {
@@ -9597,9 +9597,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9657,7 +9657,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9747,9 +9747,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9848,7 +9848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -9867,7 +9867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -9878,7 +9878,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -9925,12 +9925,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 124.824885951363,
+        "Inzidenz": null,
         "Datum_neu": 1611446400000,
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 120,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9957,7 +9957,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.620927475843,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 121.6,
@@ -9968,7 +9968,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -9987,7 +9987,7 @@
         "BelegteBetten": null,
         "Inzidenz": 118.897948920579,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 99.5,
@@ -9998,7 +9998,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -10047,7 +10047,7 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 104,
@@ -10058,7 +10058,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -10077,7 +10077,7 @@
         "BelegteBetten": null,
         "Inzidenz": 115.844678328963,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 22,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 103.6,
@@ -10088,7 +10088,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 7
       }
     },
     {
@@ -10096,29 +10096,29 @@
         "Datum": "30.01.2021",
         "Fallzahl": 20530,
         "ObjectId": 330,
-        "Sterbefall": 691,
-        "Genesungsfall": 18210,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1731,
-        "Zuwachs_Fallzahl": 74,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 84,
         "BelegteBetten": null,
         "Inzidenz": 99.3210963037465,
         "Datum_neu": 1611964800000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 97.5,
-        "Fallzahl_aktiv": 1629,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -10,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -10128,7 +10128,7 @@
         "ObjectId": 331,
         "Sterbefall": 691,
         "Genesungsfall": 18233,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1745,
         "Zuwachs_Fallzahl": 39,
         "Zuwachs_Sterbefall": 0,
@@ -10137,17 +10137,47 @@
         "BelegteBetten": null,
         "Inzidenz": 101.476346133123,
         "Datum_neu": 1612051200000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "24.01.2021 - 30.01.2021",
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 96.1,
         "Fallzahl_aktiv": 1645,
-        "Krh_I_belegt": 234,
-        "Krh_I_frei": 48,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 16,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.02.2021",
+        "Fallzahl": 20595,
+        "ObjectId": 332,
+        "Sterbefall": 709,
+        "Genesungsfall": 18431,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1746,
+        "Zuwachs_Fallzahl": 26,
+        "Zuwachs_Sterbefall": 18,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 198,
+        "BelegteBetten": null,
+        "Inzidenz": 102.733575200259,
+        "Datum_neu": 1612137600000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "25.01.2021 - 31.01.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 100.8,
+        "Fallzahl_aktiv": 1455,
+        "Krh_I_belegt": 232,
+        "Krh_I_frei": 50,
+        "Fallzahl_aktiv_Zuwachs": -190,
         "Krh_I": 282,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 48,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 51,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
