### PR TITLE
New data set: 2021-03-10T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-09T110403Z.json
+pjson/2021-03-10T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-09T110403Z.json pjson/2021-03-10T110403Z.json```:
```
--- pjson/2021-03-09T110403Z.json	2021-03-09 11:04:03.543407387 +0000
+++ pjson/2021-03-10T110403Z.json	2021-03-10 11:04:03.633041198 +0000
@@ -9336,7 +9336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 377,
+        "F\u00e4lle_Meldedatum": 378,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -9633,7 +9633,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9743,7 +9743,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 12,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -9842,7 +9842,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 13,
+        "SterbeF_Sterbedatum": 14,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -9998,7 +9998,7 @@
         "Datum_neu": 1609027200000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10328,7 +10328,7 @@
         "Datum_neu": 1609891200000,
         "F\u00e4lle_Meldedatum": 348,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10392,7 +10392,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -10955,7 +10955,7 @@
         "Datum_neu": 1611532800000,
         "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11052,7 +11052,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -11217,7 +11217,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -11417,7 +11417,7 @@
         "Datum_neu": 1612742400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11646,7 +11646,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -12086,7 +12086,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12108,7 +12108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614556800000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -12139,12 +12139,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 61,
         "BelegteBetten": null,
-        "Inzidenz": 65.9147239484177,
+        "Inzidenz": null,
         "Datum_neu": 1614643200000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 53,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12152,8 +12152,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 81.2,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12185,7 +12185,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 74.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12218,7 +12218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 77.2,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12240,7 +12240,7 @@
         "BelegteBetten": null,
         "Inzidenz": 71.5,
         "Datum_neu": 1614902400000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 62.9,
@@ -12273,7 +12273,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.6,
         "Datum_neu": 1614988800000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 63.6,
@@ -12339,9 +12339,9 @@
         "BelegteBetten": null,
         "Inzidenz": 71.8,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 70.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12361,32 +12361,65 @@
         "Datum": "09.03.2021",
         "Fallzahl": 22626,
         "ObjectId": 368,
-        "Sterbefall": 939,
-        "Genesungsfall": 20835,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2015,
-        "Zuwachs_Fallzahl": 110,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 69,
         "BelegteBetten": null,
-        "Inzidenz": 72,
+        "Inzidenz": 72.0212651316498,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 38,
-        "Zeitraum": "02.03.2021 - 08.03.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 83,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 58.7,
-        "Fallzahl_aktiv": 852,
-        "Krh_I_belegt": 231,
-        "Krh_I_frei": 48,
-        "Fallzahl_aktiv_Zuwachs": 38,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": 84.4,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.03.2021",
+        "Fallzahl": 22715,
+        "ObjectId": 369,
+        "Sterbefall": 946,
+        "Genesungsfall": 20906,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2025,
+        "Zuwachs_Fallzahl": 89,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 71,
+        "BelegteBetten": null,
+        "Inzidenz": 71.8,
+        "Datum_neu": 1615334400000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "03.03.2021 - 09.03.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 58.6,
+        "Fallzahl_aktiv": 863,
+        "Krh_I_belegt": 237,
+        "Krh_I_frei": 42,
+        "Fallzahl_aktiv_Zuwachs": 11,
         "Krh_I": 279,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 33,
-        "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 84.4,
-        "Mutation": 118,
-        "Zuwachs_Mutation": 13
+        "Krh_I_covid": 37,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 75.6,
+        "Mutation": 138,
+        "Zuwachs_Mutation": 20
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
