### PR TITLE
New data set: 2021-03-03T111404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-02T111304Z.json
+pjson/2021-03-03T111404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-02T111603Z.json pjson/2021-03-03T111404Z.json```:
```
--- pjson/2021-03-02T111603Z.json	2021-03-02 11:16:03.985307353 +0000
+++ pjson/2021-03-03T111404Z.json	2021-03-03 11:14:04.339092793 +0000
@@ -7719,7 +7719,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -7983,7 +7983,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603756800000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -8148,7 +8148,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604188800000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -8214,7 +8214,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -8247,7 +8247,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604448000000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -8480,7 +8480,7 @@
         "Datum_neu": 1605052800000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8973,7 +8973,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 277,
+        "F\u00e4lle_Meldedatum": 276,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -9369,7 +9369,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -9402,7 +9402,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 395,
+        "F\u00e4lle_Meldedatum": 396,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9435,7 +9435,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 467,
+        "F\u00e4lle_Meldedatum": 466,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -9633,7 +9633,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9798,7 +9798,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -9963,7 +9963,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -10095,7 +10095,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -10128,7 +10128,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -10986,7 +10986,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -11019,7 +11019,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -11393,7 +11393,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11888,7 +11888,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11908,12 +11908,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 79,
         "BelegteBetten": null,
-        "Inzidenz": 59.4489744602895,
+        "Inzidenz": null,
         "Datum_neu": 1614038400000,
         "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 48.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -11921,8 +11921,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
-        "Inzi_SN_RKI": 70.7,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -11943,9 +11943,9 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 46.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11976,7 +11976,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.1186824239376,
         "Datum_neu": 1614211200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 51.4,
@@ -12009,9 +12009,9 @@
         "BelegteBetten": null,
         "Inzidenz": 66.6331405582097,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 55.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12020,7 +12020,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": 75.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12042,9 +12042,9 @@
         "BelegteBetten": null,
         "Inzidenz": 62.3226408994576,
         "Datum_neu": 1614384000000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12075,9 +12075,9 @@
         "BelegteBetten": null,
         "Inzidenz": 63.4002658141456,
         "Datum_neu": 1614470400000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 58.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12097,25 +12097,25 @@
         "Datum": "01.03.2021",
         "Fallzahl": 22101,
         "ObjectId": 360,
-        "Sterbefall": 919,
-        "Genesungsfall": 20416,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 1965,
-        "Zuwachs_Fallzahl": 18,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 71,
         "BelegteBetten": null,
         "Inzidenz": 64.4778907288337,
         "Datum_neu": 1614556800000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 59.4,
-        "Fallzahl_aktiv": 766,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -60,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -12132,7 +12132,7 @@
         "ObjectId": 361,
         "Sterbefall": 924,
         "Genesungsfall": 20477,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 1973,
         "Zuwachs_Fallzahl": 97,
         "Zuwachs_Sterbefall": 5,
@@ -12141,22 +12141,55 @@
         "BelegteBetten": null,
         "Inzidenz": 65.9147239484177,
         "Datum_neu": 1614643200000,
-        "F\u00e4lle_Meldedatum": 26,
-        "Zeitraum": "23.02.2021 - 01.03.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 102,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 53,
         "Fallzahl_aktiv": 797,
-        "Krh_I_belegt": 220,
-        "Krh_I_frei": 58,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 31,
-        "Krh_I": 278,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 27,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 81.2,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.03.2021",
+        "Fallzahl": 22303,
+        "ObjectId": 362,
+        "Sterbefall": 928,
+        "Genesungsfall": 20531,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1984,
+        "Zuwachs_Fallzahl": 105,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 54,
+        "BelegteBetten": null,
+        "Inzidenz": 72.9192858938899,
+        "Datum_neu": 1614729600000,
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": "24.02.2021 - 02.03.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 56.4,
+        "Fallzahl_aktiv": 844,
+        "Krh_I_belegt": 223,
+        "Krh_I_frei": 55,
+        "Fallzahl_aktiv_Zuwachs": 47,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 27,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 74.3,
+        "Mutation": 78,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
