### PR TITLE
New data set: 2021-03-14T110004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-13T110203Z.json
+pjson/2021-03-14T110004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-13T110203Z.json pjson/2021-03-14T110004Z.json```:
```
--- pjson/2021-03-13T110203Z.json	2021-03-13 11:02:03.096110935 +0000
+++ pjson/2021-03-14T110004Z.json	2021-03-14 11:00:04.399798224 +0000
@@ -12339,7 +12339,7 @@
         "BelegteBetten": null,
         "Inzidenz": 71.8,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 70.6,
@@ -12438,7 +12438,7 @@
         "BelegteBetten": null,
         "Inzidenz": 73.9969108085779,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 62,
@@ -12460,13 +12460,13 @@
         "Datum": "12.03.2021",
         "Fallzahl": 22850,
         "ObjectId": 371,
-        "Sterbefall": 946,
-        "Genesungsfall": 21034,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2040,
-        "Zuwachs_Fallzahl": 76,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
         "Inzidenz": 77.2,
@@ -12475,12 +12475,12 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 67.7,
-        "Fallzahl_aktiv": 870,
-        "Krh_I_belegt": 239,
-        "Krh_I_frei": 42,
-        "Fallzahl_aktiv_Zuwachs": 20,
-        "Krh_I": 281,
-        "Vorz_akt_Faelle": "+",
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 90.9,
@@ -12495,7 +12495,7 @@
         "ObjectId": 372,
         "Sterbefall": 946,
         "Genesungsfall": 21066,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2041,
         "Zuwachs_Fallzahl": 97,
         "Zuwachs_Sterbefall": 0,
@@ -12504,22 +12504,55 @@
         "BelegteBetten": null,
         "Inzidenz": 78.666618772226,
         "Datum_neu": 1615593600000,
-        "F\u00e4lle_Meldedatum": 49,
-        "Zeitraum": "06.03.2021 - 12.03.2021",
+        "F\u00e4lle_Meldedatum": 68,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 69.9,
         "Fallzahl_aktiv": 935,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 65,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 33,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 100.5,
         "Mutation": 206,
         "Zuwachs_Mutation": 33
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.03.2021",
+        "Fallzahl": 22984,
+        "ObjectId": 373,
+        "Sterbefall": 946,
+        "Genesungsfall": 21083,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2041,
+        "Zuwachs_Fallzahl": 37,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 17,
+        "BelegteBetten": null,
+        "Inzidenz": 86.9284097848342,
+        "Datum_neu": 1615680000000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "07.03.2021 - 13.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 81.2,
+        "Fallzahl_aktiv": 955,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": 20,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 33,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 105.1,
+        "Mutation": 210,
+        "Zuwachs_Mutation": 4
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
