### PR TITLE
New data set: 2021-02-20T113004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-19T111403Z.json
+pjson/2021-02-20T113004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-20T112403Z.json pjson/2021-02-20T113004Z.json```:
```
--- pjson/2021-02-20T112403Z.json	2021-02-20 11:24:03.601875488 +0000
+++ pjson/2021-02-20T113004Z.json	2021-02-20 11:30:04.848495501 +0000
@@ -11107,7 +11107,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 36,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null
+        "Inzi_SN_RKI": 64.8
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
