### PR TITLE
New data set: 2021-03-03T111704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-02T111304Z.json
+pjson/2021-03-03T111704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-03T111404Z.json pjson/2021-03-03T111704Z.json```:
```
--- pjson/2021-03-03T111404Z.json	2021-03-03 11:14:04.339092793 +0000
+++ pjson/2021-03-03T111704Z.json	2021-03-03 11:17:04.364422539 +0000
@@ -12183,7 +12183,7 @@
         "Krh_I_frei": 55,
         "Fallzahl_aktiv_Zuwachs": 47,
         "Krh_I": 278,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": 27,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 74.3,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
