### PR TITLE
New data set: 2021-03-06T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-05T111303Z.json
+pjson/2021-03-06T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-05T111303Z.json pjson/2021-03-06T110903Z.json```:
```
--- pjson/2021-03-05T111303Z.json	2021-03-05 11:13:03.717603518 +0000
+++ pjson/2021-03-06T110903Z.json	2021-03-06 11:09:03.189554016 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -8313,7 +8313,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604620800000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -9633,7 +9633,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -11877,7 +11877,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12007,12 +12007,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 86,
         "BelegteBetten": null,
-        "Inzidenz": 66.6331405582097,
+        "Inzidenz": null,
         "Datum_neu": 1614297600000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 55.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12021,7 +12021,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
-        "Inzi_SN_RKI": 75.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12141,7 +12141,7 @@
         "BelegteBetten": null,
         "Inzidenz": 65.9147239484177,
         "Datum_neu": 1614643200000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 53,
@@ -12174,9 +12174,9 @@
         "BelegteBetten": null,
         "Inzidenz": 72.9192858938899,
         "Datum_neu": 1614729600000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 56.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12207,7 +12207,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.0212651316498,
         "Datum_neu": 1614816000000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 61.6,
@@ -12229,32 +12229,65 @@
         "Datum": "05.03.2021",
         "Fallzahl": 22428,
         "ObjectId": 364,
-        "Sterbefall": 934,
-        "Genesungsfall": 20653,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1993,
-        "Zuwachs_Fallzahl": 52,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
         "Inzidenz": 71.5,
         "Datum_neu": 1614902400000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "26.02.2021 - 04.03.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 50,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 62.9,
-        "Fallzahl_aktiv": 841,
-        "Krh_I_belegt": 225,
-        "Krh_I_frei": 55,
-        "Fallzahl_aktiv_Zuwachs": -24,
-        "Krh_I": 280,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 78.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.03.2021",
+        "Fallzahl": 22493,
+        "ObjectId": 365,
+        "Sterbefall": 934,
+        "Genesungsfall": 20675,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 1998,
+        "Zuwachs_Fallzahl": 65,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 22,
+        "BelegteBetten": null,
+        "Inzidenz": 72.6,
+        "Datum_neu": 1614988800000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "27.02.2021 - 05.03.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 63.6,
+        "Fallzahl_aktiv": 884,
+        "Krh_I_belegt": 219,
+        "Krh_I_frei": 61,
+        "Fallzahl_aktiv_Zuwachs": 43,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": 32,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 78.6,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": 99,
+        "Zuwachs_Mutation": 3
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
