### PR TITLE
New data set: 2021-03-19T112104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-18T112103Z.json
+pjson/2021-03-19T112104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-18T112103Z.json pjson/2021-03-19T112104Z.json```:
```
--- pjson/2021-03-18T112103Z.json	2021-03-18 11:21:03.422966744 +0000
+++ pjson/2021-03-19T112104Z.json	2021-03-19 11:21:04.230376251 +0000
@@ -6234,7 +6234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599177600000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -7719,7 +7719,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -8544,7 +8544,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 206,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -8973,7 +8973,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -10755,7 +10755,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -11745,7 +11745,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 104,
-        "Zuwachs_Mutation": 5
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12339,7 +12339,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 105,
-        "Zuwachs_Mutation": 1
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12372,7 +12372,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12383,10 +12383,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 118,
-        "Zuwachs_Mutation": 13
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12416,10 +12416,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 138,
-        "Zuwachs_Mutation": 20
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12436,12 +12436,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
-        "Inzidenz": 73.9969108085779,
+        "Inzidenz": null,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 62,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12450,9 +12450,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 85.2,
-        "Mutation": 146,
-        "Zuwachs_Mutation": 8
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12473,7 +12473,7 @@
         "Datum_neu": 1615507200000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 67.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 90.9,
-        "Mutation": 173,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12515,10 +12515,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 100.5,
-        "Mutation": 206,
-        "Zuwachs_Mutation": 33
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12539,7 +12539,7 @@
         "Datum_neu": 1615680000000,
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 81.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 105.1,
-        "Mutation": 210,
-        "Zuwachs_Mutation": 4
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12570,9 +12570,9 @@
         "BelegteBetten": null,
         "Inzidenz": 88.7244513093143,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 87.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 112.9,
-        "Mutation": 212,
-        "Zuwachs_Mutation": 2
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 71.3,
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 110,
-        "Mutation": 240,
-        "Zuwachs_Mutation": 28
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12625,32 +12625,32 @@
         "Datum": "17.03.2021",
         "Fallzahl": 23221,
         "ObjectId": 376,
-        "Sterbefall": 952,
-        "Genesungsfall": 21290,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2067,
-        "Zuwachs_Fallzahl": 126,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 63,
         "BelegteBetten": null,
         "Inzidenz": 91.5981177484824,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 71.7,
-        "Fallzahl_aktiv": 979,
-        "Krh_I_belegt": 229,
-        "Krh_I_frei": 52,
-        "Fallzahl_aktiv_Zuwachs": 61,
-        "Krh_I": 281,
-        "Vorz_akt_Faelle": "+",
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 109.1,
-        "Mutation": 284,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12658,32 +12658,65 @@
         "Datum": "18.03.2021",
         "Fallzahl": 23354,
         "ObjectId": 377,
-        "Sterbefall": 955,
-        "Genesungsfall": 21349,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2070,
-        "Zuwachs_Fallzahl": 133,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
         "Inzidenz": 98.9618879988505,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 29,
-        "Zeitraum": "11.03.2021 - 17.03.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 81.6,
-        "Fallzahl_aktiv": 1050,
-        "Krh_I_belegt": 227,
-        "Krh_I_frei": 54,
-        "Fallzahl_aktiv_Zuwachs": 71,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 109.7,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.03.2021",
+        "Fallzahl": 23450,
+        "ObjectId": 378,
+        "Sterbefall": 959,
+        "Genesungsfall": 21407,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2082,
+        "Zuwachs_Fallzahl": 96,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 58,
+        "BelegteBetten": null,
+        "Inzidenz": 96.3,
+        "Datum_neu": 1616112000000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "12.03.2021 - 18.03.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 88.5,
+        "Fallzahl_aktiv": 1084,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": 34,
         "Krh_I": 281,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": 29,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 109.7,
-        "Mutation": 322,
-        "Zuwachs_Mutation": 38
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": 127.1,
+        "Mutation": 370,
+        "Zuwachs_Mutation": 48
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
