### PR TITLE
New data set: 2021-03-29T102303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-28T100204Z.json
+pjson/2021-03-29T102303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-28T100204Z.json pjson/2021-03-29T102303Z.json```:
```
--- pjson/2021-03-28T100204Z.json	2021-03-28 10:02:04.431835867 +0000
+++ pjson/2021-03-29T102303Z.json	2021-03-29 10:23:03.754059774 +0000
@@ -8078,7 +8078,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 28,
+        "Zuwachs_Genesung": 54,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604016000000,
@@ -9138,9 +9138,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 331,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10073,7 +10073,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12,
+        "SterbeF_Sterbedatum": 13,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -11250,7 +11250,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -11912,7 +11912,7 @@
         "Datum_neu": 1614038400000,
         "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12515,7 +12515,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": 206,
         "Zuwachs_Mutation": 33
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12704,7 +12704,7 @@
         "Datum_neu": 1616112000000,
         "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12737,7 +12737,7 @@
         "Datum_neu": 1616198400000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12766,12 +12766,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
-        "Inzidenz": 105.068429182083,
+        "Inzidenz": null,
         "Datum_neu": 1616284800000,
         "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 92.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12780,7 +12780,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 145.2,
+        "Inzi_SN_RKI": null,
         "Mutation": 430,
         "Zuwachs_Mutation": 14
       }
@@ -12869,7 +12869,7 @@
         "Datum_neu": 1616544000000,
         "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 95.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12900,9 +12900,9 @@
         "BelegteBetten": null,
         "Inzidenz": 118.359136463235,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 106,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12935,7 +12935,7 @@
         "Datum_neu": 1616716800000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 107.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12955,27 +12955,27 @@
         "Datum": "27.03.2021",
         "Fallzahl": 24346,
         "ObjectId": 386,
-        "Sterbefall": 981,
-        "Genesungsfall": 21922,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2154,
-        "Zuwachs_Fallzahl": 92,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": 135.780739250691,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 121.6,
-        "Fallzahl_aktiv": 1443,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 37,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 176.4,
@@ -12990,7 +12990,7 @@
         "ObjectId": 387,
         "Sterbefall": 981,
         "Genesungsfall": 21939,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2154,
         "Zuwachs_Fallzahl": 92,
         "Zuwachs_Sterbefall": 0,
@@ -12999,8 +12999,8 @@
         "BelegteBetten": null,
         "Inzidenz": 141.34846797658,
         "Datum_neu": 1616889600000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "21.03.2021 - 27.03.2021",
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 125,
         "Fallzahl_aktiv": 1518,
@@ -13009,12 +13009,45 @@
         "Fallzahl_aktiv_Zuwachs": 75,
         "Krh_I": 278,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 37,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 183,
         "Mutation": 778,
         "Zuwachs_Mutation": 27
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.03.2021",
+        "Fallzahl": 24465,
+        "ObjectId": 388,
+        "Sterbefall": 983,
+        "Genesungsfall": 22046,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2169,
+        "Zuwachs_Fallzahl": 27,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 107,
+        "BelegteBetten": null,
+        "Inzidenz": 140.091238909444,
+        "Datum_neu": 1616976000000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "22.03.2021 - 28.03.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 137.6,
+        "Fallzahl_aktiv": 1436,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 42,
+        "Fallzahl_aktiv_Zuwachs": -82,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 35,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 200.4,
+        "Mutation": 786,
+        "Zuwachs_Mutation": 8
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
