### PR TITLE
New data set: 2021-02-23T112603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-22T111707Z.json
+pjson/2021-02-23T112603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-23T062704Z.json pjson/2021-02-23T112603Z.json```:
```
--- pjson/2021-02-23T062704Z.json	2021-02-23 06:27:04.376326358 +0000
+++ pjson/2021-02-23T112603Z.json	2021-02-23 11:26:04.051929872 +0000
@@ -6972,7 +6972,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -8026,7 +8026,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -8150,7 +8150,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8367,7 +8367,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8553,7 +8553,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -8677,7 +8677,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 223,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8956,7 +8956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -9235,7 +9235,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 484,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9299,7 +9299,7 @@
         "Datum_neu": 1608768000000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9359,7 +9359,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -9640,7 +9640,7 @@
         "Datum_neu": 1609718400000,
         "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9669,7 +9669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9762,7 +9762,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -9897,7 +9897,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9,
+        "SterbeF_Sterbedatum": 10,
         "Inzi_SN_RKI": null
       }
     },
@@ -10103,7 +10103,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10167,7 +10167,7 @@
         "Datum_neu": 1611187200000,
         "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10413,7 +10413,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -10455,7 +10455,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12,
+        "SterbeF_Sterbedatum": 13,
         "Inzi_SN_RKI": null
       }
     },
@@ -10537,7 +10537,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -10548,7 +10548,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null
       }
     },
@@ -10641,7 +10641,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null
       }
     },
@@ -10816,7 +10816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -10876,7 +10876,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 55.7,
+        "Inzidenz": null,
         "Datum_neu": 1613174400000,
         "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
@@ -10907,7 +10907,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 53.7,
+        "Inzidenz": null,
         "Datum_neu": 1613260800000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
@@ -10942,8 +10942,8 @@
         "Datum_neu": 1613347200000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 54.6,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10973,7 +10973,7 @@
         "Datum_neu": 1613433600000,
         "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 47.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10982,7 +10982,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 68.4
       }
     },
@@ -11033,7 +11033,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.2937246309135,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 52.3,
@@ -11066,7 +11066,7 @@
         "Datum_neu": 1613692800000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 50.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11115,25 +11115,25 @@
         "Datum": "21.02.2021",
         "Fallzahl": 21710,
         "ObjectId": 352,
-        "Sterbefall": 856,
-        "Genesungsfall": 20013,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1914,
-        "Zuwachs_Fallzahl": 29,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 14,
         "BelegteBetten": null,
         "Inzidenz": 58,
         "Datum_neu": 1613865600000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 55.9,
-        "Fallzahl_aktiv": 841,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 15,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -11148,7 +11148,7 @@
         "ObjectId": 353,
         "Sterbefall": 873,
         "Genesungsfall": 20048,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1927,
         "Zuwachs_Fallzahl": 15,
         "Zuwachs_Sterbefall": 17,
@@ -11157,19 +11157,50 @@
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "15.02.2021 - 21.02.2021",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 59.8,
         "Fallzahl_aktiv": 804,
-        "Krh_I_belegt": 220,
-        "Krh_I_frei": 60,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -37,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": 74.8
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.02.2021",
+        "Fallzahl": 21782,
+        "ObjectId": 354,
+        "Sterbefall": 879,
+        "Genesungsfall": 20127,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1935,
+        "Zuwachs_Fallzahl": 57,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 79,
+        "BelegteBetten": null,
+        "Inzidenz": 59.4489744602895,
+        "Datum_neu": 1614038400000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "16.02.2021 - 22.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 48.7,
+        "Fallzahl_aktiv": 776,
+        "Krh_I_belegt": 223,
+        "Krh_I_frei": 57,
+        "Fallzahl_aktiv_Zuwachs": -28,
         "Krh_I": 280,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 39,
+        "Krh_I_covid": 42,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 74.8
+        "Inzi_SN_RKI": 70.7
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
