### PR TITLE
New data set: 2021-03-16T112504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-15T111504Z.json
+pjson/2021-03-16T112504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-15T111504Z.json pjson/2021-03-16T112504Z.json```:
```
--- pjson/2021-03-15T111504Z.json	2021-03-15 11:15:05.070096419 +0000
+++ pjson/2021-03-16T112504Z.json	2021-03-16 11:25:05.063238414 +0000
@@ -11294,7 +11294,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12053,7 +12053,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12086,7 +12086,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12176,7 +12176,7 @@
         "Datum_neu": 1614729600000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12185,7 +12185,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12306,7 +12306,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615075200000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -12337,12 +12337,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 61,
         "BelegteBetten": null,
-        "Inzidenz": 71.8,
+        "Inzidenz": null,
         "Datum_neu": 1615161600000,
         "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 70.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12351,7 +12351,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 86.7,
+        "Inzi_SN_RKI": null,
         "Mutation": 105,
         "Zuwachs_Mutation": 1
       }
@@ -12372,7 +12372,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.0212651316498,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 58.7,
@@ -12407,7 +12407,7 @@
         "Datum_neu": 1615334400000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 58.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12438,9 +12438,9 @@
         "BelegteBetten": null,
         "Inzidenz": 73.9969108085779,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 62,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12471,7 +12471,7 @@
         "BelegteBetten": null,
         "Inzidenz": 77.2,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 67.7,
@@ -12526,13 +12526,13 @@
         "Datum": "14.03.2021",
         "Fallzahl": 22984,
         "ObjectId": 373,
-        "Sterbefall": 946,
-        "Genesungsfall": 21083,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2041,
-        "Zuwachs_Fallzahl": 37,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
         "Inzidenz": 86.9284097848342,
@@ -12541,13 +12541,13 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 81.2,
-        "Fallzahl_aktiv": 955,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 43,
-        "Fallzahl_aktiv_Zuwachs": 20,
-        "Krh_I": 281,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 33,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 105.1,
         "Mutation": 210,
@@ -12561,7 +12561,7 @@
         "ObjectId": 374,
         "Sterbefall": 948,
         "Genesungsfall": 21119,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2052,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 2,
@@ -12570,9 +12570,9 @@
         "BelegteBetten": null,
         "Inzidenz": 88.7244513093143,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "08.03.2021 - 14.03.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 75,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 87.6,
         "Fallzahl_aktiv": 923,
         "Krh_I_belegt": 227,
@@ -12581,11 +12581,44 @@
         "Krh_I": 284,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 32,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 112.9,
         "Mutation": 212,
         "Zuwachs_Mutation": 2
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.03.2021",
+        "Fallzahl": 23095,
+        "ObjectId": 375,
+        "Sterbefall": 950,
+        "Genesungsfall": 21227,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2061,
+        "Zuwachs_Fallzahl": 105,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 108,
+        "BelegteBetten": null,
+        "Inzidenz": 84.7731599554582,
+        "Datum_neu": 1615852800000,
+        "F\u00e4lle_Meldedatum": 29,
+        "Zeitraum": "09.03.2021 - 15.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 71.3,
+        "Fallzahl_aktiv": 918,
+        "Krh_I_belegt": 233,
+        "Krh_I_frei": 48,
+        "Fallzahl_aktiv_Zuwachs": -5,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 29,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 110,
+        "Mutation": 240,
+        "Zuwachs_Mutation": 28
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
