### PR TITLE
New data set: 2021-03-25T110303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-24T110403Z.json
+pjson/2021-03-25T110303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-24T110403Z.json pjson/2021-03-25T110303Z.json```:
```
--- pjson/2021-03-24T110403Z.json	2021-03-24 11:04:03.441352295 +0000
+++ pjson/2021-03-25T110303Z.json	2021-03-25 11:03:03.635667882 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -8940,7 +8940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 271,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -12141,7 +12141,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614643200000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 96,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12284,10 +12284,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 99,
+        "Zuwachs_Mutation": 3
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 104,
+        "Zuwachs_Mutation": 5
       }
     },
     {
@@ -12341,7 +12341,7 @@
         "Datum_neu": 1615161600000,
         "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 105,
+        "Zuwachs_Mutation": 1
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 118,
+        "Zuwachs_Mutation": 13
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 138,
+        "Zuwachs_Mutation": 20
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 146,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -12482,10 +12482,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 173,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 206,
+        "Zuwachs_Mutation": 33
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 210,
+        "Zuwachs_Mutation": 4
       }
     },
     {
@@ -12570,7 +12570,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12581,10 +12581,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 212,
+        "Zuwachs_Mutation": 2
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 240,
+        "Zuwachs_Mutation": 28
       }
     },
     {
@@ -12634,12 +12634,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 63,
         "BelegteBetten": null,
-        "Inzidenz": 91.5981177484824,
+        "Inzidenz": null,
         "Datum_neu": 1615939200000,
         "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 71.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12647,10 +12647,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 109.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": 284,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -12669,21 +12669,21 @@
         "BelegteBetten": null,
         "Inzidenz": 98.9618879988505,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 81.6,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 227,
+        "Krh_I_frei": 54,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 281,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 109.7,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 322,
+        "Zuwachs_Mutation": 38
       }
     },
     {
@@ -12702,21 +12702,21 @@
         "BelegteBetten": null,
         "Inzidenz": 96.3,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 88.5,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 43,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 281,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 127.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 370,
+        "Zuwachs_Mutation": 48
       }
     },
     {
@@ -12740,16 +12740,16 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 89.3,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 41,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 279,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": null,
+        "Krh_I_covid": 33,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 133.8,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 416,
+        "Zuwachs_Mutation": 46
       }
     },
     {
@@ -12768,21 +12768,21 @@
         "BelegteBetten": null,
         "Inzidenz": 105.068429182083,
         "Datum_neu": 1616284800000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 92.7,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 231,
+        "Krh_I_frei": 43,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 274,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": null,
+        "Krh_I_covid": 35,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 145.2,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 430,
+        "Zuwachs_Mutation": 14
       }
     },
     {
@@ -12801,21 +12801,21 @@
         "BelegteBetten": null,
         "Inzidenz": 105.966449944323,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 105.1,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 231,
+        "Krh_I_frei": 47,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 278,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": null,
+        "Krh_I_covid": 33,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 158.8,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 439,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12832,23 +12832,23 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 89,
         "BelegteBetten": null,
-        "Inzidenz": 103.6,
+        "Inzidenz": 103.631595962499,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 93.2,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": null,
-        "Krh_I_frei": null,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 42,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": null,
+        "Krh_I": 278,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "Krh_I_covid": 34,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 156.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 469,
+        "Zuwachs_Mutation": 30
       }
     },
     {
@@ -12858,18 +12858,18 @@
         "ObjectId": 383,
         "Sterbefall": 964,
         "Genesungsfall": 21718,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2143,
         "Zuwachs_Fallzahl": 174,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 13,
         "Zuwachs_Genesung": 76,
         "BelegteBetten": null,
-        "Inzidenz": 112.1,
+        "Inzidenz": 112.072991127555,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 75,
-        "Zeitraum": "17.03.2021 - 23.03.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 100,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 95.5,
         "Fallzahl_aktiv": 1264,
         "Krh_I_belegt": 236,
@@ -12883,6 +12883,39 @@
         "Mutation": 534,
         "Zuwachs_Mutation": 65
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.03.2021",
+        "Fallzahl": 24079,
+        "ObjectId": 384,
+        "Sterbefall": 971,
+        "Genesungsfall": 21788,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2149,
+        "Zuwachs_Fallzahl": 133,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 70,
+        "BelegteBetten": null,
+        "Inzidenz": 118.359136463235,
+        "Datum_neu": 1616630400000,
+        "F\u00e4lle_Meldedatum": 56,
+        "Zeitraum": "18.03.2021 - 24.03.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 106,
+        "Fallzahl_aktiv": 1320,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 42,
+        "Fallzahl_aktiv_Zuwachs": 56,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 32,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 167.3,
+        "Mutation": 626,
+        "Zuwachs_Mutation": 92
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
