### PR TITLE
New data set: 2021-03-26T110503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-25T110303Z.json
+pjson/2021-03-26T110503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-25T110303Z.json pjson/2021-03-26T110503Z.json```:
```
--- pjson/2021-03-25T110303Z.json	2021-03-25 11:03:03.635667882 +0000
+++ pjson/2021-03-26T110503Z.json	2021-03-26 11:05:03.691843966 +0000
@@ -12306,7 +12306,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615075200000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -12339,7 +12339,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -12416,7 +12416,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 138,
         "Zuwachs_Mutation": 20
@@ -12438,7 +12438,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12471,7 +12471,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -12570,7 +12570,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12581,7 +12581,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": 212,
         "Zuwachs_Mutation": 2
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12636,7 +12636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -12647,7 +12647,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 284,
         "Zuwachs_Mutation": 44
@@ -12667,21 +12667,21 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
-        "Inzidenz": 98.9618879988505,
+        "Inzidenz": null,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 81.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 227,
-        "Krh_I_frei": 54,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 109.7,
+        "Inzi_SN_RKI": null,
         "Mutation": 322,
         "Zuwachs_Mutation": 38
       }
@@ -12702,7 +12702,7 @@
         "BelegteBetten": null,
         "Inzidenz": 96.3,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 88.5,
@@ -12735,7 +12735,7 @@
         "BelegteBetten": null,
         "Inzidenz": 101.5,
         "Datum_neu": 1616198400000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 89.3,
@@ -12768,7 +12768,7 @@
         "BelegteBetten": null,
         "Inzidenz": 105.068429182083,
         "Datum_neu": 1616284800000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 92.7,
@@ -12779,7 +12779,7 @@
         "Krh_I": 274,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 35,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 145.2,
         "Mutation": 430,
         "Zuwachs_Mutation": 14
@@ -12801,7 +12801,7 @@
         "BelegteBetten": null,
         "Inzidenz": 105.966449944323,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 105.1,
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": 103.631595962499,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 93.2,
@@ -12845,7 +12845,7 @@
         "Krh_I": 278,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 34,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 156.1,
         "Mutation": 469,
         "Zuwachs_Mutation": 30
@@ -12856,27 +12856,27 @@
         "Datum": "24.03.2021",
         "Fallzahl": 23946,
         "ObjectId": 383,
-        "Sterbefall": 964,
-        "Genesungsfall": 21718,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2143,
-        "Zuwachs_Fallzahl": 174,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 76,
         "BelegteBetten": null,
         "Inzidenz": 112.072991127555,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 95.5,
-        "Fallzahl_aktiv": 1264,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": 236,
         "Krh_I_frei": 42,
-        "Fallzahl_aktiv_Zuwachs": 98,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": 278,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": 35,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 154.6,
@@ -12891,7 +12891,7 @@
         "ObjectId": 384,
         "Sterbefall": 971,
         "Genesungsfall": 21788,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2149,
         "Zuwachs_Fallzahl": 133,
         "Zuwachs_Sterbefall": 7,
@@ -12900,8 +12900,8 @@
         "BelegteBetten": null,
         "Inzidenz": 118.359136463235,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 56,
-        "Zeitraum": "18.03.2021 - 24.03.2021",
+        "F\u00e4lle_Meldedatum": 169,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 106,
         "Fallzahl_aktiv": 1320,
@@ -12916,6 +12916,39 @@
         "Mutation": 626,
         "Zuwachs_Mutation": 92
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.03.2021",
+        "Fallzahl": 24254,
+        "ObjectId": 385,
+        "Sterbefall": 977,
+        "Genesungsfall": 21871,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2152,
+        "Zuwachs_Fallzahl": 175,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 83,
+        "BelegteBetten": null,
+        "Inzidenz": 134.343906031107,
+        "Datum_neu": 1616716800000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "19.03.2021 - 25.03.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 107.9,
+        "Fallzahl_aktiv": 1406,
+        "Krh_I_belegt": 239,
+        "Krh_I_frei": 39,
+        "Fallzahl_aktiv_Zuwachs": 86,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 34,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 169.1,
+        "Mutation": 707,
+        "Zuwachs_Mutation": 81
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
