### PR TITLE
New data set: 2021-03-21T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-20T111003Z.json
+pjson/2021-03-21T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-20T111003Z.json pjson/2021-03-21T110203Z.json```:
```
--- pjson/2021-03-20T111003Z.json	2021-03-20 11:10:03.695087771 +0000
+++ pjson/2021-03-21T110203Z.json	2021-03-21 11:02:03.936144498 +0000
@@ -12405,7 +12405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615334400000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12502,12 +12502,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 78.666618772226,
+        "Inzidenz": null,
         "Datum_neu": 1615593600000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 69.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12516,7 +12516,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 100.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12636,7 +12636,7 @@
         "BelegteBetten": null,
         "Inzidenz": 91.5981177484824,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 71.7,
@@ -12669,7 +12669,7 @@
         "BelegteBetten": null,
         "Inzidenz": 98.9618879988505,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 81.6,
@@ -12702,9 +12702,9 @@
         "BelegteBetten": null,
         "Inzidenz": 96.3,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 88.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12724,32 +12724,65 @@
         "Datum": "20.03.2021",
         "Fallzahl": 23536,
         "ObjectId": 379,
-        "Sterbefall": 961,
-        "Genesungsfall": 21433,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2089,
-        "Zuwachs_Fallzahl": 86,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
         "Inzidenz": 101.5,
         "Datum_neu": 1616198400000,
-        "F\u00e4lle_Meldedatum": 19,
-        "Zeitraum": "13.03.2021 - 19.03.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 54,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 89.3,
-        "Fallzahl_aktiv": 1142,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 41,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 133.8,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.03.2021",
+        "Fallzahl": 23611,
+        "ObjectId": 380,
+        "Sterbefall": 961,
+        "Genesungsfall": 21450,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2093,
+        "Zuwachs_Fallzahl": 75,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 17,
+        "BelegteBetten": null,
+        "Inzidenz": 105.1,
+        "Datum_neu": 1616284800000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "14.03.2021 - 20.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 92.7,
+        "Fallzahl_aktiv": 1200,
+        "Krh_I_belegt": 231,
+        "Krh_I_frei": 43,
         "Fallzahl_aktiv_Zuwachs": 58,
-        "Krh_I": 279,
+        "Krh_I": 274,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 33,
+        "Krh_I_covid": 35,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 133.8,
-        "Mutation": 416,
-        "Zuwachs_Mutation": 46
+        "Inzi_SN_RKI": 145.2,
+        "Mutation": 430,
+        "Zuwachs_Mutation": 14
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
