### PR TITLE
New data set: 2021-03-18T112103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-17T112303Z.json
+pjson/2021-03-18T112103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-17T112303Z.json pjson/2021-03-18T112103Z.json```:
```
--- pjson/2021-03-17T112303Z.json	2021-03-17 11:23:03.391688171 +0000
+++ pjson/2021-03-18T112103Z.json	2021-03-18 11:21:03.422966744 +0000
@@ -6234,7 +6234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599177600000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -11943,7 +11943,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12108,7 +12108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614556800000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -12152,7 +12152,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12251,7 +12251,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 96,
         "Zuwachs_Mutation": 9
@@ -12339,7 +12339,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -12370,9 +12370,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 69,
         "BelegteBetten": null,
-        "Inzidenz": 72.0212651316498,
+        "Inzidenz": null,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12403,12 +12403,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 71,
         "BelegteBetten": null,
-        "Inzidenz": 71.8416609792018,
+        "Inzidenz": null,
         "Datum_neu": 1615334400000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 58.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12417,7 +12417,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 75.6,
+        "Inzi_SN_RKI": null,
         "Mutation": 138,
         "Zuwachs_Mutation": 20
       }
@@ -12438,9 +12438,9 @@
         "BelegteBetten": null,
         "Inzidenz": 73.9969108085779,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 62,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12506,7 +12506,7 @@
         "Datum_neu": 1615593600000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 69.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12515,7 +12515,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 100.5,
         "Mutation": 206,
         "Zuwachs_Mutation": 33
@@ -12570,7 +12570,7 @@
         "BelegteBetten": null,
         "Inzidenz": 88.7244513093143,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 87.6,
@@ -12592,28 +12592,28 @@
         "Datum": "16.03.2021",
         "Fallzahl": 23095,
         "ObjectId": 375,
-        "Sterbefall": 950,
-        "Genesungsfall": 21227,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2061,
-        "Zuwachs_Fallzahl": 105,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 71.3,
-        "Fallzahl_aktiv": 918,
-        "Krh_I_belegt": 233,
-        "Krh_I_frei": 48,
-        "Fallzahl_aktiv_Zuwachs": -5,
-        "Krh_I": 281,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 29,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 110,
         "Mutation": 240,
@@ -12627,7 +12627,7 @@
         "ObjectId": 376,
         "Sterbefall": 952,
         "Genesungsfall": 21290,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2067,
         "Zuwachs_Fallzahl": 126,
         "Zuwachs_Sterbefall": 2,
@@ -12636,9 +12636,9 @@
         "BelegteBetten": null,
         "Inzidenz": 91.5981177484824,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 21,
-        "Zeitraum": "10.03.2021 - 16.03.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 107,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 71.7,
         "Fallzahl_aktiv": 979,
         "Krh_I_belegt": 229,
@@ -12646,12 +12646,45 @@
         "Fallzahl_aktiv_Zuwachs": 61,
         "Krh_I": 281,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 27,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 109.1,
         "Mutation": 284,
         "Zuwachs_Mutation": 44
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.03.2021",
+        "Fallzahl": 23354,
+        "ObjectId": 377,
+        "Sterbefall": 955,
+        "Genesungsfall": 21349,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2070,
+        "Zuwachs_Fallzahl": 133,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 59,
+        "BelegteBetten": null,
+        "Inzidenz": 98.9618879988505,
+        "Datum_neu": 1616025600000,
+        "F\u00e4lle_Meldedatum": 29,
+        "Zeitraum": "11.03.2021 - 17.03.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 81.6,
+        "Fallzahl_aktiv": 1050,
+        "Krh_I_belegt": 227,
+        "Krh_I_frei": 54,
+        "Fallzahl_aktiv_Zuwachs": 71,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 29,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 109.7,
+        "Mutation": 322,
+        "Zuwachs_Mutation": 38
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
