### PR TITLE
New data set: 2021-03-27T110803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-26T110503Z.json
+pjson/2021-03-27T110803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-26T110503Z.json pjson/2021-03-27T110803Z.json```:
```
--- pjson/2021-03-26T110503Z.json	2021-03-26 11:05:03.691843966 +0000
+++ pjson/2021-03-27T110803Z.json	2021-03-27 11:08:04.035351095 +0000
@@ -10788,7 +10788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -12405,7 +12405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615334400000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -12581,7 +12581,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": 212,
         "Zuwachs_Mutation": 2
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12669,7 +12669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -12700,21 +12700,21 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 58,
         "BelegteBetten": null,
-        "Inzidenz": 96.3,
+        "Inzidenz": null,
         "Datum_neu": 1616112000000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 88.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 127.1,
+        "Inzi_SN_RKI": null,
         "Mutation": 370,
         "Zuwachs_Mutation": 48
       }
@@ -12740,13 +12740,13 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 89.3,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 41,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 279,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 33,
-        "SterbeF_Sterbedatum": 0,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 133.8,
         "Mutation": 416,
         "Zuwachs_Mutation": 46
@@ -12773,12 +12773,12 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 92.7,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 231,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 274,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 35,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 145.2,
         "Mutation": 430,
@@ -12801,18 +12801,18 @@
         "BelegteBetten": null,
         "Inzidenz": 105.966449944323,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 105.1,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 231,
-        "Krh_I_frei": 47,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 33,
-        "SterbeF_Sterbedatum": 0,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 158.8,
         "Mutation": 439,
         "Zuwachs_Mutation": 9
@@ -12834,17 +12834,17 @@
         "BelegteBetten": null,
         "Inzidenz": 103.631595962499,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 93.2,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 42,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 34,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 156.1,
         "Mutation": 469,
@@ -12867,17 +12867,17 @@
         "BelegteBetten": null,
         "Inzidenz": 112.072991127555,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 95.5,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 42,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 35,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 154.6,
         "Mutation": 534,
@@ -12889,29 +12889,29 @@
         "Datum": "25.03.2021",
         "Fallzahl": 24079,
         "ObjectId": 384,
-        "Sterbefall": 971,
-        "Genesungsfall": 21788,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2149,
-        "Zuwachs_Fallzahl": 133,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 70,
         "BelegteBetten": null,
         "Inzidenz": 118.359136463235,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 169,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 106,
-        "Fallzahl_aktiv": 1320,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 42,
-        "Fallzahl_aktiv_Zuwachs": 56,
-        "Krh_I": 278,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 32,
-        "SterbeF_Sterbedatum": 0,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 167.3,
         "Mutation": 626,
         "Zuwachs_Mutation": 92
@@ -12924,7 +12924,7 @@
         "ObjectId": 385,
         "Sterbefall": 977,
         "Genesungsfall": 21871,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2152,
         "Zuwachs_Fallzahl": 175,
         "Zuwachs_Sterbefall": 6,
@@ -12933,22 +12933,55 @@
         "BelegteBetten": null,
         "Inzidenz": 134.343906031107,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "19.03.2021 - 25.03.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 107,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 107.9,
         "Fallzahl_aktiv": 1406,
-        "Krh_I_belegt": 239,
-        "Krh_I_frei": 39,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 86,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 34,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 169.1,
         "Mutation": 707,
         "Zuwachs_Mutation": 81
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.03.2021",
+        "Fallzahl": 24346,
+        "ObjectId": 386,
+        "Sterbefall": 981,
+        "Genesungsfall": 21922,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2154,
+        "Zuwachs_Fallzahl": 92,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 51,
+        "BelegteBetten": null,
+        "Inzidenz": 135.780739250691,
+        "Datum_neu": 1616803200000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "20.03.2021 - 26.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 121.6,
+        "Fallzahl_aktiv": 1443,
+        "Krh_I_belegt": 240,
+        "Krh_I_frei": 38,
+        "Fallzahl_aktiv_Zuwachs": 37,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 37,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 176.4,
+        "Mutation": 751,
+        "Zuwachs_Mutation": 44
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
