### PR TITLE
New data set: 2021-03-17T112303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-16T112504Z.json
+pjson/2021-03-17T112303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-16T112504Z.json pjson/2021-03-17T112303Z.json```:
```
--- pjson/2021-03-16T112504Z.json	2021-03-16 11:25:05.063238414 +0000
+++ pjson/2021-03-17T112303Z.json	2021-03-17 11:23:03.391688171 +0000
@@ -7851,7 +7851,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603411200000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -9633,7 +9633,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 360,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -9831,7 +9831,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 486,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -10238,7 +10238,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 18,
+        "SterbeF_Sterbedatum": 19,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -10821,7 +10821,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10986,7 +10986,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -11217,7 +11217,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612224000000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -11778,7 +11778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12240,7 +12240,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614902400000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12339,7 +12339,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -12372,10 +12372,10 @@
         "BelegteBetten": null,
         "Inzidenz": 72.0212651316498,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 89,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 58.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12384,7 +12384,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 84.4,
+        "Inzi_SN_RKI": null,
         "Mutation": 118,
         "Zuwachs_Mutation": 13
       }
@@ -12405,7 +12405,7 @@
         "BelegteBetten": null,
         "Inzidenz": 71.8416609792018,
         "Datum_neu": 1615334400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 58.6,
@@ -12438,9 +12438,9 @@
         "BelegteBetten": null,
         "Inzidenz": 73.9969108085779,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 62,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12449,7 +12449,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 85.2,
         "Mutation": 146,
         "Zuwachs_Mutation": 8
@@ -12471,7 +12471,7 @@
         "BelegteBetten": null,
         "Inzidenz": 77.2,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 67.7,
@@ -12506,7 +12506,7 @@
         "Datum_neu": 1615593600000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 69.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12559,28 +12559,28 @@
         "Datum": "15.03.2021",
         "Fallzahl": 22990,
         "ObjectId": 374,
-        "Sterbefall": 948,
-        "Genesungsfall": 21119,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2052,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 36,
         "BelegteBetten": null,
         "Inzidenz": 88.7244513093143,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 87.6,
-        "Fallzahl_aktiv": 923,
-        "Krh_I_belegt": 227,
-        "Krh_I_frei": 57,
-        "Fallzahl_aktiv_Zuwachs": -32,
-        "Krh_I": 284,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 32,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 112.9,
         "Mutation": 212,
@@ -12594,7 +12594,7 @@
         "ObjectId": 375,
         "Sterbefall": 950,
         "Genesungsfall": 21227,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2061,
         "Zuwachs_Fallzahl": 105,
         "Zuwachs_Sterbefall": 2,
@@ -12603,9 +12603,9 @@
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 29,
-        "Zeitraum": "09.03.2021 - 15.03.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 103,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 71.3,
         "Fallzahl_aktiv": 918,
         "Krh_I_belegt": 233,
@@ -12619,6 +12619,39 @@
         "Mutation": 240,
         "Zuwachs_Mutation": 28
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.03.2021",
+        "Fallzahl": 23221,
+        "ObjectId": 376,
+        "Sterbefall": 952,
+        "Genesungsfall": 21290,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2067,
+        "Zuwachs_Fallzahl": 126,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 63,
+        "BelegteBetten": null,
+        "Inzidenz": 91.5981177484824,
+        "Datum_neu": 1615939200000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "10.03.2021 - 16.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 71.7,
+        "Fallzahl_aktiv": 979,
+        "Krh_I_belegt": 229,
+        "Krh_I_frei": 52,
+        "Fallzahl_aktiv_Zuwachs": 61,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 27,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 109.1,
+        "Mutation": 284,
+        "Zuwachs_Mutation": 44
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
