### PR TITLE
New data set: 2021-02-18T112203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-17T110103Z.json
+pjson/2021-02-18T112203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-17T110103Z.json pjson/2021-02-18T112203Z.json```:
```
--- pjson/2021-02-17T110103Z.json	2021-02-17 11:01:03.759757500 +0000
+++ pjson/2021-02-18T112203Z.json	2021-02-18 11:22:03.972488719 +0000
@@ -8212,7 +8212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -8336,7 +8336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8553,7 +8553,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 212,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -8677,7 +8677,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 221,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8708,7 +8708,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8832,7 +8832,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 394,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -8865,7 +8865,7 @@
         "Datum_neu": 1607558400000,
         "F\u00e4lle_Meldedatum": 466,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8967,7 +8967,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 12,
         "Inzi_SN_RKI": 348.65179540817
       }
     },
@@ -8987,7 +8987,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -8998,7 +8998,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": 379.103878686759
       }
     },
@@ -9080,7 +9080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 518,
+        "F\u00e4lle_Meldedatum": 519,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9266,9 +9266,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 442,
+        "F\u00e4lle_Meldedatum": 443,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9494,7 +9494,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 19,
+        "SterbeF_Sterbedatum": 20,
         "Inzi_SN_RKI": 329.963057202519
       }
     },
@@ -9618,7 +9618,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": 329.69291775408
       }
     },
@@ -9669,7 +9669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 388,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -10072,7 +10072,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -10134,7 +10134,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -10165,7 +10165,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -10289,7 +10289,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -10300,7 +10300,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": 171.391200968769
       }
     },
@@ -10320,7 +10320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -10331,7 +10331,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": 160.929436874673
       }
     },
@@ -10351,7 +10351,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10382,7 +10382,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -10444,7 +10444,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611964800000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10475,7 +10475,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612051200000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -10486,7 +10486,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": 120.064705765341
       }
     },
@@ -10506,7 +10506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10537,7 +10537,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -10632,7 +10632,7 @@
         "Datum_neu": 1612483200000,
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10663,7 +10663,7 @@
         "Datum_neu": 1612569600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10785,7 +10785,7 @@
         "BelegteBetten": null,
         "Inzidenz": 66.8,
         "Datum_neu": 1612915200000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 56.4,
@@ -10796,7 +10796,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 75.7618362213287
       }
     },
@@ -10816,7 +10816,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.5,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 57.5,
@@ -10827,7 +10827,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 74.5093715058383
       }
     },
@@ -10847,9 +10847,9 @@
         "BelegteBetten": null,
         "Inzidenz": 59.8,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 53.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10858,7 +10858,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 71.0221168078063
       }
     },
@@ -10878,7 +10878,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.7,
         "Datum_neu": 1613174400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 50.5,
@@ -10940,9 +10940,9 @@
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 54.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10951,7 +10951,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 68.1488154016814
       }
     },
@@ -10971,9 +10971,9 @@
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613433600000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 47.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10992,29 +10992,60 @@
         "Fallzahl": 21504,
         "ObjectId": 348,
         "Sterbefall": 834,
-        "Genesungsfall": 19733,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 19825,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1893,
         "Zuwachs_Fallzahl": 77,
         "Zuwachs_Sterbefall": 14,
         "Zuwachs_Krankenhauseinweisung": 7,
         "Zuwachs_Genesung": 74,
         "BelegteBetten": null,
-        "Inzidenz": 54.8,
+        "Inzidenz": 54.7792664966414,
         "Datum_neu": 1613520000000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "10.02.2021 - 16.02.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 45.6,
-        "Fallzahl_aktiv": 937,
-        "Krh_I_belegt": 218,
-        "Krh_I_frei": 63,
+        "Fallzahl_aktiv": 845,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 62.6477939061943
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.02.2021",
+        "Fallzahl": 21554,
+        "ObjectId": 349,
+        "Sterbefall": 843,
+        "Genesungsfall": 19916,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1900,
+        "Zuwachs_Fallzahl": 50,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 91,
+        "BelegteBetten": null,
+        "Inzidenz": 57.2937246309135,
+        "Datum_neu": 1613606400000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "11.02.2021 - 17.02.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 52.3,
+        "Fallzahl_aktiv": 795,
+        "Krh_I_belegt": 224,
+        "Krh_I_frei": 57,
+        "Fallzahl_aktiv_Zuwachs": -50,
         "Krh_I": 281,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 37,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 62.6477939061943
+        "Inzi_SN_RKI": 66.1596067359026
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
