### PR TITLE
New data set: 2021-03-23T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-22T111603Z.json
+pjson/2021-03-23T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-22T111603Z.json pjson/2021-03-23T110903Z.json```:
```
--- pjson/2021-03-22T111603Z.json	2021-03-22 11:16:03.657377957 +0000
+++ pjson/2021-03-23T110903Z.json	2021-03-23 11:09:03.341530390 +0000
@@ -9336,7 +9336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 378,
+        "F\u00e4lle_Meldedatum": 377,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -11780,7 +11780,7 @@
         "Datum_neu": 1613692800000,
         "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11846,7 +11846,7 @@
         "Datum_neu": 1613865600000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11910,7 +11910,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614038400000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -12110,7 +12110,7 @@
         "Datum_neu": 1614556800000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 104,
-        "Zuwachs_Mutation": 5
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12341,7 +12341,7 @@
         "Datum_neu": 1615161600000,
         "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 105,
-        "Zuwachs_Mutation": 1
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12374,7 +12374,7 @@
         "Datum_neu": 1615248000000,
         "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 118,
-        "Zuwachs_Mutation": 13
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12407,7 +12407,7 @@
         "Datum_neu": 1615334400000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 138,
-        "Zuwachs_Mutation": 20
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 146,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12473,7 +12473,7 @@
         "Datum_neu": 1615507200000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 173,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 206,
-        "Zuwachs_Mutation": 33
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 210,
-        "Zuwachs_Mutation": 4
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12568,12 +12568,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 36,
         "BelegteBetten": null,
-        "Inzidenz": 88.7244513093143,
+        "Inzidenz": null,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 87.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12582,9 +12582,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
-        "Inzi_SN_RKI": 112.9,
-        "Mutation": 212,
-        "Zuwachs_Mutation": 2
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 71.3,
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 110,
-        "Mutation": 240,
-        "Zuwachs_Mutation": 28
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 109.1,
-        "Mutation": 284,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12669,21 +12669,21 @@
         "BelegteBetten": null,
         "Inzidenz": 98.9618879988505,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 81.6,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 227,
-        "Krh_I_frei": 54,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 109.7,
-        "Mutation": 322,
-        "Zuwachs_Mutation": 38
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12702,21 +12702,21 @@
         "BelegteBetten": null,
         "Inzidenz": 96.3,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 88.5,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 127.1,
-        "Mutation": 370,
-        "Zuwachs_Mutation": 48
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12735,21 +12735,21 @@
         "BelegteBetten": null,
         "Inzidenz": 101.5,
         "Datum_neu": 1616198400000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 89.3,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 41,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 279,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 33,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 133.8,
-        "Mutation": 416,
-        "Zuwachs_Mutation": 46
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12757,32 +12757,32 @@
         "Datum": "21.03.2021",
         "Fallzahl": 23611,
         "ObjectId": 380,
-        "Sterbefall": 961,
-        "Genesungsfall": 21450,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2093,
-        "Zuwachs_Fallzahl": 75,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
         "Inzidenz": 105.068429182083,
         "Datum_neu": 1616284800000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 92.7,
-        "Fallzahl_aktiv": 1200,
-        "Krh_I_belegt": 231,
-        "Krh_I_frei": 43,
-        "Fallzahl_aktiv_Zuwachs": 58,
-        "Krh_I": 274,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 35,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 145.2,
-        "Mutation": 430,
-        "Zuwachs_Mutation": 14
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12790,32 +12790,65 @@
         "Datum": "22.03.2021",
         "Fallzahl": 23627,
         "ObjectId": 381,
-        "Sterbefall": 964,
-        "Genesungsfall": 21553,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2109,
-        "Zuwachs_Fallzahl": 16,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 103,
         "BelegteBetten": null,
         "Inzidenz": 105.966449944323,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "15.03.2021 - 21.03.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 67,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 105.1,
-        "Fallzahl_aktiv": 1110,
-        "Krh_I_belegt": 231,
-        "Krh_I_frei": 47,
-        "Fallzahl_aktiv_Zuwachs": -90,
-        "Krh_I": 278,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 33,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 158.8,
-        "Mutation": 439,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.03.2021",
+        "Fallzahl": 23772,
+        "ObjectId": 382,
+        "Sterbefall": 964,
+        "Genesungsfall": 21642,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2130,
+        "Zuwachs_Fallzahl": 145,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 89,
+        "BelegteBetten": null,
+        "Inzidenz": 103.6,
+        "Datum_neu": 1616457600000,
+        "F\u00e4lle_Meldedatum": 73,
+        "Zeitraum": "16.03.2021 - 22.03.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 93.2,
+        "Fallzahl_aktiv": 1166,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 42,
+        "Fallzahl_aktiv_Zuwachs": 56,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 34,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 156.1,
+        "Mutation": 469,
+        "Zuwachs_Mutation": 30
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
