### PR TITLE
New data set: 2021-03-02T090404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-01T110503Z.json
+pjson/2021-03-02T090404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-02T090203Z.json pjson/2021-03-02T090404Z.json```:
```
--- pjson/2021-03-02T090203Z.json	2021-03-02 09:02:03.850736662 +0000
+++ pjson/2021-03-02T090404Z.json	2021-03-02 09:04:04.534814693 +0000
@@ -12122,7 +12122,7 @@
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 84.3,
         "Mutation": 63,
-        "Zuwachs_Mutation": null
+        "Zuwachs_Mutation": 0
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
