### PR TITLE
New data set: 2021-03-02T111304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-01T110503Z.json
+pjson/2021-03-02T111304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-02T090404Z.json pjson/2021-03-02T111304Z.json```:
```
--- pjson/2021-03-02T090404Z.json	2021-03-02 09:04:04.534814693 +0000
+++ pjson/2021-03-02T111304Z.json	2021-03-02 11:13:04.424460415 +0000
@@ -9809,7 +9809,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15,
+        "SterbeF_Sterbedatum": 16,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -9833,7 +9833,7 @@
         "Datum_neu": 1608595200000,
         "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10260,7 +10260,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -10469,7 +10469,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 15,
+        "SterbeF_Sterbedatum": 16,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -10526,7 +10526,7 @@
         "Datum_neu": 1610409600000,
         "F\u00e4lle_Meldedatum": 270,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10590,7 +10590,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -10986,7 +10986,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -11019,7 +11019,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -11261,7 +11261,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11679,7 +11679,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613433600000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -11875,12 +11875,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 35,
         "BelegteBetten": null,
-        "Inzidenz": 61.9634325945616,
+        "Inzidenz": null,
         "Datum_neu": 1613952000000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 59.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -11888,8 +11888,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
-        "Inzi_SN_RKI": 74.8,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -11945,7 +11945,7 @@
         "Datum_neu": 1614124800000,
         "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 46.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11976,9 +11976,9 @@
         "BelegteBetten": null,
         "Inzidenz": 64.1186824239376,
         "Datum_neu": 1614211200000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 51.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12009,7 +12009,7 @@
         "BelegteBetten": null,
         "Inzidenz": 66.6331405582097,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 55.7,
@@ -12042,7 +12042,7 @@
         "BelegteBetten": null,
         "Inzidenz": 62.3226408994576,
         "Datum_neu": 1614384000000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 53.3,
@@ -12064,29 +12064,29 @@
         "Datum": "28.02.2021",
         "Fallzahl": 22083,
         "ObjectId": 359,
-        "Sterbefall": 912,
-        "Genesungsfall": 20345,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1962,
-        "Zuwachs_Fallzahl": 23,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
         "Inzidenz": 63.4002658141456,
         "Datum_neu": 1614470400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 58.9,
-        "Fallzahl_aktiv": 826,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 18,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 77.8,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12099,7 +12099,7 @@
         "ObjectId": 360,
         "Sterbefall": 919,
         "Genesungsfall": 20416,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1965,
         "Zuwachs_Fallzahl": 18,
         "Zuwachs_Sterbefall": 7,
@@ -12108,21 +12108,54 @@
         "BelegteBetten": null,
         "Inzidenz": 64.4778907288337,
         "Datum_neu": 1614556800000,
-        "F\u00e4lle_Meldedatum": 5,
-        "Zeitraum": "22.02.2021 - 28.02.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 68,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 59.4,
         "Fallzahl_aktiv": 766,
-        "Krh_I_belegt": 215,
-        "Krh_I_frei": 65,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -60,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 26,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 84.3,
-        "Mutation": 63,
-        "Zuwachs_Mutation": 0
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.03.2021",
+        "Fallzahl": 22198,
+        "ObjectId": 361,
+        "Sterbefall": 924,
+        "Genesungsfall": 20477,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1973,
+        "Zuwachs_Fallzahl": 97,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 61,
+        "BelegteBetten": null,
+        "Inzidenz": 65.9147239484177,
+        "Datum_neu": 1614643200000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "23.02.2021 - 01.03.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 53,
+        "Fallzahl_aktiv": 797,
+        "Krh_I_belegt": 220,
+        "Krh_I_frei": 58,
+        "Fallzahl_aktiv_Zuwachs": 31,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 27,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 81.2,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
