### PR TITLE
New data set: 2021-02-12T060204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-11T110903Z.json
+pjson/2021-02-12T060204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-11T151303Z.json pjson/2021-02-12T060204Z.json```:
```
--- pjson/2021-02-11T151303Z.json	2021-02-11 15:13:03.721853314 +0000
+++ pjson/2021-02-12T060204Z.json	2021-02-12 06:02:04.579264004 +0000
@@ -10458,7 +10458,7 @@
         "ObjectId": 342,
         "Sterbefall": 800,
         "Genesungsfall": 19506,
-        "Anzeige_Indikator": null,
+        "Anzeige_Indikator": "x",
         "Hospitalisierung": 1853,
         "Zuwachs_Fallzahl": 26,
         "Zuwachs_Sterbefall": 9,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
