### PR TITLE
New data set: 2021-02-15T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-14T105504Z.json
+pjson/2021-02-15T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-14T105504Z.json pjson/2021-02-15T110504Z.json```:
```
--- pjson/2021-02-14T105504Z.json	2021-02-14 10:55:04.606797228 +0000
+++ pjson/2021-02-15T110504Z.json	2021-02-15 11:05:04.312967050 +0000
@@ -7437,7 +7437,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603584000000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -7499,7 +7499,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -7778,7 +7778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604534400000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -8491,7 +8491,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606521600000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -8584,7 +8584,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 334,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -8863,7 +8863,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 465,
+        "F\u00e4lle_Meldedatum": 466,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -8894,7 +8894,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -9049,7 +9049,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9204,7 +9204,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 461,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": null,
@@ -9452,7 +9452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 556,
+        "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9483,7 +9483,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -9917,7 +9917,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -9981,7 +9981,7 @@
         "Datum_neu": 1610668800000,
         "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10103,7 +10103,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10134,7 +10134,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -10165,7 +10165,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -10351,7 +10351,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10382,7 +10382,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -10663,7 +10663,7 @@
         "Datum_neu": 1612569600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10690,12 +10690,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 27,
         "BelegteBetten": null,
-        "Inzidenz": 69.3,
+        "Inzidenz": null,
         "Datum_neu": 1612656000000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 58.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10703,7 +10703,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 95.5311322207354
       }
     },
@@ -10723,9 +10723,9 @@
         "BelegteBetten": null,
         "Inzidenz": 72.4,
         "Datum_neu": 1612742400000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 69.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10756,7 +10756,7 @@
         "Datum_neu": 1612828800000,
         "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 61.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10787,7 +10787,7 @@
         "Datum_neu": 1612915200000,
         "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 56.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10816,9 +10816,9 @@
         "BelegteBetten": null,
         "Inzidenz": 64.5,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 57.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10847,9 +10847,9 @@
         "BelegteBetten": null,
         "Inzidenz": 59.8,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 53.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10858,7 +10858,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 71.0221168078063
       }
     },
@@ -10878,9 +10878,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.7,
         "Datum_neu": 1613174400000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 50.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10889,8 +10889,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": 68.3698385867679
       }
     },
     {
@@ -10898,28 +10898,59 @@
         "Datum": "14.02.2021",
         "Fallzahl": 21344,
         "ObjectId": 345,
-        "Sterbefall": 813,
-        "Genesungsfall": 19632,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1860,
-        "Zuwachs_Fallzahl": 36,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
         "Inzidenz": 53.7,
         "Datum_neu": 1613260800000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "07.02.2021 - 13.02.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 51.7,
-        "Fallzahl_aktiv": 899,
-        "Krh_I_belegt": 220,
-        "Krh_I_frei": 59,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 65.0299326787936
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.02.2021",
+        "Fallzahl": 21347,
+        "ObjectId": 346,
+        "Sterbefall": 817,
+        "Genesungsfall": 19673,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1877,
+        "Zuwachs_Fallzahl": 3,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 41,
+        "BelegteBetten": null,
+        "Inzidenz": 56,
+        "Datum_neu": 1613347200000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "08.02.2021 - 14.02.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 54.6,
+        "Fallzahl_aktiv": 857,
+        "Krh_I_belegt": 211,
+        "Krh_I_frei": 68,
+        "Fallzahl_aktiv_Zuwachs": -42,
         "Krh_I": 279,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 38,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 35,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
