### PR TITLE
New data set: 2021-02-03T110104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-02T110104Z.json
+pjson/2021-02-03T110104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-02T110104Z.json pjson/2021-02-03T110104Z.json```:
```
--- pjson/2021-02-02T110104Z.json	2021-02-02 11:01:04.295677583 +0000
+++ pjson/2021-02-03T110104Z.json	2021-02-03 11:01:04.244076000 +0000
@@ -5967,7 +5967,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600041600000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -7707,7 +7707,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -7767,7 +7767,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 204,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -8277,7 +8277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -8307,7 +8307,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 331,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -8367,7 +8367,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -8588,7 +8588,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -8937,7 +8937,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9417,7 +9417,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9537,7 +9537,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -9599,7 +9599,7 @@
         "Datum_neu": 1610496000000,
         "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9627,7 +9627,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9728,7 +9728,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -9758,7 +9758,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9807,7 +9807,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -9908,7 +9908,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6
+        "SterbeF_Sterbedatum": 8
       }
     },
     {
@@ -9938,7 +9938,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -9959,8 +9959,8 @@
         "Datum_neu": 1611532800000,
         "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
-        "Inzidenz_RKI": 121.6,
+        "Hosp_Meldedatum": 30,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -9985,9 +9985,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 242,
         "BelegteBetten": null,
-        "Inzidenz": 118.897948920579,
+        "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 99.5,
@@ -9998,7 +9998,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -10017,7 +10017,7 @@
         "BelegteBetten": null,
         "Inzidenz": 119.257157225475,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 102.9,
@@ -10047,7 +10047,7 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 104,
@@ -10077,7 +10077,7 @@
         "BelegteBetten": null,
         "Inzidenz": 115.844678328963,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 103.6,
@@ -10107,7 +10107,7 @@
         "BelegteBetten": null,
         "Inzidenz": 99.3210963037465,
         "Datum_neu": 1611964800000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 97.5,
@@ -10137,7 +10137,7 @@
         "BelegteBetten": null,
         "Inzidenz": 101.476346133123,
         "Datum_neu": 1612051200000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 96.1,
@@ -10156,25 +10156,25 @@
         "Datum": "01.02.2021",
         "Fallzahl": 20595,
         "ObjectId": 332,
-        "Sterbefall": 709,
-        "Genesungsfall": 18431,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1746,
-        "Zuwachs_Fallzahl": 26,
-        "Zuwachs_Sterbefall": 18,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 198,
         "BelegteBetten": null,
         "Inzidenz": 102.733575200259,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 100.8,
-        "Fallzahl_aktiv": 1455,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -190,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -10188,7 +10188,7 @@
         "ObjectId": 333,
         "Sterbefall": 736,
         "Genesungsfall": 18510,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1755,
         "Zuwachs_Fallzahl": 125,
         "Zuwachs_Sterbefall": 27,
@@ -10197,16 +10197,46 @@
         "BelegteBetten": null,
         "Inzidenz": 95.3698049498904,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "26.01.2021 - 01.02.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 77,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 84.8,
         "Fallzahl_aktiv": 1474,
-        "Krh_I_belegt": 234,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 19,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.02.2021",
+        "Fallzahl": 20798,
+        "ObjectId": 334,
+        "Sterbefall": 743,
+        "Genesungsfall": 18651,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1758,
+        "Zuwachs_Fallzahl": 78,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 141,
+        "BelegteBetten": null,
+        "Inzidenz": 85.1323682603542,
+        "Datum_neu": 1612310400000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "27.01.2021 - 02.02.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 78.3,
+        "Fallzahl_aktiv": 1404,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 41,
+        "Fallzahl_aktiv_Zuwachs": -70,
         "Krh_I": 277,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": 51,
         "SterbeF_Sterbedatum": 0
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
