### PR TITLE
New data set: 2021-02-21T105603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-20T113004Z.json
+pjson/2021-02-21T105603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-20T113004Z.json pjson/2021-02-21T105603Z.json```:
```
--- pjson/2021-02-20T113004Z.json	2021-02-20 11:30:04.848495501 +0000
+++ pjson/2021-02-21T105603Z.json	2021-02-21 10:56:03.501358591 +0000
@@ -9049,7 +9049,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9235,7 +9235,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -10845,7 +10845,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
-        "Inzidenz": 59.8,
+        "Inzidenz": null,
         "Datum_neu": 1613088000000,
         "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
@@ -10881,7 +10881,7 @@
         "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 50.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10971,7 +10971,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613433600000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 47.1,
@@ -11053,25 +11053,25 @@
         "Datum": "19.02.2021",
         "Fallzahl": 21628,
         "ObjectId": 350,
-        "Sterbefall": 853,
-        "Genesungsfall": 19981,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1907,
-        "Zuwachs_Fallzahl": 74,
-        "Zuwachs_Sterbefall": 10,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 65,
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 50.3,
-        "Fallzahl_aktiv": 794,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -11086,7 +11086,7 @@
         "ObjectId": 351,
         "Sterbefall": 856,
         "Genesungsfall": 19999,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1914,
         "Zuwachs_Fallzahl": 53,
         "Zuwachs_Sterbefall": 3,
@@ -11095,19 +11095,50 @@
         "BelegteBetten": null,
         "Inzidenz": 57.4733287833615,
         "Datum_neu": 1613779200000,
-        "F\u00e4lle_Meldedatum": 14,
-        "Zeitraum": "13.02.2021 - 19.02.2021",
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 49.4,
         "Fallzahl_aktiv": 826,
-        "Krh_I_belegt": 218,
-        "Krh_I_frei": 62,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 32,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.02.2021",
+        "Fallzahl": 21710,
+        "ObjectId": 352,
+        "Sterbefall": 856,
+        "Genesungsfall": 20013,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1914,
+        "Zuwachs_Fallzahl": 29,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 14,
+        "BelegteBetten": null,
+        "Inzidenz": 58.0121412407055,
+        "Datum_neu": 1613865600000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "14.02.2021 - 20.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 55.9,
+        "Fallzahl_aktiv": 841,
+        "Krh_I_belegt": 227,
+        "Krh_I_frei": 53,
+        "Fallzahl_aktiv_Zuwachs": 15,
         "Krh_I": 280,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 36,
+        "Krh_I_covid": 37,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 64.8
+        "Inzi_SN_RKI": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
