### PR TITLE
New data set: 2021-03-09T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-08T110303Z.json
+pjson/2021-03-09T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-08T110303Z.json pjson/2021-03-09T110403Z.json```:
```
--- pjson/2021-03-08T110303Z.json	2021-03-08 11:03:03.552926640 +0000
+++ pjson/2021-03-09T110403Z.json	2021-03-09 11:04:03.543407387 +0000
@@ -7719,7 +7719,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -10238,7 +10238,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 17,
+        "SterbeF_Sterbedatum": 18,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -10557,7 +10557,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -11052,7 +11052,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -12075,7 +12075,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614470400000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -12086,7 +12086,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12106,12 +12106,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 71,
         "BelegteBetten": null,
-        "Inzidenz": 64.4778907288337,
+        "Inzidenz": null,
         "Datum_neu": 1614556800000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 59.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12120,7 +12120,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 84.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12141,7 +12141,7 @@
         "BelegteBetten": null,
         "Inzidenz": 65.9147239484177,
         "Datum_neu": 1614643200000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 53,
@@ -12154,7 +12154,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 81.2,
-        "Mutation": 67,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -12174,9 +12174,9 @@
         "BelegteBetten": null,
         "Inzidenz": 72.9192858938899,
         "Datum_neu": 1614729600000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 56.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12187,8 +12187,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 74.3,
-        "Mutation": 78,
-        "Zuwachs_Mutation": 11
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12207,7 +12207,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.0212651316498,
         "Datum_neu": 1614816000000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.6,
@@ -12220,8 +12220,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 77.2,
-        "Mutation": 87,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12240,9 +12240,9 @@
         "BelegteBetten": null,
         "Inzidenz": 71.5,
         "Datum_neu": 1614902400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 62.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 78.6,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 77.9,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12295,32 +12295,32 @@
         "Datum": "07.03.2021",
         "Fallzahl": 22509,
         "ObjectId": 366,
-        "Sterbefall": 934,
-        "Genesungsfall": 20705,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2001,
-        "Zuwachs_Fallzahl": 16,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 30,
         "BelegteBetten": null,
-        "Inzidenz": 72.2008692840979,
+        "Inzidenz": 72.2,
         "Datum_neu": 1615075200000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 70.7,
-        "Fallzahl_aktiv": 870,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -14,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 81.6,
-        "Mutation": 104,
-        "Zuwachs_Mutation": 5
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12328,32 +12328,65 @@
         "Datum": "08.03.2021",
         "Fallzahl": 22516,
         "ObjectId": 367,
-        "Sterbefall": 936,
-        "Genesungsfall": 20766,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2006,
-        "Zuwachs_Fallzahl": 7,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 61,
         "BelegteBetten": null,
-        "Inzidenz": 71.8416609792018,
+        "Inzidenz": 71.8,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "01.03.2021 - 07.03.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 70,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 70.6,
-        "Fallzahl_aktiv": 814,
-        "Krh_I_belegt": 223,
-        "Krh_I_frei": 55,
-        "Fallzahl_aktiv_Zuwachs": -56,
-        "Krh_I": 278,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 35,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 86.7,
-        "Mutation": 105,
-        "Zuwachs_Mutation": 1
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.03.2021",
+        "Fallzahl": 22626,
+        "ObjectId": 368,
+        "Sterbefall": 939,
+        "Genesungsfall": 20835,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2015,
+        "Zuwachs_Fallzahl": 110,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 69,
+        "BelegteBetten": null,
+        "Inzidenz": 72,
+        "Datum_neu": 1615248000000,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": "02.03.2021 - 08.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 58.7,
+        "Fallzahl_aktiv": 852,
+        "Krh_I_belegt": 231,
+        "Krh_I_frei": 48,
+        "Fallzahl_aktiv_Zuwachs": 38,
+        "Krh_I": 279,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 33,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": 84.4,
+        "Mutation": 118,
+        "Zuwachs_Mutation": 13
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
