### PR TITLE
New data set: 2021-02-20T112403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-19T111403Z.json
+pjson/2021-02-20T112403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-20T111304Z.json pjson/2021-02-20T112403Z.json```:
```
--- pjson/2021-02-20T111304Z.json	2021-02-20 11:13:04.401062957 +0000
+++ pjson/2021-02-20T112403Z.json	2021-02-20 11:24:03.601875488 +0000
@@ -11078,6 +11078,37 @@
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 65.9631416824923
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.02.2021",
+        "Fallzahl": 21681,
+        "ObjectId": 351,
+        "Sterbefall": 856,
+        "Genesungsfall": 19999,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1914,
+        "Zuwachs_Fallzahl": 53,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 18,
+        "BelegteBetten": null,
+        "Inzidenz": 57.4733287833615,
+        "Datum_neu": 1613779200000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "13.02.2021 - 19.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 49.4,
+        "Fallzahl_aktiv": 826,
+        "Krh_I_belegt": 218,
+        "Krh_I_frei": 62,
+        "Fallzahl_aktiv_Zuwachs": 32,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 36,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
