### PR TITLE
New data set: 2021-02-02T110104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-01T110104Z.json
+pjson/2021-02-02T110104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-01T110104Z.json pjson/2021-02-02T110104Z.json```:
```
--- pjson/2021-02-01T110104Z.json	2021-02-01 11:01:04.411204247 +0000
+++ pjson/2021-02-02T110104Z.json	2021-02-02 11:01:04.295677583 +0000
@@ -6627,7 +6627,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601942400000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -7047,7 +7047,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603152000000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -8127,7 +8127,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8307,7 +8307,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 330,
+        "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -8487,7 +8487,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 375,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -8678,7 +8678,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -8757,7 +8757,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -8847,7 +8847,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -9327,7 +9327,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 252,
+        "F\u00e4lle_Meldedatum": 256,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9357,7 +9357,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 396,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 251,
+        "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13
+        "SterbeF_Sterbedatum": 14
       }
     },
     {
@@ -9698,7 +9698,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 9
       }
     },
     {
@@ -9747,9 +9747,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9837,7 +9837,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -9848,7 +9848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -9867,7 +9867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -9908,7 +9908,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -9938,7 +9938,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 11
       }
     },
     {
@@ -9955,9 +9955,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 183,
         "BelegteBetten": null,
-        "Inzidenz": 126.620927475843,
+        "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 121.6,
@@ -9968,7 +9968,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -10017,7 +10017,7 @@
         "BelegteBetten": null,
         "Inzidenz": 119.257157225475,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 102.9,
@@ -10047,7 +10047,7 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 104,
@@ -10058,7 +10058,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -10077,9 +10077,9 @@
         "BelegteBetten": null,
         "Inzidenz": 115.844678328963,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 103.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10107,9 +10107,9 @@
         "BelegteBetten": null,
         "Inzidenz": 99.3210963037465,
         "Datum_neu": 1611964800000,
-        "F\u00e4lle_Meldedatum": 33,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10118,7 +10118,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -10126,29 +10126,29 @@
         "Datum": "31.01.2021",
         "Fallzahl": 20569,
         "ObjectId": 331,
-        "Sterbefall": 691,
-        "Genesungsfall": 18233,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1745,
-        "Zuwachs_Fallzahl": 39,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
         "Inzidenz": 101.476346133123,
         "Datum_neu": 1612051200000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 96.1,
-        "Fallzahl_aktiv": 1645,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 16,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -10158,7 +10158,7 @@
         "ObjectId": 332,
         "Sterbefall": 709,
         "Genesungsfall": 18431,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1746,
         "Zuwachs_Fallzahl": 26,
         "Zuwachs_Sterbefall": 18,
@@ -10167,16 +10167,46 @@
         "BelegteBetten": null,
         "Inzidenz": 102.733575200259,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 6,
-        "Zeitraum": "25.01.2021 - 31.01.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 100.8,
         "Fallzahl_aktiv": 1455,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 50,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -190,
-        "Krh_I": 282,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 5
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.02.2021",
+        "Fallzahl": 20720,
+        "ObjectId": 333,
+        "Sterbefall": 736,
+        "Genesungsfall": 18510,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1755,
+        "Zuwachs_Fallzahl": 125,
+        "Zuwachs_Sterbefall": 27,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 79,
+        "BelegteBetten": null,
+        "Inzidenz": 95.3698049498904,
+        "Datum_neu": 1612224000000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "26.01.2021 - 01.02.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 84.8,
+        "Fallzahl_aktiv": 1474,
+        "Krh_I_belegt": 234,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": 19,
+        "Krh_I": 277,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": 51,
         "SterbeF_Sterbedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
