### PR TITLE
New data set: 2021-03-24T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-23T110903Z.json
+pjson/2021-03-24T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-23T110903Z.json pjson/2021-03-24T110403Z.json```:
```
--- pjson/2021-03-23T110903Z.json	2021-03-23 11:09:03.341530390 +0000
+++ pjson/2021-03-24T110403Z.json	2021-03-24 11:04:03.441352295 +0000
@@ -11910,7 +11910,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614038400000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -12341,7 +12341,7 @@
         "Datum_neu": 1615161600000,
         "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12438,7 +12438,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12471,7 +12471,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -12570,7 +12570,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12601,12 +12601,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 84.7731599554582,
+        "Inzidenz": null,
         "Datum_neu": 1615852800000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 71.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12615,7 +12615,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 110,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -12669,7 +12669,7 @@
         "BelegteBetten": null,
         "Inzidenz": 98.9618879988505,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 81.6,
@@ -12702,9 +12702,9 @@
         "BelegteBetten": null,
         "Inzidenz": 96.3,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 88.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12735,7 +12735,7 @@
         "BelegteBetten": null,
         "Inzidenz": 101.5,
         "Datum_neu": 1616198400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 89.3,
@@ -12768,7 +12768,7 @@
         "BelegteBetten": null,
         "Inzidenz": 105.068429182083,
         "Datum_neu": 1616284800000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 92.7,
@@ -12801,9 +12801,9 @@
         "BelegteBetten": null,
         "Inzidenz": 105.966449944323,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 105.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12823,32 +12823,65 @@
         "Datum": "23.03.2021",
         "Fallzahl": 23772,
         "ObjectId": 382,
-        "Sterbefall": 964,
-        "Genesungsfall": 21642,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2130,
-        "Zuwachs_Fallzahl": 145,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 89,
         "BelegteBetten": null,
         "Inzidenz": 103.6,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 73,
-        "Zeitraum": "16.03.2021 - 22.03.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 133,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 93.2,
-        "Fallzahl_aktiv": 1166,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 156.1,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.03.2021",
+        "Fallzahl": 23946,
+        "ObjectId": 383,
+        "Sterbefall": 964,
+        "Genesungsfall": 21718,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2143,
+        "Zuwachs_Fallzahl": 174,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 76,
+        "BelegteBetten": null,
+        "Inzidenz": 112.1,
+        "Datum_neu": 1616544000000,
+        "F\u00e4lle_Meldedatum": 75,
+        "Zeitraum": "17.03.2021 - 23.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 95.5,
+        "Fallzahl_aktiv": 1264,
         "Krh_I_belegt": 236,
         "Krh_I_frei": 42,
-        "Fallzahl_aktiv_Zuwachs": 56,
+        "Fallzahl_aktiv_Zuwachs": 98,
         "Krh_I": 278,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 34,
+        "Krh_I_covid": 35,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 156.1,
-        "Mutation": 469,
-        "Zuwachs_Mutation": 30
+        "Inzi_SN_RKI": 154.6,
+        "Mutation": 534,
+        "Zuwachs_Mutation": 65
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
