### PR TITLE
New data set: 2021-03-30T102003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-29T102303Z.json
+pjson/2021-03-30T102003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-29T102303Z.json pjson/2021-03-30T102003Z.json```:
```
--- pjson/2021-03-29T102303Z.json	2021-03-29 10:23:03.754059774 +0000
+++ pjson/2021-03-30T102003Z.json	2021-03-30 10:20:03.655227225 +0000
@@ -8214,7 +8214,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604361600000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -10095,7 +10095,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 449,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -10392,7 +10392,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -10524,7 +10524,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 270,
+        "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -12341,7 +12341,7 @@
         "Datum_neu": 1615161600000,
         "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12570,7 +12570,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12614,7 +12614,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 240,
         "Zuwachs_Mutation": 28
@@ -12636,7 +12636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -12702,7 +12702,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -12713,7 +12713,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": 370,
         "Zuwachs_Mutation": 48
@@ -12799,12 +12799,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 103,
         "BelegteBetten": null,
-        "Inzidenz": 105.966449944323,
+        "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 105.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12813,7 +12813,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 158.8,
+        "Inzi_SN_RKI": null,
         "Mutation": 439,
         "Zuwachs_Mutation": 9
       }
@@ -12834,9 +12834,9 @@
         "BelegteBetten": null,
         "Inzidenz": 103.631595962499,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 93.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": 112.072991127555,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 95.5,
@@ -12900,9 +12900,9 @@
         "BelegteBetten": null,
         "Inzidenz": 118.359136463235,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 106,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12933,7 +12933,7 @@
         "BelegteBetten": null,
         "Inzidenz": 134.343906031107,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 107.9,
@@ -12966,9 +12966,9 @@
         "BelegteBetten": null,
         "Inzidenz": 135.780739250691,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 121.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12988,27 +12988,27 @@
         "Datum": "28.03.2021",
         "Fallzahl": 24438,
         "ObjectId": 387,
-        "Sterbefall": 981,
-        "Genesungsfall": 21939,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2154,
-        "Zuwachs_Fallzahl": 92,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
         "Inzidenz": 141.34846797658,
         "Datum_neu": 1616889600000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 125,
-        "Fallzahl_aktiv": 1518,
-        "Krh_I_belegt": 249,
-        "Krh_I_frei": 29,
-        "Fallzahl_aktiv_Zuwachs": 75,
-        "Krh_I": 278,
-        "Vorz_akt_Faelle": "+",
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 183,
@@ -13023,7 +13023,7 @@
         "ObjectId": 388,
         "Sterbefall": 983,
         "Genesungsfall": 22046,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2169,
         "Zuwachs_Fallzahl": 27,
         "Zuwachs_Sterbefall": 2,
@@ -13032,9 +13032,9 @@
         "BelegteBetten": null,
         "Inzidenz": 140.091238909444,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "22.03.2021 - 28.03.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 118,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 137.6,
         "Fallzahl_aktiv": 1436,
         "Krh_I_belegt": 236,
@@ -13042,12 +13042,45 @@
         "Fallzahl_aktiv_Zuwachs": -82,
         "Krh_I": 278,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 35,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 200.4,
         "Mutation": 786,
         "Zuwachs_Mutation": 8
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.03.2021",
+        "Fallzahl": 24641,
+        "ObjectId": 389,
+        "Sterbefall": 985,
+        "Genesungsfall": 22161,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2188,
+        "Zuwachs_Fallzahl": 176,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 115,
+        "BelegteBetten": null,
+        "Inzidenz": 142.24648873882,
+        "Datum_neu": 1617062400000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "23.03.2021 - 29.03.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 118.9,
+        "Fallzahl_aktiv": 1495,
+        "Krh_I_belegt": 241,
+        "Krh_I_frei": 37,
+        "Fallzahl_aktiv_Zuwachs": 59,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 36,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 193.4,
+        "Mutation": 893,
+        "Zuwachs_Mutation": 107
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
