### PR TITLE
New data set: 2021-02-05T111004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-04T114404Z.json
+pjson/2021-02-05T111004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-04T114404Z.json pjson/2021-02-05T111004Z.json```:
```
--- pjson/2021-02-04T114404Z.json	2021-02-04 11:44:04.443331266 +0000
+++ pjson/2021-02-05T111004Z.json	2021-02-05 11:10:04.213985516 +0000
@@ -7767,7 +7767,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 204,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -7797,7 +7797,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605312000000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -7887,7 +7887,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8007,7 +8007,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605916800000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -8189,7 +8189,7 @@
         "Datum_neu": 1606435200000,
         "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8277,7 +8277,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -8309,7 +8309,7 @@
         "Datum_neu": 1606780800000,
         "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8367,7 +8367,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 300,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -8397,7 +8397,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8427,9 +8427,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8519,7 +8519,7 @@
         "Datum_neu": 1607385600000,
         "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8547,9 +8547,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8579,7 +8579,7 @@
         "Datum_neu": 1607558400000,
         "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8607,9 +8607,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8669,7 +8669,7 @@
         "Datum_neu": 1607817600000,
         "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8699,7 +8699,7 @@
         "Datum_neu": 1607904000000,
         "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8729,7 +8729,7 @@
         "Datum_neu": 1607990400000,
         "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8757,9 +8757,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8817,9 +8817,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 458,
+        "F\u00e4lle_Meldedatum": 457,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 458,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -9179,7 +9179,7 @@
         "Datum_neu": 1609286400000,
         "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9239,7 +9239,7 @@
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9267,9 +9267,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9327,7 +9327,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 256,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9387,7 +9387,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 350,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -9447,7 +9447,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9627,7 +9627,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9668,7 +9668,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15
+        "SterbeF_Sterbedatum": 16
       }
     },
     {
@@ -9728,7 +9728,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -9747,7 +9747,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9777,7 +9777,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9837,7 +9837,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -9899,7 +9899,7 @@
         "Datum_neu": 1611360000000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9908,7 +9908,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 9
       }
     },
     {
@@ -9938,7 +9938,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -9957,7 +9957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -9989,7 +9989,7 @@
         "Datum_neu": 1611619200000,
         "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9998,7 +9998,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 6
       }
     },
     {
@@ -10020,7 +10020,7 @@
         "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 102.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10028,7 +10028,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -10045,12 +10045,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 144,
         "BelegteBetten": null,
-        "Inzidenz": 122.3,
+        "Inzidenz": null,
         "Datum_neu": 1611792000000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 104,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10088,7 +10088,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -10109,7 +10109,7 @@
         "Datum_neu": 1611964800000,
         "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10118,7 +10118,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 8
       }
     },
     {
@@ -10148,7 +10148,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -10167,7 +10167,7 @@
         "BelegteBetten": null,
         "Inzidenz": 102.7,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 100.8,
@@ -10197,7 +10197,7 @@
         "BelegteBetten": null,
         "Inzidenz": 95.4,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 84.8,
@@ -10208,7 +10208,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 0
       }
     },
     {
@@ -10227,9 +10227,9 @@
         "BelegteBetten": null,
         "Inzidenz": 85.1,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 78.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10238,7 +10238,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 1
       }
     },
     {
@@ -10248,18 +10248,18 @@
         "ObjectId": 335,
         "Sterbefall": 752,
         "Genesungsfall": 18759,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1790,
         "Zuwachs_Fallzahl": 92,
         "Zuwachs_Sterbefall": 9,
         "Zuwachs_Krankenhauseinweisung": 32,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 75.6,
+        "Inzidenz": 75.6133481806099,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "28.01.2021 - 03.02.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 63.9,
         "Fallzahl_aktiv": 1379,
         "Krh_I_belegt": 226,
@@ -10267,8 +10267,38 @@
         "Fallzahl_aktiv_Zuwachs": -25,
         "Krh_I": 275,
         "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.02.2021",
+        "Fallzahl": 20970,
+        "ObjectId": 336,
+        "Sterbefall": 764,
+        "Genesungsfall": 18869,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1803,
+        "Zuwachs_Fallzahl": 80,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 110,
+        "BelegteBetten": null,
+        "Inzidenz": 71.4824526743058,
+        "Datum_neu": 1612483200000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": "29.01.2021 - 04.02.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 64.3,
+        "Fallzahl_aktiv": 1337,
+        "Krh_I_belegt": 230,
+        "Krh_I_frei": 46,
+        "Fallzahl_aktiv_Zuwachs": -42,
+        "Krh_I": 276,
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": 50,
-        "SterbeF_Sterbedatum": 1
+        "SterbeF_Sterbedatum": 0
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
