### PR TITLE
New data set: 2021-02-12T110404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-11T110903Z.json
+pjson/2021-02-12T110404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-12T070503Z.json pjson/2021-02-12T110404Z.json```:
```
--- pjson/2021-02-12T070503Z.json	2021-02-12 07:05:03.710239853 +0000
+++ pjson/2021-02-12T110404Z.json	2021-02-12 11:04:04.283370031 +0000
@@ -7158,7 +7158,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602806400000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -7747,7 +7747,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 204,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -7778,7 +7778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -8026,7 +8026,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 206,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -8460,7 +8460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 233,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -8770,7 +8770,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 375,
+        "F\u00e4lle_Meldedatum": 374,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -8801,7 +8801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 329,
+        "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -8832,7 +8832,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 391,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8863,7 +8863,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 466,
+        "F\u00e4lle_Meldedatum": 465,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -8894,7 +8894,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 339,
+        "F\u00e4lle_Meldedatum": 338,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -8905,7 +8905,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": 313.140737004267
       }
     },
@@ -9049,7 +9049,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9060,7 +9060,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 12,
         "Inzi_SN_RKI": 407.075590666044
       }
     },
@@ -9111,7 +9111,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 461,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -9184,7 +9184,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": 427.409723694005
       }
     },
@@ -9235,7 +9235,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 487,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9266,7 +9266,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 443,
+        "F\u00e4lle_Meldedatum": 442,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -9297,7 +9297,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9370,7 +9370,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9,
+        "SterbeF_Sterbedatum": 10,
         "Inzi_SN_RKI": 403.735684758069
       }
     },
@@ -9421,7 +9421,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 366,
+        "F\u00e4lle_Meldedatum": 364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -9483,7 +9483,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9494,7 +9494,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 18,
+        "SterbeF_Sterbedatum": 19,
         "Inzi_SN_RKI": 329.963057202519
       }
     },
@@ -9556,7 +9556,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13,
+        "SterbeF_Sterbedatum": 14,
         "Inzi_SN_RKI": 334.457195299279
       }
     },
@@ -9700,7 +9700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 348,
+        "F\u00e4lle_Meldedatum": 347,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -9762,7 +9762,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -10103,7 +10103,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10196,7 +10196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10351,7 +10351,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10506,7 +10506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10517,7 +10517,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": 120.924240374011
       }
     },
@@ -10597,12 +10597,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 75.6133481806099,
+        "Inzidenz": null,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 63.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10628,9 +10628,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 71.4824526743058,
+        "Inzidenz": 71.5,
         "Datum_neu": 1612483200000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 64.3,
@@ -10641,7 +10641,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 100.590107346049
       }
     },
@@ -10659,7 +10659,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 84,
         "BelegteBetten": null,
-        "Inzidenz": 72.0212651316498,
+        "Inzidenz": 72,
         "Datum_neu": 1612569600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
@@ -10692,7 +10692,7 @@
         "BelegteBetten": null,
         "Inzidenz": 69.3,
         "Datum_neu": 1612656000000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 58.9,
@@ -10721,9 +10721,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 172,
         "BelegteBetten": null,
-        "Inzidenz": 72.3804734365459,
+        "Inzidenz": 72.4,
         "Datum_neu": 1612742400000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 69.1,
@@ -10752,11 +10752,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 119,
         "BelegteBetten": null,
-        "Inzidenz": 69.8660153022738,
+        "Inzidenz": 69.9,
         "Datum_neu": 1612828800000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 61.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10785,7 +10785,7 @@
         "BelegteBetten": null,
         "Inzidenz": 66.8,
         "Datum_neu": 1612915200000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 56.4,
@@ -10805,30 +10805,61 @@
         "Datum": "11.02.2021",
         "Fallzahl": 21226,
         "ObjectId": 342,
-        "Sterbefall": 800,
-        "Genesungsfall": 19506,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1853,
-        "Zuwachs_Fallzahl": 26,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": 64.5,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "04.02.2021 - 10.02.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 57.5,
-        "Fallzahl_aktiv": 920,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": 74.5093715058383
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.02.2021",
+        "Fallzahl": 21287,
+        "ObjectId": 343,
+        "Sterbefall": 809,
+        "Genesungsfall": 19568,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1859,
+        "Zuwachs_Fallzahl": 61,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 62,
+        "BelegteBetten": null,
+        "Inzidenz": 59.8,
+        "Datum_neu": 1613088000000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "05.02.2021 - 11.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 53.9,
+        "Fallzahl_aktiv": 910,
         "Krh_I_belegt": 231,
-        "Krh_I_frei": 40,
-        "Fallzahl_aktiv_Zuwachs": -34,
-        "Krh_I": 271,
+        "Krh_I_frei": 50,
+        "Fallzahl_aktiv_Zuwachs": -10,
+        "Krh_I": 281,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 45,
+        "Krh_I_covid": 40,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 74.5093715058383
+        "Inzi_SN_RKI": 71.0221168078063
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
