### PR TITLE
New data set: 2021-03-02T111603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-01T110503Z.json
+pjson/2021-03-02T111603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-02T111304Z.json pjson/2021-03-02T111603Z.json```:
```
--- pjson/2021-03-02T111304Z.json	2021-03-02 11:13:04.424460415 +0000
+++ pjson/2021-03-02T111603Z.json	2021-03-02 11:16:03.985307353 +0000
@@ -12150,7 +12150,7 @@
         "Krh_I_frei": 58,
         "Fallzahl_aktiv_Zuwachs": 31,
         "Krh_I": 278,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": 27,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 81.2,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
