### PR TITLE
New data set: 2021-02-14T105504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-13T112103Z.json
+pjson/2021-02-14T105504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-13T112103Z.json pjson/2021-02-14T105504Z.json```:
```
--- pjson/2021-02-13T112103Z.json	2021-02-13 11:21:03.592535129 +0000
+++ pjson/2021-02-14T105504Z.json	2021-02-14 10:55:04.606797228 +0000
@@ -9731,7 +9731,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 281,
+        "F\u00e4lle_Meldedatum": 285,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9804,7 +9804,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": 339.123240317772
       }
     },
@@ -9979,7 +9979,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -10351,7 +10351,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10568,7 +10568,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -10630,7 +10630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612483200000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -10659,12 +10659,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 84,
         "BelegteBetten": null,
-        "Inzidenz": 72,
+        "Inzidenz": null,
         "Datum_neu": 1612569600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 65.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10754,7 +10754,7 @@
         "BelegteBetten": null,
         "Inzidenz": 69.9,
         "Datum_neu": 1612828800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 61.4,
@@ -10816,7 +10816,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.5,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 57.5,
@@ -10847,7 +10847,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.8,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 53.9,
@@ -10867,28 +10867,59 @@
         "Datum": "13.02.2021",
         "Fallzahl": 21308,
         "ObjectId": 344,
-        "Sterbefall": 812,
-        "Genesungsfall": 19600,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1859,
-        "Zuwachs_Fallzahl": 21,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 55.6772872588814,
+        "Inzidenz": 55.7,
         "Datum_neu": 1613174400000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "06.02.2021 - 12.02.2021",
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 50.5,
-        "Fallzahl_aktiv": 896,
-        "Krh_I_belegt": 219,
-        "Krh_I_frei": 60,
-        "Fallzahl_aktiv_Zuwachs": -14,
-        "Krh_I": 279,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 37,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.02.2021",
+        "Fallzahl": 21344,
+        "ObjectId": 345,
+        "Sterbefall": 813,
+        "Genesungsfall": 19632,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1860,
+        "Zuwachs_Fallzahl": 36,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 32,
+        "BelegteBetten": null,
+        "Inzidenz": 53.7,
+        "Datum_neu": 1613260800000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "07.02.2021 - 13.02.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 51.7,
+        "Fallzahl_aktiv": 899,
+        "Krh_I_belegt": 220,
+        "Krh_I_frei": 59,
+        "Fallzahl_aktiv_Zuwachs": 3,
+        "Krh_I": 279,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 38,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
