### PR TITLE
New data set: 2021-03-20T111003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-19T112104Z.json
+pjson/2021-03-20T111003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-19T112104Z.json pjson/2021-03-20T111003Z.json```:
```
--- pjson/2021-03-19T112104Z.json	2021-03-19 11:21:04.230376251 +0000
+++ pjson/2021-03-20T111003Z.json	2021-03-20 11:10:03.695087771 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -9765,7 +9765,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -11811,7 +11811,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613779200000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -12372,7 +12372,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12469,12 +12469,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
-        "Inzidenz": 77.2,
+        "Inzidenz": null,
         "Datum_neu": 1615507200000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 67.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12483,7 +12483,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 90.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12570,7 +12570,7 @@
         "BelegteBetten": null,
         "Inzidenz": 88.7244513093143,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 87.6,
@@ -12581,7 +12581,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 112.9,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12636,9 +12636,9 @@
         "BelegteBetten": null,
         "Inzidenz": 91.5981177484824,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 71.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12669,7 +12669,7 @@
         "BelegteBetten": null,
         "Inzidenz": 98.9618879988505,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 81.6,
@@ -12680,7 +12680,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 109.7,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12691,32 +12691,65 @@
         "Datum": "19.03.2021",
         "Fallzahl": 23450,
         "ObjectId": 378,
-        "Sterbefall": 959,
-        "Genesungsfall": 21407,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2082,
-        "Zuwachs_Fallzahl": 96,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 58,
         "BelegteBetten": null,
         "Inzidenz": 96.3,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 46,
-        "Zeitraum": "12.03.2021 - 18.03.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 82,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 88.5,
-        "Fallzahl_aktiv": 1084,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 43,
-        "Fallzahl_aktiv_Zuwachs": 34,
-        "Krh_I": 281,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 29,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 127.1,
-        "Mutation": 370,
-        "Zuwachs_Mutation": 48
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.03.2021",
+        "Fallzahl": 23536,
+        "ObjectId": 379,
+        "Sterbefall": 961,
+        "Genesungsfall": 21433,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2089,
+        "Zuwachs_Fallzahl": 86,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 26,
+        "BelegteBetten": null,
+        "Inzidenz": 101.5,
+        "Datum_neu": 1616198400000,
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": "13.03.2021 - 19.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 89.3,
+        "Fallzahl_aktiv": 1142,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 41,
+        "Fallzahl_aktiv_Zuwachs": 58,
+        "Krh_I": 279,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 33,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 133.8,
+        "Mutation": 416,
+        "Zuwachs_Mutation": 46
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
