### PR TITLE
New data set: 2021-03-31T100404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-30T102003Z.json
+pjson/2021-03-31T100404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-30T102003Z.json pjson/2021-03-31T100404Z.json```:
```
--- pjson/2021-03-30T102003Z.json	2021-03-30 10:20:03.655227225 +0000
+++ pjson/2021-03-31T100404Z.json	2021-03-31 10:04:04.145734076 +0000
@@ -9138,7 +9138,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -11283,7 +11283,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12570,7 +12570,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12614,7 +12614,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 240,
         "Zuwachs_Mutation": 28
@@ -12702,7 +12702,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -12801,7 +12801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12812,7 +12812,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 439,
         "Zuwachs_Mutation": 9
@@ -12832,12 +12832,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 89,
         "BelegteBetten": null,
-        "Inzidenz": 103.631595962499,
+        "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 161,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 93.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12846,7 +12846,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 156.1,
+        "Inzi_SN_RKI": null,
         "Mutation": 469,
         "Zuwachs_Mutation": 30
       }
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": 112.072991127555,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 95.5,
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": 118.359136463235,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 106,
@@ -12933,9 +12933,9 @@
         "BelegteBetten": null,
         "Inzidenz": 134.343906031107,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 107.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12966,7 +12966,7 @@
         "BelegteBetten": null,
         "Inzidenz": 135.780739250691,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 121.6,
@@ -12999,7 +12999,7 @@
         "BelegteBetten": null,
         "Inzidenz": 141.34846797658,
         "Datum_neu": 1616889600000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 125,
@@ -13021,26 +13021,26 @@
         "Datum": "29.03.2021",
         "Fallzahl": 24465,
         "ObjectId": 388,
-        "Sterbefall": 983,
-        "Genesungsfall": 22046,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2169,
-        "Zuwachs_Fallzahl": 27,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 107,
         "BelegteBetten": null,
         "Inzidenz": 140.091238909444,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 137.6,
-        "Fallzahl_aktiv": 1436,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 42,
-        "Fallzahl_aktiv_Zuwachs": -82,
-        "Krh_I": 278,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
@@ -13056,7 +13056,7 @@
         "ObjectId": 389,
         "Sterbefall": 985,
         "Genesungsfall": 22161,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2188,
         "Zuwachs_Fallzahl": 176,
         "Zuwachs_Sterbefall": 2,
@@ -13065,22 +13065,55 @@
         "BelegteBetten": null,
         "Inzidenz": 142.24648873882,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "23.03.2021 - 29.03.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 205,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 118.9,
         "Fallzahl_aktiv": 1495,
-        "Krh_I_belegt": 241,
-        "Krh_I_frei": 37,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 59,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 36,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
         "Mutation": 893,
         "Zuwachs_Mutation": 107
       }
+    },
+    {
+      "attributes": {
+        "Datum": "31.03.2021",
+        "Fallzahl": 24844,
+        "ObjectId": 390,
+        "Sterbefall": 987,
+        "Genesungsfall": 22279,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2198,
+        "Zuwachs_Fallzahl": 203,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 118,
+        "BelegteBetten": null,
+        "Inzidenz": 150.149071446532,
+        "Datum_neu": 1617148800000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "24.03.2021 - 30.03.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 115.5,
+        "Fallzahl_aktiv": 1578,
+        "Krh_I_belegt": 245,
+        "Krh_I_frei": 35,
+        "Fallzahl_aktiv_Zuwachs": 83,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 38,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 182.3,
+        "Mutation": 975,
+        "Zuwachs_Mutation": 82
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
