### PR TITLE
New data set: 2021-02-27T110204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-26T110303Z.json
+pjson/2021-02-27T110204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-26T110303Z.json pjson/2021-02-27T110204Z.json```:
```
--- pjson/2021-02-26T110303Z.json	2021-02-26 11:03:03.628622781 +0000
+++ pjson/2021-02-27T110204Z.json	2021-02-27 11:02:04.730230102 +0000
@@ -8708,7 +8708,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8770,7 +8770,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 377,
+        "F\u00e4lle_Meldedatum": 378,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -11033,7 +11033,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -11062,12 +11062,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 65,
         "BelegteBetten": null,
-        "Inzidenz": 58.3713495456015,
+        "Inzidenz": null,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 50.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -11076,7 +11076,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 66
+        "Inzi_SN_RKI": null
       }
     },
     {
@@ -11157,7 +11157,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 59.8,
@@ -11168,7 +11168,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": 74.8
       }
     },
@@ -11188,7 +11188,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.4489744602895,
         "Datum_neu": 1614038400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 48.7,
@@ -11219,7 +11219,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 46.3,
@@ -11239,28 +11239,28 @@
         "Datum": "25.02.2021",
         "Fallzahl": 21941,
         "ObjectId": 356,
-        "Sterbefall": 905,
-        "Genesungsfall": 20252,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1951,
-        "Zuwachs_Fallzahl": 80,
-        "Zuwachs_Sterbefall": 14,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
         "Inzidenz": 64.1186824239376,
         "Datum_neu": 1614211200000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.4,
-        "Fallzahl_aktiv": 784,
-        "Krh_I_belegt": 225,
-        "Krh_I_frei": 56,
-        "Fallzahl_aktiv_Zuwachs": 13,
-        "Krh_I": 281,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 43,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 71.3
       }
@@ -11272,7 +11272,7 @@
         "ObjectId": 357,
         "Sterbefall": 911,
         "Genesungsfall": 20338,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1955,
         "Zuwachs_Fallzahl": 66,
         "Zuwachs_Sterbefall": 6,
@@ -11281,20 +11281,51 @@
         "BelegteBetten": null,
         "Inzidenz": 66.6331405582097,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "19.02.2021 - 25.02.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 48,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 55.7,
         "Fallzahl_aktiv": 758,
-        "Krh_I_belegt": 222,
-        "Krh_I_frei": 59,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -26,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 37,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 75.3
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.02.2021",
+        "Fallzahl": 22060,
+        "ObjectId": 358,
+        "Sterbefall": 912,
+        "Genesungsfall": 20340,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1960,
+        "Zuwachs_Fallzahl": 53,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 2,
+        "BelegteBetten": null,
+        "Inzidenz": 62.3226408994576,
+        "Datum_neu": 1614384000000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "20.02.2021 - 26.02.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 53.3,
+        "Fallzahl_aktiv": 808,
+        "Krh_I_belegt": 221,
+        "Krh_I_frei": 59,
+        "Fallzahl_aktiv_Zuwachs": 50,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 32,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 78
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
