### PR TITLE
New data set: 2021-03-01T110503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-02-28T110203Z.json
+pjson/2021-03-01T110503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-01T082704Z.json pjson/2021-03-01T110503Z.json```:
```
--- pjson/2021-03-01T082704Z.json	2021-03-01 08:27:04.373572520 +0000
+++ pjson/2021-03-01T110503Z.json	2021-03-01 11:05:03.751711029 +0000
@@ -11624,7 +11624,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11657,7 +11657,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11745,7 +11745,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -11778,7 +11778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -11842,12 +11842,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 14,
         "BelegteBetten": null,
-        "Inzidenz": 58,
+        "Inzidenz": null,
         "Datum_neu": 1613865600000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 55.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -11856,7 +11856,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 69.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -11877,7 +11877,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 59.8,
@@ -11943,7 +11943,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 46.3,
@@ -11954,7 +11954,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 66.2,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11987,7 +11987,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 71.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12009,9 +12009,9 @@
         "BelegteBetten": null,
         "Inzidenz": 66.6331405582097,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 55.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12020,7 +12020,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 75.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12031,25 +12031,25 @@
         "Datum": "27.02.2021",
         "Fallzahl": 22060,
         "ObjectId": 358,
-        "Sterbefall": 912,
-        "Genesungsfall": 20340,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1960,
-        "Zuwachs_Fallzahl": 53,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
         "Inzidenz": 62.3226408994576,
         "Datum_neu": 1614384000000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 53.3,
-        "Fallzahl_aktiv": 808,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 50,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -12066,7 +12066,7 @@
         "ObjectId": 359,
         "Sterbefall": 912,
         "Genesungsfall": 20345,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1962,
         "Zuwachs_Fallzahl": 23,
         "Zuwachs_Sterbefall": 0,
@@ -12075,22 +12075,55 @@
         "BelegteBetten": null,
         "Inzidenz": 63.4002658141456,
         "Datum_neu": 1614470400000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "21.02.2021 - 27.02.2021",
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 58.9,
         "Fallzahl_aktiv": 826,
-        "Krh_I_belegt": 221,
-        "Krh_I_frei": 59,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 18,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 33,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 77.8,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.03.2021",
+        "Fallzahl": 22101,
+        "ObjectId": 360,
+        "Sterbefall": 919,
+        "Genesungsfall": 20416,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1965,
+        "Zuwachs_Fallzahl": 18,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 71,
+        "BelegteBetten": null,
+        "Inzidenz": 64.4778907288337,
+        "Datum_neu": 1614556800000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": "22.02.2021 - 28.02.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 59.4,
+        "Fallzahl_aktiv": 766,
+        "Krh_I_belegt": 215,
+        "Krh_I_frei": 65,
+        "Fallzahl_aktiv_Zuwachs": -60,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 26,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 84.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
