### PR TITLE
New data set: 2021-03-15T111504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-14T110004Z.json
+pjson/2021-03-15T111504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-14T110004Z.json pjson/2021-03-15T111504Z.json```:
```
--- pjson/2021-03-14T110004Z.json	2021-03-14 11:00:04.399798224 +0000
+++ pjson/2021-03-15T111504Z.json	2021-03-15 11:15:05.070096419 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -11879,7 +11879,7 @@
         "Datum_neu": 1613952000000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12143,7 +12143,7 @@
         "Datum_neu": 1614643200000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12176,7 +12176,7 @@
         "Datum_neu": 1614729600000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12207,7 +12207,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614816000000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -12238,12 +12238,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
-        "Inzidenz": 71.5,
+        "Inzidenz": null,
         "Datum_neu": 1614902400000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 62.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12271,12 +12271,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 22,
         "BelegteBetten": null,
-        "Inzidenz": 72.6,
+        "Inzidenz": null,
         "Datum_neu": 1614988800000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 63.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12285,7 +12285,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 77.9,
+        "Inzi_SN_RKI": null,
         "Mutation": 99,
         "Zuwachs_Mutation": 3
       }
@@ -12304,12 +12304,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 30,
         "BelegteBetten": null,
-        "Inzidenz": 72.2,
+        "Inzidenz": null,
         "Datum_neu": 1615075200000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 70.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12318,7 +12318,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 81.6,
+        "Inzi_SN_RKI": null,
         "Mutation": 104,
         "Zuwachs_Mutation": 5
       }
@@ -12372,7 +12372,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.0212651316498,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 58.7,
@@ -12407,7 +12407,7 @@
         "Datum_neu": 1615334400000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 58.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12438,7 +12438,7 @@
         "BelegteBetten": null,
         "Inzidenz": 73.9969108085779,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 62,
@@ -12471,7 +12471,7 @@
         "BelegteBetten": null,
         "Inzidenz": 77.2,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 67.7,
@@ -12482,7 +12482,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 90.9,
         "Mutation": 173,
         "Zuwachs_Mutation": 27
@@ -12493,27 +12493,27 @@
         "Datum": "13.03.2021",
         "Fallzahl": 22947,
         "ObjectId": 372,
-        "Sterbefall": 946,
-        "Genesungsfall": 21066,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2041,
-        "Zuwachs_Fallzahl": 97,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
         "Inzidenz": 78.666618772226,
         "Datum_neu": 1615593600000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 69.9,
-        "Fallzahl_aktiv": 935,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 65,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 100.5,
@@ -12528,7 +12528,7 @@
         "ObjectId": 373,
         "Sterbefall": 946,
         "Genesungsfall": 21083,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2041,
         "Zuwachs_Fallzahl": 37,
         "Zuwachs_Sterbefall": 0,
@@ -12537,9 +12537,9 @@
         "BelegteBetten": null,
         "Inzidenz": 86.9284097848342,
         "Datum_neu": 1615680000000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "07.03.2021 - 13.03.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 81.2,
         "Fallzahl_aktiv": 955,
         "Krh_I_belegt": 238,
@@ -12553,6 +12553,39 @@
         "Mutation": 210,
         "Zuwachs_Mutation": 4
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.03.2021",
+        "Fallzahl": 22990,
+        "ObjectId": 374,
+        "Sterbefall": 948,
+        "Genesungsfall": 21119,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2052,
+        "Zuwachs_Fallzahl": 6,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 36,
+        "BelegteBetten": null,
+        "Inzidenz": 88.7244513093143,
+        "Datum_neu": 1615766400000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "08.03.2021 - 14.03.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 87.6,
+        "Fallzahl_aktiv": 923,
+        "Krh_I_belegt": 227,
+        "Krh_I_frei": 57,
+        "Fallzahl_aktiv_Zuwachs": -32,
+        "Krh_I": 284,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 32,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 112.9,
+        "Mutation": 212,
+        "Zuwachs_Mutation": 2
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
