### PR TITLE
New data set: 2021-02-25T111403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-24T111703Z.json
+pjson/2021-02-25T111403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-24T111703Z.json pjson/2021-02-25T111403Z.json```:
```
--- pjson/2021-02-24T111703Z.json	2021-02-24 11:17:03.694700278 +0000
+++ pjson/2021-02-25T111403Z.json	2021-02-25 11:14:04.147504816 +0000
@@ -8615,7 +8615,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -9215,7 +9215,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 14,
+        "SterbeF_Sterbedatum": 15,
         "Inzi_SN_RKI": null
       }
     },
@@ -9246,7 +9246,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12,
+        "SterbeF_Sterbedatum": 13,
         "Inzi_SN_RKI": null
       }
     },
@@ -9266,9 +9266,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 443,
+        "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9328,7 +9328,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9483,7 +9483,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -9494,7 +9494,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 20,
+        "SterbeF_Sterbedatum": 21,
         "Inzi_SN_RKI": null
       }
     },
@@ -9669,7 +9669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 388,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9680,7 +9680,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15,
+        "SterbeF_Sterbedatum": 16,
         "Inzi_SN_RKI": null
       }
     },
@@ -9700,7 +9700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 346,
+        "F\u00e4lle_Meldedatum": 347,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -9764,7 +9764,7 @@
         "Datum_neu": 1610064000000,
         "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10506,7 +10506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10548,7 +10548,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null
       }
     },
@@ -10601,7 +10601,7 @@
         "Datum_neu": 1612396800000,
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10632,7 +10632,7 @@
         "Datum_neu": 1612483200000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10703,7 +10703,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null
       }
     },
@@ -10725,7 +10725,7 @@
         "Datum_neu": 1612742400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10938,7 +10938,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 41,
         "BelegteBetten": null,
-        "Inzidenz": 56,
+        "Inzidenz": null,
         "Datum_neu": 1613347200000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
@@ -10969,9 +10969,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 78,
         "BelegteBetten": null,
-        "Inzidenz": 56,
+        "Inzidenz": null,
         "Datum_neu": 1613433600000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -10982,7 +10982,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null
       }
     },
@@ -11000,12 +11000,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 74,
         "BelegteBetten": null,
-        "Inzidenz": 54.7792664966414,
+        "Inzidenz": null,
         "Datum_neu": 1613520000000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 45.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -11014,7 +11014,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 62.6
+        "Inzi_SN_RKI": null
       }
     },
     {
@@ -11033,7 +11033,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.2937246309135,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 52.3,
@@ -11044,7 +11044,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": 66.2
       }
     },
@@ -11064,7 +11064,7 @@
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 50.3,
@@ -11075,7 +11075,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 66
       }
     },
@@ -11106,7 +11106,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 64.8
       }
     },
@@ -11157,7 +11157,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 59.8,
@@ -11168,7 +11168,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": 74.8
       }
     },
@@ -11177,29 +11177,29 @@
         "Datum": "23.02.2021",
         "Fallzahl": 21782,
         "ObjectId": 354,
-        "Sterbefall": 879,
-        "Genesungsfall": 20127,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1935,
-        "Zuwachs_Fallzahl": 57,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 79,
         "BelegteBetten": null,
         "Inzidenz": 59.4489744602895,
         "Datum_neu": 1614038400000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 48.7,
-        "Fallzahl_aktiv": 776,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -28,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 70.7
       }
     },
@@ -11210,7 +11210,7 @@
         "ObjectId": 355,
         "Sterbefall": 891,
         "Genesungsfall": 20199,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1943,
         "Zuwachs_Fallzahl": 79,
         "Zuwachs_Sterbefall": 12,
@@ -11219,20 +11219,51 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "17.02.2021 - 23.02.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 62,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 46.3,
         "Fallzahl_aktiv": 771,
-        "Krh_I_belegt": 229,
-        "Krh_I_frei": 52,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -5,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 42,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 66.2
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.02.2021",
+        "Fallzahl": 21941,
+        "ObjectId": 356,
+        "Sterbefall": 905,
+        "Genesungsfall": 20252,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1951,
+        "Zuwachs_Fallzahl": 80,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 53,
+        "BelegteBetten": null,
+        "Inzidenz": 64.1186824239376,
+        "Datum_neu": 1614211200000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "18.02.2021 - 24.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 51.4,
+        "Fallzahl_aktiv": 784,
+        "Krh_I_belegt": 225,
+        "Krh_I_frei": 56,
+        "Fallzahl_aktiv_Zuwachs": 13,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 43,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 71.3
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
