### PR TITLE
New data set: 2021-02-21T142104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-21T105603Z.json
+pjson/2021-02-21T142104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-21T142004Z.json pjson/2021-02-21T142104Z.json```:
```
--- pjson/2021-02-21T142004Z.json	2021-02-21 14:20:04.293085822 +0000
+++ pjson/2021-02-21T142104Z.json	2021-02-21 14:21:04.225517480 +0000
@@ -11138,7 +11138,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 37,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null
+        "Inzi_SN_RKI": 69.9
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
