### PR TITLE
New data set: 2021-02-06T110304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-05T111004Z.json
+pjson/2021-02-06T110304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-05T111004Z.json pjson/2021-02-06T110304Z.json```:
```
--- pjson/2021-02-05T111004Z.json	2021-02-05 11:10:04.213985516 +0000
+++ pjson/2021-02-06T110304Z.json	2021-02-06 11:03:04.501561249 +0000
@@ -5577,7 +5577,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1598918400000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -7317,7 +7317,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603929600000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -7347,7 +7347,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604016000000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -7527,7 +7527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -7707,7 +7707,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605052800000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -7767,7 +7767,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -8307,7 +8307,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -8337,7 +8337,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -8397,7 +8397,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 215,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8817,7 +8817,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 458,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 458,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -8937,7 +8937,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -8967,7 +8967,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 439,
+        "F\u00e4lle_Meldedatum": 440,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 364,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -9417,7 +9417,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9749,7 +9749,7 @@
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9839,7 +9839,7 @@
         "Datum_neu": 1611187200000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9867,7 +9867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -9899,7 +9899,7 @@
         "Datum_neu": 1611360000000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9957,7 +9957,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -10017,7 +10017,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10047,9 +10047,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10075,12 +10075,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 156,
         "BelegteBetten": null,
-        "Inzidenz": 115.8,
+        "Inzidenz": null,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 103.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10137,7 +10137,7 @@
         "BelegteBetten": null,
         "Inzidenz": 101.5,
         "Datum_neu": 1612051200000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 96.1,
@@ -10148,7 +10148,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4
+        "SterbeF_Sterbedatum": 5
       }
     },
     {
@@ -10167,7 +10167,7 @@
         "BelegteBetten": null,
         "Inzidenz": 102.7,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 100.8,
@@ -10197,9 +10197,9 @@
         "BelegteBetten": null,
         "Inzidenz": 95.4,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 84.8,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10227,9 +10227,9 @@
         "BelegteBetten": null,
         "Inzidenz": 85.1,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 78.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10246,29 +10246,29 @@
         "Datum": "04.02.2021",
         "Fallzahl": 20890,
         "ObjectId": 335,
-        "Sterbefall": 752,
-        "Genesungsfall": 18759,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1790,
-        "Zuwachs_Fallzahl": 92,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 32,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
         "Inzidenz": 75.6133481806099,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 63.9,
-        "Fallzahl_aktiv": 1379,
-        "Krh_I_belegt": 226,
-        "Krh_I_frei": 49,
-        "Fallzahl_aktiv_Zuwachs": -25,
-        "Krh_I": 275,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 3
       }
     },
     {
@@ -10278,7 +10278,7 @@
         "ObjectId": 336,
         "Sterbefall": 764,
         "Genesungsfall": 18869,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1803,
         "Zuwachs_Fallzahl": 80,
         "Zuwachs_Sterbefall": 12,
@@ -10287,17 +10287,47 @@
         "BelegteBetten": null,
         "Inzidenz": 71.4824526743058,
         "Datum_neu": 1612483200000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "29.01.2021 - 04.02.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 68,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 64.3,
         "Fallzahl_aktiv": 1337,
-        "Krh_I_belegt": 230,
-        "Krh_I_frei": 46,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -42,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.02.2021",
+        "Fallzahl": 21032,
+        "ObjectId": 337,
+        "Sterbefall": 766,
+        "Genesungsfall": 18953,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1817,
+        "Zuwachs_Fallzahl": 62,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 84,
+        "BelegteBetten": null,
+        "Inzidenz": 72.0212651316498,
+        "Datum_neu": 1612569600000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "30.01.2021 - 05.02.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 65.2,
+        "Fallzahl_aktiv": 1313,
+        "Krh_I_belegt": 237,
+        "Krh_I_frei": 39,
+        "Fallzahl_aktiv_Zuwachs": -24,
         "Krh_I": 276,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 50,
+        "Krh_I_covid": 49,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
