### PR TITLE
New data set: 2021-02-22T111707Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-21T142104Z.json
+pjson/2021-02-22T111707Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-21T142104Z.json pjson/2021-02-22T111707Z.json```:
```
--- pjson/2021-02-21T142104Z.json	2021-02-21 14:21:04.225517480 +0000
+++ pjson/2021-02-22T111707Z.json	2021-02-22 11:17:07.208058570 +0000
@@ -7997,7 +7997,7 @@
         "Datum_neu": 1605139200000,
         "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10610,7 +10610,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": 100.1235028442
       }
     },
@@ -10734,7 +10734,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 100.197177239229
       }
     },
@@ -10796,7 +10796,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 75.7618362213287
       }
     },
@@ -10827,7 +10827,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": 74.5093715058383
       }
     },
@@ -10858,7 +10858,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": 71.0221168078063
       }
     },
@@ -10889,7 +10889,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 68.3698385867679
       }
     },
@@ -10912,7 +10912,7 @@
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 51.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10920,7 +10920,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": 65.0299326787936
       }
     },
@@ -10982,7 +10982,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 68.4435129817968
       }
     },
@@ -11064,9 +11064,9 @@
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 50.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11084,30 +11084,30 @@
         "Datum": "20.02.2021",
         "Fallzahl": 21681,
         "ObjectId": 351,
-        "Sterbefall": 856,
-        "Genesungsfall": 19999,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1914,
-        "Zuwachs_Fallzahl": 53,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 18,
         "BelegteBetten": null,
         "Inzidenz": 57.4733287833615,
         "Datum_neu": 1613779200000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 49.4,
-        "Fallzahl_aktiv": 826,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 32,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 64.8
+        "Inzi_SN_RKI": 64.7597932303546
       }
     },
     {
@@ -11117,28 +11117,59 @@
         "ObjectId": 352,
         "Sterbefall": 856,
         "Genesungsfall": 20013,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1914,
         "Zuwachs_Fallzahl": 29,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 14,
         "BelegteBetten": null,
-        "Inzidenz": 58.0121412407055,
+        "Inzidenz": 58,
         "Datum_neu": 1613865600000,
         "F\u00e4lle_Meldedatum": 18,
-        "Zeitraum": "14.02.2021 - 20.02.2021",
-        "Hosp_Meldedatum": 0,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 55.9,
         "Fallzahl_aktiv": 841,
-        "Krh_I_belegt": 227,
-        "Krh_I_frei": 53,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 15,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": 69.8678846190211
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.02.2021",
+        "Fallzahl": 21725,
+        "ObjectId": 353,
+        "Sterbefall": 873,
+        "Genesungsfall": 20048,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1927,
+        "Zuwachs_Fallzahl": 15,
+        "Zuwachs_Sterbefall": 17,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 35,
+        "BelegteBetten": null,
+        "Inzidenz": 61.9634325945616,
+        "Datum_neu": 1613952000000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "15.02.2021 - 21.02.2021",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 59.8,
+        "Fallzahl_aktiv": 804,
+        "Krh_I_belegt": 220,
+        "Krh_I_frei": 60,
+        "Fallzahl_aktiv_Zuwachs": -37,
         "Krh_I": 280,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 37,
+        "Krh_I_covid": 39,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 69.9
+        "Inzi_SN_RKI": 74.7795109542774
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
