### PR TITLE
New data set: 2021-04-02T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-01T100902Z.json
+pjson/2021-04-02T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-01T100902Z.json pjson/2021-04-02T100903Z.json```:
```
--- pjson/2021-04-01T100902Z.json	2021-04-01 10:09:02.993462598 +0000
+++ pjson/2021-04-02T100903Z.json	2021-04-02 10:09:03.114601704 +0000
@@ -9435,7 +9435,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 464,
+        "F\u00e4lle_Meldedatum": 465,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10095,7 +10095,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -10722,7 +10722,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 104,
-        "Zuwachs_Mutation": 5
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 105,
-        "Zuwachs_Mutation": 1
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 118,
-        "Zuwachs_Mutation": 13
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 138,
-        "Zuwachs_Mutation": 20
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 146,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 173,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 206,
-        "Zuwachs_Mutation": 33
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 210,
-        "Zuwachs_Mutation": 4
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": 212,
-        "Zuwachs_Mutation": 2
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 240,
-        "Zuwachs_Mutation": 28
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 284,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12682,8 +12682,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 322,
-        "Zuwachs_Mutation": 38
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12715,8 +12715,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 370,
-        "Zuwachs_Mutation": 48
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12748,8 +12748,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 416,
-        "Zuwachs_Mutation": 46
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12781,8 +12781,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 430,
-        "Zuwachs_Mutation": 14
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12801,7 +12801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12814,8 +12814,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 439,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 168,
+        "F\u00e4lle_Meldedatum": 169,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12847,8 +12847,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 469,
-        "Zuwachs_Mutation": 30
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12880,8 +12880,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 534,
-        "Zuwachs_Mutation": 65
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12898,12 +12898,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 70,
         "BelegteBetten": null,
-        "Inzidenz": 118.359136463235,
+        "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 106,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12912,9 +12912,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 167.3,
-        "Mutation": 626,
-        "Zuwachs_Mutation": 92
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12933,7 +12933,7 @@
         "BelegteBetten": null,
         "Inzidenz": 134.343906031107,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 107.9,
@@ -12946,8 +12946,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 169.1,
-        "Mutation": 707,
-        "Zuwachs_Mutation": 81
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12966,7 +12966,7 @@
         "BelegteBetten": null,
         "Inzidenz": 135.780739250691,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 121.6,
@@ -12979,8 +12979,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 176.4,
-        "Mutation": 751,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13012,8 +13012,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 183,
-        "Mutation": 778,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13030,9 +13030,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 107,
         "BelegteBetten": null,
-        "Inzidenz": 140.091238909444,
+        "Inzidenz": 140.1,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 137.6,
@@ -13045,8 +13045,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 200.4,
-        "Mutation": 786,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13063,9 +13063,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 115,
         "BelegteBetten": null,
-        "Inzidenz": 142.24648873882,
+        "Inzidenz": 142.2,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 217,
+        "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 118.9,
@@ -13078,8 +13078,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
-        "Mutation": 893,
-        "Zuwachs_Mutation": 107
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13087,32 +13087,32 @@
         "Datum": "31.03.2021",
         "Fallzahl": 24844,
         "ObjectId": 390,
-        "Sterbefall": 987,
-        "Genesungsfall": 22279,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2198,
-        "Zuwachs_Fallzahl": 203,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 118,
         "BelegteBetten": null,
-        "Inzidenz": 150.149071446532,
+        "Inzidenz": 150.1,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 115.5,
-        "Fallzahl_aktiv": 1578,
-        "Krh_I_belegt": 245,
-        "Krh_I_frei": 35,
-        "Fallzahl_aktiv_Zuwachs": 83,
-        "Krh_I": 280,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 38,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 182.3,
-        "Mutation": 975,
-        "Zuwachs_Mutation": 82
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13120,32 +13120,65 @@
         "Datum": "01.04.2021",
         "Fallzahl": 24988,
         "ObjectId": 391,
-        "Sterbefall": 987,
-        "Genesungsfall": 22392,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2212,
-        "Zuwachs_Fallzahl": 144,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
-        "Inzidenz": 146.556988397572,
+        "Inzidenz": 146.6,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 82,
-        "Zeitraum": "25.03.2021 - 31.03.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 120,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 137.2,
-        "Fallzahl_aktiv": 1609,
-        "Krh_I_belegt": 246,
-        "Krh_I_frei": 32,
-        "Fallzahl_aktiv_Zuwachs": 31,
-        "Krh_I": 278,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 35,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 190.3,
-        "Mutation": 1087,
-        "Zuwachs_Mutation": 112
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.04.2021",
+        "Fallzahl": 25113,
+        "ObjectId": 392,
+        "Sterbefall": 987,
+        "Genesungsfall": 22496,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2218,
+        "Zuwachs_Fallzahl": 125,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 104,
+        "BelegteBetten": null,
+        "Inzidenz": 137.8,
+        "Datum_neu": 1617321600000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": "26.03.2021 - 01.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 126.6,
+        "Fallzahl_aktiv": 1630,
+        "Krh_I_belegt": 245,
+        "Krh_I_frei": 31,
+        "Fallzahl_aktiv_Zuwachs": 21,
+        "Krh_I": 276,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 44,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 189.7,
+        "Mutation": 1179,
+        "Zuwachs_Mutation": 92
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
