### PR TITLE
New data set: 2021-03-28T100204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-27T110803Z.json
+pjson/2021-03-28T100204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-27T110803Z.json pjson/2021-03-28T100204Z.json```:
```
--- pjson/2021-03-27T110803Z.json	2021-03-27 11:08:04.035351095 +0000
+++ pjson/2021-03-28T100204Z.json	2021-03-28 10:02:04.431835867 +0000
@@ -9699,7 +9699,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -11778,7 +11778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613692800000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12636,7 +12636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -12702,7 +12702,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -12733,12 +12733,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
-        "Inzidenz": 101.5,
+        "Inzidenz": null,
         "Datum_neu": 1616198400000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 89.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12747,7 +12747,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 133.8,
+        "Inzi_SN_RKI": null,
         "Mutation": 416,
         "Zuwachs_Mutation": 46
       }
@@ -12801,7 +12801,7 @@
         "BelegteBetten": null,
         "Inzidenz": 105.966449944323,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 105.1,
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": 103.631595962499,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 93.2,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": 112.072991127555,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 95.5,
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": 118.359136463235,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 106,
@@ -12922,27 +12922,27 @@
         "Datum": "26.03.2021",
         "Fallzahl": 24254,
         "ObjectId": 385,
-        "Sterbefall": 977,
-        "Genesungsfall": 21871,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2152,
-        "Zuwachs_Fallzahl": 175,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
         "Inzidenz": 134.343906031107,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 107.9,
-        "Fallzahl_aktiv": 1406,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 86,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 169.1,
@@ -12957,7 +12957,7 @@
         "ObjectId": 386,
         "Sterbefall": 981,
         "Genesungsfall": 21922,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2154,
         "Zuwachs_Fallzahl": 92,
         "Zuwachs_Sterbefall": 4,
@@ -12966,22 +12966,55 @@
         "BelegteBetten": null,
         "Inzidenz": 135.780739250691,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "20.03.2021 - 26.03.2021",
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 121.6,
         "Fallzahl_aktiv": 1443,
-        "Krh_I_belegt": 240,
-        "Krh_I_frei": 38,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 37,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 37,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 176.4,
         "Mutation": 751,
         "Zuwachs_Mutation": 44
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.03.2021",
+        "Fallzahl": 24438,
+        "ObjectId": 387,
+        "Sterbefall": 981,
+        "Genesungsfall": 21939,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2154,
+        "Zuwachs_Fallzahl": 92,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 17,
+        "BelegteBetten": null,
+        "Inzidenz": 141.34846797658,
+        "Datum_neu": 1616889600000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "21.03.2021 - 27.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 125,
+        "Fallzahl_aktiv": 1518,
+        "Krh_I_belegt": 249,
+        "Krh_I_frei": 29,
+        "Fallzahl_aktiv_Zuwachs": 75,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 37,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 183,
+        "Mutation": 778,
+        "Zuwachs_Mutation": 27
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
