### PR TITLE
New data set: 2021-04-01T100902Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-03-31T100404Z.json
+pjson/2021-04-01T100902Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-03-31T100404Z.json pjson/2021-04-01T100902Z.json```:
```
--- pjson/2021-03-31T100404Z.json	2021-03-31 10:04:04.145734076 +0000
+++ pjson/2021-04-01T100902Z.json	2021-04-01 10:09:02.993462598 +0000
@@ -7950,7 +7950,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -9173,7 +9173,7 @@
         "Datum_neu": 1606867200000,
         "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9371,7 +9371,7 @@
         "Datum_neu": 1607385600000,
         "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9635,7 +9635,7 @@
         "Datum_neu": 1608076800000,
         "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 38,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9699,7 +9699,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 461,
+        "F\u00e4lle_Meldedatum": 462,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12702,7 +12702,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -12801,7 +12801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 161,
+        "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12865,12 +12865,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 76,
         "BelegteBetten": null,
-        "Inzidenz": 112.072991127555,
+        "Inzidenz": null,
         "Datum_neu": 1616544000000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 95.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12879,7 +12879,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 154.6,
+        "Inzi_SN_RKI": null,
         "Mutation": 534,
         "Zuwachs_Mutation": 65
       }
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": 118.359136463235,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 106,
@@ -12933,7 +12933,7 @@
         "BelegteBetten": null,
         "Inzidenz": 134.343906031107,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 107.9,
@@ -13032,7 +13032,7 @@
         "BelegteBetten": null,
         "Inzidenz": 140.091238909444,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 137.6,
@@ -13054,27 +13054,27 @@
         "Datum": "30.03.2021",
         "Fallzahl": 24641,
         "ObjectId": 389,
-        "Sterbefall": 985,
-        "Genesungsfall": 22161,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2188,
-        "Zuwachs_Fallzahl": 176,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 115,
         "BelegteBetten": null,
         "Inzidenz": 142.24648873882,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 118.9,
-        "Fallzahl_aktiv": 1495,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 59,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
@@ -13089,7 +13089,7 @@
         "ObjectId": 390,
         "Sterbefall": 987,
         "Genesungsfall": 22279,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2198,
         "Zuwachs_Fallzahl": 203,
         "Zuwachs_Sterbefall": 2,
@@ -13098,9 +13098,9 @@
         "BelegteBetten": null,
         "Inzidenz": 150.149071446532,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "24.03.2021 - 30.03.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 62,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 115.5,
         "Fallzahl_aktiv": 1578,
         "Krh_I_belegt": 245,
@@ -13114,6 +13114,39 @@
         "Mutation": 975,
         "Zuwachs_Mutation": 82
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.04.2021",
+        "Fallzahl": 24988,
+        "ObjectId": 391,
+        "Sterbefall": 987,
+        "Genesungsfall": 22392,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2212,
+        "Zuwachs_Fallzahl": 144,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 113,
+        "BelegteBetten": null,
+        "Inzidenz": 146.556988397572,
+        "Datum_neu": 1617235200000,
+        "F\u00e4lle_Meldedatum": 82,
+        "Zeitraum": "25.03.2021 - 31.03.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 137.2,
+        "Fallzahl_aktiv": 1609,
+        "Krh_I_belegt": 246,
+        "Krh_I_frei": 32,
+        "Fallzahl_aktiv_Zuwachs": 31,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 35,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 190.3,
+        "Mutation": 1087,
+        "Zuwachs_Mutation": 112
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
