### PR TITLE
New data set: 2021-02-24T111703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-23T112603Z.json
+pjson/2021-02-24T111703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-23T112603Z.json pjson/2021-02-24T111703Z.json```:
```
--- pjson/2021-02-23T112603Z.json	2021-02-23 11:26:04.051929872 +0000
+++ pjson/2021-02-24T111703Z.json	2021-02-24 11:17:03.694700278 +0000
@@ -1558,7 +1558,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null
       }
     },
@@ -1837,7 +1837,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null
       }
     },
@@ -1930,7 +1930,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null
       }
     },
@@ -7377,7 +7377,7 @@
         "Datum_neu": 1603411200000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -7386,7 +7386,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null
       }
     },
@@ -8212,7 +8212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -8336,7 +8336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8367,7 +8367,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8657,7 +8657,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null
       }
     },
@@ -8741,7 +8741,7 @@
         "Datum_neu": 1607212800000,
         "F\u00e4lle_Meldedatum": 161,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8801,9 +8801,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 331,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8863,7 +8863,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 467,
+        "F\u00e4lle_Meldedatum": 468,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8894,7 +8894,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -9029,7 +9029,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 17,
+        "SterbeF_Sterbedatum": 16,
         "Inzi_SN_RKI": null
       }
     },
@@ -9339,7 +9339,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": null
       }
     },
@@ -9401,7 +9401,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 22,
+        "SterbeF_Sterbedatum": 23,
         "Inzi_SN_RKI": null
       }
     },
@@ -9421,9 +9421,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 364,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9452,7 +9452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9618,7 +9618,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 14,
+        "SterbeF_Sterbedatum": 15,
         "Inzi_SN_RKI": null
       }
     },
@@ -9638,9 +9638,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10238,7 +10238,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 12,
         "Inzi_SN_RKI": null
       }
     },
@@ -10320,7 +10320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -10382,7 +10382,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -10599,7 +10599,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -10734,7 +10734,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null
       }
     },
@@ -10754,7 +10754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612828800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -10847,7 +10847,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -10940,7 +10940,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -10951,7 +10951,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null
       }
     },
@@ -10971,10 +10971,10 @@
         "BelegteBetten": null,
         "Inzidenz": 56,
         "Datum_neu": 1613433600000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 47.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -10982,8 +10982,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 68.4
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null
       }
     },
     {
@@ -11002,7 +11002,7 @@
         "BelegteBetten": null,
         "Inzidenz": 54.7792664966414,
         "Datum_neu": 1613520000000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 45.6,
@@ -11033,9 +11033,9 @@
         "BelegteBetten": null,
         "Inzidenz": 57.2937246309135,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 52.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11064,9 +11064,9 @@
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 50.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11095,7 +11095,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.4733287833615,
         "Datum_neu": 1613779200000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 49.4,
@@ -11146,29 +11146,29 @@
         "Datum": "22.02.2021",
         "Fallzahl": 21725,
         "ObjectId": 353,
-        "Sterbefall": 873,
-        "Genesungsfall": 20048,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1927,
-        "Zuwachs_Fallzahl": 15,
-        "Zuwachs_Sterbefall": 17,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 35,
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1613952000000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 59.8,
-        "Fallzahl_aktiv": 804,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -37,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 74.8
       }
     },
@@ -11179,7 +11179,7 @@
         "ObjectId": 354,
         "Sterbefall": 879,
         "Genesungsfall": 20127,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1935,
         "Zuwachs_Fallzahl": 57,
         "Zuwachs_Sterbefall": 6,
@@ -11188,19 +11188,50 @@
         "BelegteBetten": null,
         "Inzidenz": 59.4489744602895,
         "Datum_neu": 1614038400000,
-        "F\u00e4lle_Meldedatum": 11,
-        "Zeitraum": "16.02.2021 - 22.02.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 69,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 48.7,
         "Fallzahl_aktiv": 776,
-        "Krh_I_belegt": 223,
-        "Krh_I_frei": 57,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -28,
-        "Krh_I": 280,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": 70.7
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.02.2021",
+        "Fallzahl": 21861,
+        "ObjectId": 355,
+        "Sterbefall": 891,
+        "Genesungsfall": 20199,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1943,
+        "Zuwachs_Fallzahl": 79,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 72,
+        "BelegteBetten": null,
+        "Inzidenz": 60.5265993749776,
+        "Datum_neu": 1614124800000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "17.02.2021 - 23.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 46.3,
+        "Fallzahl_aktiv": 771,
+        "Krh_I_belegt": 229,
+        "Krh_I_frei": 52,
+        "Fallzahl_aktiv_Zuwachs": -5,
+        "Krh_I": 281,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 42,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 70.7
+        "Inzi_SN_RKI": 66.2
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
