### PR TITLE
New data set: 2021-03-07T111403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-06T110903Z.json
+pjson/2021-03-07T111403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-06T110903Z.json pjson/2021-03-07T111403Z.json```:
```
--- pjson/2021-03-06T110903Z.json	2021-03-06 11:09:03.189554016 +0000
+++ pjson/2021-03-07T111403Z.json	2021-03-07 11:14:04.049519529 +0000
@@ -12040,12 +12040,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
-        "Inzidenz": 62.3226408994576,
+        "Inzidenz": null,
         "Datum_neu": 1614384000000,
         "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 53.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12054,7 +12054,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 78,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12240,7 +12240,7 @@
         "BelegteBetten": null,
         "Inzidenz": 71.5,
         "Datum_neu": 1614902400000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 62.9,
@@ -12262,32 +12262,65 @@
         "Datum": "06.03.2021",
         "Fallzahl": 22493,
         "ObjectId": 365,
-        "Sterbefall": 934,
-        "Genesungsfall": 20675,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 1998,
-        "Zuwachs_Fallzahl": 65,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 22,
         "BelegteBetten": null,
         "Inzidenz": 72.6,
         "Datum_neu": 1614988800000,
-        "F\u00e4lle_Meldedatum": 18,
-        "Zeitraum": "27.02.2021 - 05.03.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 63.6,
-        "Fallzahl_aktiv": 884,
-        "Krh_I_belegt": 219,
-        "Krh_I_frei": 61,
-        "Fallzahl_aktiv_Zuwachs": 43,
-        "Krh_I": 280,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 32,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 78.6,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.03.2021",
+        "Fallzahl": 22509,
+        "ObjectId": 366,
+        "Sterbefall": 934,
+        "Genesungsfall": 20705,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2001,
+        "Zuwachs_Fallzahl": 16,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 30,
+        "BelegteBetten": null,
+        "Inzidenz": 72.2,
+        "Datum_neu": 1615075200000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "28.02.2021 - 06.03.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 70.7,
+        "Fallzahl_aktiv": 870,
+        "Krh_I_belegt": 221,
+        "Krh_I_frei": 59,
+        "Fallzahl_aktiv_Zuwachs": -14,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 33,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 81.6,
+        "Mutation": 104,
+        "Zuwachs_Mutation": 5
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
