### PR TITLE
New data set: 2021-02-17T110103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-16T112304Z.json
+pjson/2021-02-17T110103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-16T112304Z.json pjson/2021-02-17T110103Z.json```:
```
--- pjson/2021-02-16T112304Z.json	2021-02-16 11:23:04.450503524 +0000
+++ pjson/2021-02-17T110103Z.json	2021-02-17 11:01:03.759757500 +0000
@@ -8026,7 +8026,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -8429,7 +8429,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -8584,7 +8584,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 333,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -8989,7 +8989,7 @@
         "Datum_neu": 1607904000000,
         "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9113,7 +9113,7 @@
         "Datum_neu": 1608249600000,
         "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9144,7 +9144,7 @@
         "Datum_neu": 1608336000000,
         "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9153,7 +9153,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": 432.223117502556
       }
     },
@@ -9246,7 +9246,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 12,
         "Inzi_SN_RKI": 426.771212270421
       }
     },
@@ -9762,7 +9762,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -10196,7 +10196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10331,7 +10331,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": 160.929436874673
       }
     },
@@ -10393,7 +10393,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": 129.961632830882
       }
     },
@@ -10486,7 +10486,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": 120.064705765341
       }
     },
@@ -10568,7 +10568,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -10579,7 +10579,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": 105.428059286277
       }
     },
@@ -10601,7 +10601,7 @@
         "Datum_neu": 1612396800000,
         "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10630,7 +10630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612483200000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -10672,7 +10672,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": 97.3975502281328
       }
     },
@@ -10703,7 +10703,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": 95.5311322207354
       }
     },
@@ -10725,7 +10725,7 @@
         "Datum_neu": 1612742400000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10734,7 +10734,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 100.197177239229
       }
     },
@@ -10752,12 +10752,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 119,
         "BelegteBetten": null,
-        "Inzidenz": 69.9,
+        "Inzidenz": null,
         "Datum_neu": 1612828800000,
         "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 61.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10765,7 +10765,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 91.2580173090624
       }
     },
@@ -10816,7 +10816,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.5,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 57.5,
@@ -10847,7 +10847,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.8,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 53.9,
@@ -10920,7 +10920,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 65.0299326787936
       }
     },
@@ -10940,7 +10940,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 54.6,
@@ -10960,31 +10960,62 @@
         "Datum": "16.02.2021",
         "Fallzahl": 21427,
         "ObjectId": 347,
-        "Sterbefall": 820,
-        "Genesungsfall": 19751,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1886,
-        "Zuwachs_Fallzahl": 80,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 78,
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613433600000,
-        "F\u00e4lle_Meldedatum": 31,
-        "Zeitraum": "09.02.2021 - 15.02.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 73,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 47.1,
-        "Fallzahl_aktiv": 856,
-        "Krh_I_belegt": 223,
-        "Krh_I_frei": 56,
-        "Fallzahl_aktiv_Zuwachs": -1,
-        "Krh_I": 279,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 36,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 68.4435129817968
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.02.2021",
+        "Fallzahl": 21504,
+        "ObjectId": 348,
+        "Sterbefall": 834,
+        "Genesungsfall": 19733,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1893,
+        "Zuwachs_Fallzahl": 77,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 74,
+        "BelegteBetten": null,
+        "Inzidenz": 54.8,
+        "Datum_neu": 1613520000000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "10.02.2021 - 16.02.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 45.6,
+        "Fallzahl_aktiv": 937,
+        "Krh_I_belegt": 218,
+        "Krh_I_frei": 63,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 37,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 62.6477939061943
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
