### PR TITLE
New data set: 2021-02-26T110303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-25T111403Z.json
+pjson/2021-02-26T110303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-25T111403Z.json pjson/2021-02-26T110303Z.json```:
```
--- pjson/2021-02-25T111403Z.json	2021-02-25 11:14:04.147504816 +0000
+++ pjson/2021-02-26T110303Z.json	2021-02-26 11:03:03.628622781 +0000
@@ -7747,7 +7747,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -8863,7 +8863,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 468,
+        "F\u00e4lle_Meldedatum": 467,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8998,7 +8998,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9,
+        "SterbeF_Sterbedatum": 10,
         "Inzi_SN_RKI": null
       }
     },
@@ -9113,7 +9113,7 @@
         "Datum_neu": 1608249600000,
         "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9142,7 +9142,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 164,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -9184,7 +9184,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 12,
         "Inzi_SN_RKI": null
       }
     },
@@ -9206,7 +9206,7 @@
         "Datum_neu": 1608508800000,
         "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 46,
+        "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9235,7 +9235,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9390,9 +9390,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9618,7 +9618,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15,
+        "SterbeF_Sterbedatum": 16,
         "Inzi_SN_RKI": null
       }
     },
@@ -9669,7 +9669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 388,
+        "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -9700,7 +9700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 347,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -9742,7 +9742,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12,
+        "SterbeF_Sterbedatum": 13,
         "Inzi_SN_RKI": null
       }
     },
@@ -9762,7 +9762,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -10072,7 +10072,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -10506,7 +10506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612137600000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10599,7 +10599,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -10632,7 +10632,7 @@
         "Datum_neu": 1612483200000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10641,7 +10641,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null
       }
     },
@@ -10816,7 +10816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -10827,7 +10827,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null
       }
     },
@@ -10971,7 +10971,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613433600000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -11031,12 +11031,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 91,
         "BelegteBetten": null,
-        "Inzidenz": 57.2937246309135,
+        "Inzidenz": null,
         "Datum_neu": 1613606400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 52.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -11045,7 +11045,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
-        "Inzi_SN_RKI": 66.2
+        "Inzi_SN_RKI": null
       }
     },
     {
@@ -11157,9 +11157,9 @@
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 59.8,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11188,7 +11188,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.4489744602895,
         "Datum_neu": 1614038400000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 48.7,
@@ -11208,25 +11208,25 @@
         "Datum": "24.02.2021",
         "Fallzahl": 21861,
         "ObjectId": 355,
-        "Sterbefall": 891,
-        "Genesungsfall": 20199,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1943,
-        "Zuwachs_Fallzahl": 79,
-        "Zuwachs_Sterbefall": 12,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 46.3,
-        "Fallzahl_aktiv": 771,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -5,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -11241,7 +11241,7 @@
         "ObjectId": 356,
         "Sterbefall": 905,
         "Genesungsfall": 20252,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1951,
         "Zuwachs_Fallzahl": 80,
         "Zuwachs_Sterbefall": 14,
@@ -11250,9 +11250,9 @@
         "BelegteBetten": null,
         "Inzidenz": 64.1186824239376,
         "Datum_neu": 1614211200000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "18.02.2021 - 24.02.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 57,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 51.4,
         "Fallzahl_aktiv": 784,
         "Krh_I_belegt": 225,
@@ -11264,6 +11264,37 @@
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 71.3
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.02.2021",
+        "Fallzahl": 22007,
+        "ObjectId": 357,
+        "Sterbefall": 911,
+        "Genesungsfall": 20338,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1955,
+        "Zuwachs_Fallzahl": 66,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 86,
+        "BelegteBetten": null,
+        "Inzidenz": 66.6331405582097,
+        "Datum_neu": 1614297600000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "19.02.2021 - 25.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 55.7,
+        "Fallzahl_aktiv": 758,
+        "Krh_I_belegt": 222,
+        "Krh_I_frei": 59,
+        "Fallzahl_aktiv_Zuwachs": -26,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 37,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 75.3
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
