### PR TITLE
New data set: 2021-02-28T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-27T110204Z.json
+pjson/2021-02-28T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-02-27T110204Z.json pjson/2021-02-28T110203Z.json```:
```
--- pjson/2021-02-27T110204Z.json	2021-02-27 11:02:04.730230102 +0000
+++ pjson/2021-02-28T110203Z.json	2021-02-28 11:02:03.626767682 +0000
@@ -8832,7 +8832,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 394,
+        "F\u00e4lle_Meldedatum": 395,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -10940,7 +10940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -11093,12 +11093,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 18,
         "BelegteBetten": null,
-        "Inzidenz": 57.4733287833615,
+        "Inzidenz": null,
         "Datum_neu": 1613779200000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 49.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -11107,7 +11107,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 64.8
+        "Inzi_SN_RKI": null
       }
     },
     {
@@ -11157,7 +11157,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 59.8,
@@ -11188,7 +11188,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.4489744602895,
         "Datum_neu": 1614038400000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 48.7,
@@ -11219,7 +11219,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 46.3,
@@ -11250,7 +11250,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.1186824239376,
         "Datum_neu": 1614211200000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.4,
@@ -11270,25 +11270,25 @@
         "Datum": "26.02.2021",
         "Fallzahl": 22007,
         "ObjectId": 357,
-        "Sterbefall": 911,
-        "Genesungsfall": 20338,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1955,
-        "Zuwachs_Fallzahl": 66,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 86,
         "BelegteBetten": null,
         "Inzidenz": 66.6331405582097,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 55.7,
-        "Fallzahl_aktiv": 758,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -26,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -11303,7 +11303,7 @@
         "ObjectId": 358,
         "Sterbefall": 912,
         "Genesungsfall": 20340,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1960,
         "Zuwachs_Fallzahl": 53,
         "Zuwachs_Sterbefall": 1,
@@ -11312,19 +11312,50 @@
         "BelegteBetten": null,
         "Inzidenz": 62.3226408994576,
         "Datum_neu": 1614384000000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "20.02.2021 - 26.02.2021",
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 53.3,
         "Fallzahl_aktiv": 808,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 50,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 78
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.02.2021",
+        "Fallzahl": 22083,
+        "ObjectId": 359,
+        "Sterbefall": 912,
+        "Genesungsfall": 20345,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1962,
+        "Zuwachs_Fallzahl": 23,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 5,
+        "BelegteBetten": null,
+        "Inzidenz": 63.4002658141456,
+        "Datum_neu": 1614470400000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "21.02.2021 - 27.02.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 58.9,
+        "Fallzahl_aktiv": 826,
         "Krh_I_belegt": 221,
         "Krh_I_frei": 59,
-        "Fallzahl_aktiv_Zuwachs": 50,
+        "Fallzahl_aktiv_Zuwachs": 18,
         "Krh_I": 280,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 32,
+        "Krh_I_covid": 33,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 78
+        "Inzi_SN_RKI": 77.8
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
