### PR TITLE
New data set: 2021-03-13T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-12T111603Z.json
+pjson/2021-03-13T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-12T111603Z.json pjson/2021-03-13T110203Z.json```:
```
--- pjson/2021-03-12T111603Z.json	2021-03-12 11:16:03.741818869 +0000
+++ pjson/2021-03-13T110203Z.json	2021-03-13 11:02:03.096110935 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -8414,7 +8414,7 @@
         "Datum_neu": 1604880000000,
         "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8513,7 +8513,7 @@
         "Datum_neu": 1605139200000,
         "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8546,7 +8546,7 @@
         "Datum_neu": 1605225600000,
         "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8579,7 +8579,7 @@
         "Datum_neu": 1605312000000,
         "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8645,7 +8645,7 @@
         "Datum_neu": 1605484800000,
         "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8744,7 +8744,7 @@
         "Datum_neu": 1605744000000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8876,7 +8876,7 @@
         "Datum_neu": 1606089600000,
         "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -8942,7 +8942,7 @@
         "Datum_neu": 1606262400000,
         "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9008,7 +9008,7 @@
         "Datum_neu": 1606435200000,
         "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9140,7 +9140,7 @@
         "Datum_neu": 1606780800000,
         "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9173,7 +9173,7 @@
         "Datum_neu": 1606867200000,
         "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9239,7 +9239,7 @@
         "Datum_neu": 1607040000000,
         "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9272,7 +9272,7 @@
         "Datum_neu": 1607126400000,
         "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9371,7 +9371,7 @@
         "Datum_neu": 1607385600000,
         "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 41,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9437,7 +9437,7 @@
         "Datum_neu": 1607558400000,
         "F\u00e4lle_Meldedatum": 464,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9470,7 +9470,7 @@
         "Datum_neu": 1607644800000,
         "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9569,7 +9569,7 @@
         "Datum_neu": 1607904000000,
         "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9602,7 +9602,7 @@
         "Datum_neu": 1607990400000,
         "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9633,7 +9633,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9701,7 +9701,7 @@
         "Datum_neu": 1608249600000,
         "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9734,7 +9734,7 @@
         "Datum_neu": 1608336000000,
         "F\u00e4lle_Meldedatum": 164,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10097,7 +10097,7 @@
         "Datum_neu": 1609286400000,
         "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 38,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10130,7 +10130,7 @@
         "Datum_neu": 1609372800000,
         "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10163,7 +10163,7 @@
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10229,7 +10229,7 @@
         "Datum_neu": 1609632000000,
         "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10295,7 +10295,7 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10493,7 +10493,7 @@
         "Datum_neu": 1610323200000,
         "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 42,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10559,7 +10559,7 @@
         "Datum_neu": 1610496000000,
         "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10625,7 +10625,7 @@
         "Datum_neu": 1610668800000,
         "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10724,7 +10724,7 @@
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10823,7 +10823,7 @@
         "Datum_neu": 1611187200000,
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10988,7 +10988,7 @@
         "Datum_neu": 1611619200000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11186,7 +11186,7 @@
         "Datum_neu": 1612137600000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11285,7 +11285,7 @@
         "Datum_neu": 1612396800000,
         "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11351,7 +11351,7 @@
         "Datum_neu": 1612569600000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11384,7 +11384,7 @@
         "Datum_neu": 1612656000000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11417,7 +11417,7 @@
         "Datum_neu": 1612742400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11483,7 +11483,7 @@
         "Datum_neu": 1612915200000,
         "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12110,7 +12110,7 @@
         "Datum_neu": 1614556800000,
         "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12143,7 +12143,7 @@
         "Datum_neu": 1614643200000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12209,7 +12209,7 @@
         "Datum_neu": 1614816000000,
         "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12252,7 +12252,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 78.6,
+        "Inzi_SN_RKI": null,
         "Mutation": 96,
         "Zuwachs_Mutation": 9
       }
@@ -12372,7 +12372,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.0212651316498,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 58.7,
@@ -12407,7 +12407,7 @@
         "Datum_neu": 1615334400000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 58.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12427,26 +12427,26 @@
         "Datum": "11.03.2021",
         "Fallzahl": 22774,
         "ObjectId": 370,
-        "Sterbefall": 946,
-        "Genesungsfall": 20978,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2028,
-        "Zuwachs_Fallzahl": 59,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
         "Inzidenz": 73.9969108085779,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 62,
-        "Fallzahl_aktiv": 850,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 45,
-        "Fallzahl_aktiv_Zuwachs": -13,
-        "Krh_I": 281,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
@@ -12462,17 +12462,17 @@
         "ObjectId": 371,
         "Sterbefall": 946,
         "Genesungsfall": 21034,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2040,
         "Zuwachs_Fallzahl": 76,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 12,
         "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
-        "Inzidenz": 77.229785552642,
+        "Inzidenz": 77.2,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 26,
-        "Zeitraum": "05.03.2021 - 11.03.2021",
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 67.7,
         "Fallzahl_aktiv": 870,
@@ -12481,12 +12481,45 @@
         "Fallzahl_aktiv_Zuwachs": 20,
         "Krh_I": 281,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 34,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 90.9,
         "Mutation": 173,
         "Zuwachs_Mutation": 27
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.03.2021",
+        "Fallzahl": 22947,
+        "ObjectId": 372,
+        "Sterbefall": 946,
+        "Genesungsfall": 21066,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2041,
+        "Zuwachs_Fallzahl": 97,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 32,
+        "BelegteBetten": null,
+        "Inzidenz": 78.666618772226,
+        "Datum_neu": 1615593600000,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": "06.03.2021 - 12.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 69.9,
+        "Fallzahl_aktiv": 935,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": 65,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 33,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 100.5,
+        "Mutation": 206,
+        "Zuwachs_Mutation": 33
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
