### PR TITLE
New data set: 2021-02-04T114404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-03T110104Z.json
+pjson/2021-02-04T114404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-03T110104Z.json pjson/2021-02-04T114404Z.json```:
```
--- pjson/2021-02-03T110104Z.json	2021-02-03 11:01:04.244076000 +0000
+++ pjson/2021-02-04T114404Z.json	2021-02-04 11:44:04.443331266 +0000
@@ -9509,7 +9509,7 @@
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 14
+        "SterbeF_Sterbedatum": 15
       }
     },
     {
@@ -9848,7 +9848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9878,7 +9878,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -9938,7 +9938,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -9957,7 +9957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -9987,10 +9987,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 99.5,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10015,11 +10015,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 256,
         "BelegteBetten": null,
-        "Inzidenz": 119.257157225475,
+        "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 102.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10028,7 +10028,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 2
       }
     },
     {
@@ -10045,11 +10045,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 122.310427817091,
+        "Inzidenz": 122.3,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 104,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10058,7 +10058,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6
+        "SterbeF_Sterbedatum": 7
       }
     },
     {
@@ -10075,11 +10075,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 156,
         "BelegteBetten": null,
-        "Inzidenz": 115.844678328963,
+        "Inzidenz": 115.8,
         "Datum_neu": 1611878400000,
         "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 103.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10105,7 +10105,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 84,
         "BelegteBetten": null,
-        "Inzidenz": 99.3210963037465,
+        "Inzidenz": 99.3,
         "Datum_neu": 1611964800000,
         "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
@@ -10135,11 +10135,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
-        "Inzidenz": 101.476346133123,
+        "Inzidenz": 101.5,
         "Datum_neu": 1612051200000,
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 96.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10165,11 +10165,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 198,
         "BelegteBetten": null,
-        "Inzidenz": 102.733575200259,
+        "Inzidenz": 102.7,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 100.8,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10186,29 +10186,29 @@
         "Datum": "02.02.2021",
         "Fallzahl": 20720,
         "ObjectId": 333,
-        "Sterbefall": 736,
-        "Genesungsfall": 18510,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1755,
-        "Zuwachs_Fallzahl": 125,
-        "Zuwachs_Sterbefall": 27,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 79,
         "BelegteBetten": null,
-        "Inzidenz": 95.3698049498904,
+        "Inzidenz": 95.4,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 84.8,
-        "Fallzahl_aktiv": 1474,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 19,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 1
       }
     },
     {
@@ -10216,30 +10216,60 @@
         "Datum": "03.02.2021",
         "Fallzahl": 20798,
         "ObjectId": 334,
-        "Sterbefall": 743,
-        "Genesungsfall": 18651,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1758,
-        "Zuwachs_Fallzahl": 78,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 141,
         "BelegteBetten": null,
-        "Inzidenz": 85.1323682603542,
+        "Inzidenz": 85.1,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "27.01.2021 - 02.02.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 76,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 78.3,
-        "Fallzahl_aktiv": 1404,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 41,
-        "Fallzahl_aktiv_Zuwachs": -70,
-        "Krh_I": 277,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 51,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.02.2021",
+        "Fallzahl": 20890,
+        "ObjectId": 335,
+        "Sterbefall": 752,
+        "Genesungsfall": 18759,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1790,
+        "Zuwachs_Fallzahl": 92,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 32,
+        "Zuwachs_Genesung": 108,
+        "BelegteBetten": null,
+        "Inzidenz": 75.6,
+        "Datum_neu": 1612396800000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "28.01.2021 - 03.02.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 63.9,
+        "Fallzahl_aktiv": 1379,
+        "Krh_I_belegt": 226,
+        "Krh_I_frei": 49,
+        "Fallzahl_aktiv_Zuwachs": -25,
+        "Krh_I": 275,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 50,
+        "SterbeF_Sterbedatum": 1
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
