### PR TITLE
New data set: 2021-02-16T112304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-15T164104Z.json
+pjson/2021-02-16T112304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-15T164104Z.json pjson/2021-02-16T112304Z.json```:
```
--- pjson/2021-02-15T164104Z.json	2021-02-15 16:41:04.673723237 +0000
+++ pjson/2021-02-16T112304Z.json	2021-02-16 11:23:04.450503524 +0000
@@ -8243,7 +8243,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 197,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8553,7 +8553,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -8615,7 +8615,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -8770,7 +8770,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 374,
+        "F\u00e4lle_Meldedatum": 376,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -8987,7 +8987,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -9990,7 +9990,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 16,
+        "SterbeF_Sterbedatum": 17,
         "Inzi_SN_RKI": 274.01963324395
       }
     },
@@ -10291,7 +10291,7 @@
         "Datum_neu": 1611532800000,
         "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10331,7 +10331,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": 160.929436874673
       }
     },
@@ -10486,7 +10486,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": 120.064705765341
       }
     },
@@ -10568,7 +10568,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -10721,12 +10721,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 172,
         "BelegteBetten": null,
-        "Inzidenz": 72.4,
+        "Inzidenz": null,
         "Datum_neu": 1612742400000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 69.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10754,7 +10754,7 @@
         "BelegteBetten": null,
         "Inzidenz": 69.9,
         "Datum_neu": 1612828800000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 61.4,
@@ -10785,7 +10785,7 @@
         "BelegteBetten": null,
         "Inzidenz": 66.8,
         "Datum_neu": 1612915200000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 56.4,
@@ -10816,7 +10816,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.5,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 57.5,
@@ -10847,7 +10847,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.8,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 53.9,
@@ -10878,9 +10878,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.7,
         "Datum_neu": 1613174400000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 50.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10929,31 +10929,62 @@
         "Datum": "15.02.2021",
         "Fallzahl": 21347,
         "ObjectId": 346,
-        "Sterbefall": 817,
-        "Genesungsfall": 19673,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1877,
-        "Zuwachs_Fallzahl": 3,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 41,
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "08.02.2021 - 14.02.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 54.6,
-        "Fallzahl_aktiv": 857,
-        "Krh_I_belegt": 211,
-        "Krh_I_frei": 68,
-        "Fallzahl_aktiv_Zuwachs": -42,
-        "Krh_I": 279,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 35,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 68.1488154016814
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.02.2021",
+        "Fallzahl": 21427,
+        "ObjectId": 347,
+        "Sterbefall": 820,
+        "Genesungsfall": 19751,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1886,
+        "Zuwachs_Fallzahl": 80,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 78,
+        "BelegteBetten": null,
+        "Inzidenz": 56,
+        "Datum_neu": 1613433600000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "09.02.2021 - 15.02.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 47.1,
+        "Fallzahl_aktiv": 856,
+        "Krh_I_belegt": 223,
+        "Krh_I_frei": 56,
+        "Fallzahl_aktiv_Zuwachs": -1,
+        "Krh_I": 279,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 36,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 68.4435129817968
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
