### PR TITLE
New data set: 2021-03-22T111603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-21T110203Z.json
+pjson/2021-03-22T111603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-21T110203Z.json pjson/2021-03-22T111603Z.json```:
```
--- pjson/2021-03-21T110203Z.json	2021-03-21 11:02:03.936144498 +0000
+++ pjson/2021-03-22T111603Z.json	2021-03-22 11:16:03.657377957 +0000
@@ -11019,7 +11019,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -11912,7 +11912,7 @@
         "Datum_neu": 1614038400000,
         "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12086,7 +12086,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 96,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 99,
+        "Zuwachs_Mutation": 3
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 104,
+        "Zuwachs_Mutation": 5
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 105,
+        "Zuwachs_Mutation": 1
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 118,
+        "Zuwachs_Mutation": 13
       }
     },
     {
@@ -12407,7 +12407,7 @@
         "Datum_neu": 1615334400000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 138,
+        "Zuwachs_Mutation": 20
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 146,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -12473,7 +12473,7 @@
         "Datum_neu": 1615507200000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 173,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -12515,10 +12515,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 206,
+        "Zuwachs_Mutation": 33
       }
     },
     {
@@ -12535,12 +12535,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
-        "Inzidenz": 86.9284097848342,
+        "Inzidenz": null,
         "Datum_neu": 1615680000000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 81.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12549,9 +12549,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 105.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Inzi_SN_RKI": null,
+        "Mutation": 210,
+        "Zuwachs_Mutation": 4
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": 112.9,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 212,
+        "Zuwachs_Mutation": 2
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 110,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 240,
+        "Zuwachs_Mutation": 28
       }
     },
     {
@@ -12636,9 +12636,9 @@
         "BelegteBetten": null,
         "Inzidenz": 91.5981177484824,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 71.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 109.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 284,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -12669,21 +12669,21 @@
         "BelegteBetten": null,
         "Inzidenz": 98.9618879988505,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 81.6,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 227,
+        "Krh_I_frei": 54,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 281,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 109.7,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 322,
+        "Zuwachs_Mutation": 38
       }
     },
     {
@@ -12702,21 +12702,21 @@
         "BelegteBetten": null,
         "Inzidenz": 96.3,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 88.5,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 43,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 281,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 127.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 370,
+        "Zuwachs_Mutation": 48
       }
     },
     {
@@ -12740,16 +12740,16 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 89.3,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 41,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 279,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": null,
+        "Krh_I_covid": 33,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 133.8,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 416,
+        "Zuwachs_Mutation": 46
       }
     },
     {
@@ -12759,17 +12759,17 @@
         "ObjectId": 380,
         "Sterbefall": 961,
         "Genesungsfall": 21450,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2093,
         "Zuwachs_Fallzahl": 75,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 4,
         "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
-        "Inzidenz": 105.1,
+        "Inzidenz": 105.068429182083,
         "Datum_neu": 1616284800000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "14.03.2021 - 20.03.2021",
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 92.7,
         "Fallzahl_aktiv": 1200,
@@ -12784,6 +12784,39 @@
         "Mutation": 430,
         "Zuwachs_Mutation": 14
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.03.2021",
+        "Fallzahl": 23627,
+        "ObjectId": 381,
+        "Sterbefall": 964,
+        "Genesungsfall": 21553,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2109,
+        "Zuwachs_Fallzahl": 16,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 103,
+        "BelegteBetten": null,
+        "Inzidenz": 105.966449944323,
+        "Datum_neu": 1616371200000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "15.03.2021 - 21.03.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 105.1,
+        "Fallzahl_aktiv": 1110,
+        "Krh_I_belegt": 231,
+        "Krh_I_frei": 47,
+        "Fallzahl_aktiv_Zuwachs": -90,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 33,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 158.8,
+        "Mutation": 439,
+        "Zuwachs_Mutation": 9
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
