### PR TITLE
New data set: 2021-02-11T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-10T111504Z.json
+pjson/2021-02-11T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-10T111504Z.json pjson/2021-02-11T110903Z.json```:
```
--- pjson/2021-02-10T111504Z.json	2021-02-10 11:15:05.069986181 +0000
+++ pjson/2021-02-11T110903Z.json	2021-02-11 11:09:03.727600395 +0000
@@ -6867,7 +6867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602633600000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -7227,7 +7227,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -7287,7 +7287,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603843200000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -7497,7 +7497,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 206,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -7587,7 +7587,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604707200000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -7767,7 +7767,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -7887,7 +7887,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8097,7 +8097,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8577,7 +8577,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 465,
+        "F\u00e4lle_Meldedatum": 466,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -8607,7 +8607,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 339,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -8637,7 +8637,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -8697,7 +8697,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -8787,7 +8787,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 519,
+        "F\u00e4lle_Meldedatum": 518,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 462,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": null,
@@ -9087,7 +9087,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -9117,7 +9117,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 365,
+        "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -9147,7 +9147,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 557,
+        "F\u00e4lle_Meldedatum": 556,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9177,7 +9177,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 452,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9297,7 +9297,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609632000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9327,7 +9327,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 248,
+        "F\u00e4lle_Meldedatum": 246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9447,7 +9447,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 221,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9477,7 +9477,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -9507,7 +9507,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610236800000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -9537,7 +9537,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9597,7 +9597,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 242,
+        "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -9627,7 +9627,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9657,7 +9657,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9807,7 +9807,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -9867,7 +9867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10028,7 +10028,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5
+        "SterbeF_Sterbedatum": 7
       }
     },
     {
@@ -10088,7 +10088,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12
+        "SterbeF_Sterbedatum": 13
       }
     },
     {
@@ -10118,7 +10118,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11
+        "SterbeF_Sterbedatum": 12
       }
     },
     {
@@ -10167,7 +10167,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10178,7 +10178,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8
+        "SterbeF_Sterbedatum": 10
       }
     },
     {
@@ -10199,7 +10199,7 @@
         "Datum_neu": 1612224000000,
         "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10225,12 +10225,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 141,
         "BelegteBetten": null,
-        "Inzidenz": 85.1,
+        "Inzidenz": null,
         "Datum_neu": 1612310400000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 78.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10238,7 +10238,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2
+        "SterbeF_Sterbedatum": 4
       }
     },
     {
@@ -10287,7 +10287,7 @@
         "BelegteBetten": null,
         "Inzidenz": 71.4824526743058,
         "Datum_neu": 1612483200000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 64.3,
@@ -10317,7 +10317,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.0212651316498,
         "Datum_neu": 1612569600000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 65.2,
@@ -10328,7 +10328,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0
+        "SterbeF_Sterbedatum": 1
       }
     },
     {
@@ -10347,7 +10347,7 @@
         "BelegteBetten": null,
         "Inzidenz": 69.3,
         "Datum_neu": 1612656000000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 58.9,
@@ -10377,9 +10377,9 @@
         "BelegteBetten": null,
         "Inzidenz": 72.3804734365459,
         "Datum_neu": 1612742400000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 69.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10407,7 +10407,7 @@
         "BelegteBetten": null,
         "Inzidenz": 69.8660153022738,
         "Datum_neu": 1612828800000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 61.4,
@@ -10426,28 +10426,58 @@
         "Datum": "10.02.2021",
         "Fallzahl": 21200,
         "ObjectId": 341,
-        "Sterbefall": 791,
-        "Genesungsfall": 19455,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1848,
-        "Zuwachs_Fallzahl": 68,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 184,
         "BelegteBetten": null,
         "Inzidenz": 66.8,
         "Datum_neu": 1612915200000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "03.02.2021 - 09.02.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 44,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 56.4,
-        "Fallzahl_aktiv": 954,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 39,
-        "Fallzahl_aktiv_Zuwachs": -118,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.02.2021",
+        "Fallzahl": 21226,
+        "ObjectId": 342,
+        "Sterbefall": 800,
+        "Genesungsfall": 19506,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1853,
+        "Zuwachs_Fallzahl": 26,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 51,
+        "BelegteBetten": null,
+        "Inzidenz": 64.5,
+        "Datum_neu": 1613001600000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "04.02.2021 - 10.02.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 57.5,
+        "Fallzahl_aktiv": 920,
+        "Krh_I_belegt": 231,
+        "Krh_I_frei": 40,
+        "Fallzahl_aktiv_Zuwachs": -34,
         "Krh_I": 271,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 44,
+        "Krh_I_covid": 45,
         "SterbeF_Sterbedatum": 0
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
