### PR TITLE
New data set: 2021-03-08T110303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-07T111403Z.json
+pjson/2021-03-08T110303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-07T111403Z.json pjson/2021-03-08T110303Z.json```:
```
--- pjson/2021-03-07T111403Z.json	2021-03-07 11:14:04.049519529 +0000
+++ pjson/2021-03-08T110303Z.json	2021-03-08 11:03:03.552926640 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -10238,7 +10238,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 16,
+        "SterbeF_Sterbedatum": 17,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11921,7 +11921,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12073,12 +12073,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
-        "Inzidenz": 63.4002658141456,
+        "Inzidenz": null,
         "Datum_neu": 1614470400000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 58.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12087,7 +12087,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 77.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12108,9 +12108,9 @@
         "BelegteBetten": null,
         "Inzidenz": 64.4778907288337,
         "Datum_neu": 1614556800000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 59.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12154,7 +12154,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 81.2,
-        "Mutation": null,
+        "Mutation": 67,
         "Zuwachs_Mutation": null
       }
     },
@@ -12174,9 +12174,9 @@
         "BelegteBetten": null,
         "Inzidenz": 72.9192858938899,
         "Datum_neu": 1614729600000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 56.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12187,8 +12187,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 74.3,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 78,
+        "Zuwachs_Mutation": 11
       }
     },
     {
@@ -12209,7 +12209,7 @@
         "Datum_neu": 1614816000000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12220,8 +12220,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 77.2,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 87,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12240,7 +12240,7 @@
         "BelegteBetten": null,
         "Inzidenz": 71.5,
         "Datum_neu": 1614902400000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 62.9,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 78.6,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 96,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12273,7 +12273,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.6,
         "Datum_neu": 1614988800000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 63.6,
@@ -12285,9 +12285,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 78.6,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Inzi_SN_RKI": 77.9,
+        "Mutation": 99,
+        "Zuwachs_Mutation": 3
       }
     },
     {
@@ -12297,31 +12297,64 @@
         "ObjectId": 366,
         "Sterbefall": 934,
         "Genesungsfall": 20705,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2001,
         "Zuwachs_Fallzahl": 16,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 3,
         "Zuwachs_Genesung": 30,
         "BelegteBetten": null,
-        "Inzidenz": 72.2,
+        "Inzidenz": 72.2008692840979,
         "Datum_neu": 1615075200000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "28.02.2021 - 06.03.2021",
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 70.7,
         "Fallzahl_aktiv": 870,
-        "Krh_I_belegt": 221,
-        "Krh_I_frei": 59,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -14,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 33,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 81.6,
         "Mutation": 104,
         "Zuwachs_Mutation": 5
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.03.2021",
+        "Fallzahl": 22516,
+        "ObjectId": 367,
+        "Sterbefall": 936,
+        "Genesungsfall": 20766,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2006,
+        "Zuwachs_Fallzahl": 7,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 61,
+        "BelegteBetten": null,
+        "Inzidenz": 71.8416609792018,
+        "Datum_neu": 1615161600000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "01.03.2021 - 07.03.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 70.6,
+        "Fallzahl_aktiv": 814,
+        "Krh_I_belegt": 223,
+        "Krh_I_frei": 55,
+        "Fallzahl_aktiv_Zuwachs": -56,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 35,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 86.7,
+        "Mutation": 105,
+        "Zuwachs_Mutation": 1
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
