### PR TITLE
New data set: 2021-02-12T060603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-11T110903Z.json
+pjson/2021-02-12T060603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-12T060404Z.json pjson/2021-02-12T060603Z.json```:
```
--- pjson/2021-02-12T060404Z.json	2021-02-12 06:04:04.792049752 +0000
+++ pjson/2021-02-12T060603Z.json	2021-02-12 06:06:03.916842229 +0000
@@ -1998,7 +1998,7 @@
         "ObjectId": 60,
         "Sterbefall": null,
         "Genesungsfall": null,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
