### PR TITLE
New data set: 2021-02-15T145604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-15T110504Z.json
+pjson/2021-02-15T145604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-15T110504Z.json pjson/2021-02-15T145604Z.json```:
```
--- pjson/2021-02-15T110504Z.json	2021-02-15 11:05:04.312967050 +0000
+++ pjson/2021-02-15T145604Z.json	2021-02-15 14:56:04.308757819 +0000
@@ -10952,7 +10952,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 35,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null
+        "Inzi_SN_RKI": 68.1488154016814
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
