### PR TITLE
New data set: 2021-02-19T111403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-18T112203Z.json
+pjson/2021-02-19T111403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-18T112203Z.json pjson/2021-02-19T111403Z.json```:
```
--- pjson/2021-02-18T112203Z.json	2021-02-18 11:22:03.972488719 +0000
+++ pjson/2021-02-19T111403Z.json	2021-02-19 11:14:03.838305904 +0000
@@ -7716,7 +7716,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -8150,7 +8150,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8677,7 +8677,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8708,7 +8708,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8770,7 +8770,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 376,
+        "F\u00e4lle_Meldedatum": 377,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -8801,7 +8801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 330,
+        "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -8863,7 +8863,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 466,
+        "F\u00e4lle_Meldedatum": 467,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -9018,7 +9018,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 421,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -9111,7 +9111,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -9297,7 +9297,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608768000000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9618,7 +9618,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 14,
         "Inzi_SN_RKI": 329.69291775408
       }
     },
@@ -9638,7 +9638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 245,
+        "F\u00e4lle_Meldedatum": 246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9680,7 +9680,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 14,
+        "SterbeF_Sterbedatum": 15,
         "Inzi_SN_RKI": 298.749671841965
       }
     },
@@ -9773,7 +9773,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": 297.59543965318
       }
     },
@@ -9793,7 +9793,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -9826,7 +9826,7 @@
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9835,7 +9835,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 14,
+        "SterbeF_Sterbedatum": 15,
         "Inzi_SN_RKI": 357.640071601689
       }
     },
@@ -9855,7 +9855,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 178,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -10196,7 +10196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -10320,7 +10320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -10351,9 +10351,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10362,7 +10362,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": 141.012792085209
       }
     },
@@ -10382,7 +10382,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -10506,7 +10506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10630,9 +10630,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612483200000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10692,7 +10692,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612656000000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -10723,7 +10723,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612742400000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10754,7 +10754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612828800000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -10785,10 +10785,10 @@
         "BelegteBetten": null,
         "Inzidenz": 66.8,
         "Datum_neu": 1612915200000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 56.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10816,10 +10816,10 @@
         "BelegteBetten": null,
         "Inzidenz": 64.5,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 57.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10847,7 +10847,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.8,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 53.9,
@@ -10940,7 +10940,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 54.6,
@@ -10951,7 +10951,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 68.1488154016814
       }
     },
@@ -10973,7 +10973,7 @@
         "Datum_neu": 1613433600000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 47.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11002,7 +11002,7 @@
         "BelegteBetten": null,
         "Inzidenz": 54.7792664966414,
         "Datum_neu": 1613520000000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 45.6,
@@ -11013,7 +11013,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 62.6477939061943
       }
     },
@@ -11024,7 +11024,7 @@
         "ObjectId": 349,
         "Sterbefall": 843,
         "Genesungsfall": 19916,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1900,
         "Zuwachs_Fallzahl": 50,
         "Zuwachs_Sterbefall": 9,
@@ -11033,19 +11033,50 @@
         "BelegteBetten": null,
         "Inzidenz": 57.2937246309135,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "11.02.2021 - 17.02.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 52.3,
         "Fallzahl_aktiv": 795,
-        "Krh_I_belegt": 224,
-        "Krh_I_frei": 57,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -50,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": 66.1596067359026
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.02.2021",
+        "Fallzahl": 21628,
+        "ObjectId": 350,
+        "Sterbefall": 853,
+        "Genesungsfall": 19981,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1907,
+        "Zuwachs_Fallzahl": 74,
+        "Zuwachs_Sterbefall": 10,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 65,
+        "BelegteBetten": null,
+        "Inzidenz": 58.3713495456015,
+        "Datum_neu": 1613692800000,
+        "F\u00e4lle_Meldedatum": 30,
+        "Zeitraum": "12.02.2021 - 18.02.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 50.3,
+        "Fallzahl_aktiv": 794,
+        "Krh_I_belegt": 219,
+        "Krh_I_frei": 62,
+        "Fallzahl_aktiv_Zuwachs": -1,
         "Krh_I": 281,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 37,
+        "Krh_I_covid": 38,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 66.1596067359026
+        "Inzi_SN_RKI": 65.9631416824923
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
