### PR TITLE
New data set: 2021-04-03T095603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-02T100903Z.json
+pjson/2021-04-03T095603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-02T100903Z.json pjson/2021-04-03T095603Z.json```:
```
--- pjson/2021-04-02T100903Z.json	2021-04-02 10:09:03.114601704 +0000
+++ pjson/2021-04-03T095603Z.json	2021-04-03 09:56:03.732930761 +0000
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 96,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 99,
+        "Zuwachs_Mutation": 3
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 104,
+        "Zuwachs_Mutation": 5
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 105,
+        "Zuwachs_Mutation": 1
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 118,
+        "Zuwachs_Mutation": 13
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 138,
+        "Zuwachs_Mutation": 20
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 146,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 173,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 206,
+        "Zuwachs_Mutation": 33
       }
     },
     {
@@ -12548,10 +12548,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 210,
+        "Zuwachs_Mutation": 4
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 212,
+        "Zuwachs_Mutation": 2
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 240,
+        "Zuwachs_Mutation": 28
       }
     },
     {
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 284,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -12682,8 +12682,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 322,
+        "Zuwachs_Mutation": 38
       }
     },
     {
@@ -12715,8 +12715,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 370,
+        "Zuwachs_Mutation": 48
       }
     },
     {
@@ -12748,8 +12748,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 416,
+        "Zuwachs_Mutation": 46
       }
     },
     {
@@ -12779,10 +12779,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 430,
+        "Zuwachs_Mutation": 14
       }
     },
     {
@@ -12814,8 +12814,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 439,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12847,8 +12847,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 469,
+        "Zuwachs_Mutation": 30
       }
     },
     {
@@ -12880,8 +12880,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 534,
+        "Zuwachs_Mutation": 65
       }
     },
     {
@@ -12913,8 +12913,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 626,
+        "Zuwachs_Mutation": 92
       }
     },
     {
@@ -12946,8 +12946,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 169.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 707,
+        "Zuwachs_Mutation": 81
       }
     },
     {
@@ -12979,8 +12979,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 176.4,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 751,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -13012,8 +13012,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 183,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 778,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -13032,7 +13032,7 @@
         "BelegteBetten": null,
         "Inzidenz": 140.1,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 137.6,
@@ -13045,8 +13045,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 200.4,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 786,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -13078,8 +13078,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 893,
+        "Zuwachs_Mutation": 107
       }
     },
     {
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.1,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 115.5,
@@ -13109,10 +13109,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 182.3,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 975,
+        "Zuwachs_Mutation": 82
       }
     },
     {
@@ -13123,29 +13123,29 @@
         "Sterbefall": null,
         "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2212,
+        "Zuwachs_Fallzahl": 144,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 14,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
         "Inzidenz": 146.6,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 137.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 31,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 190.3,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1087,
+        "Zuwachs_Mutation": 112
       }
     },
     {
@@ -13155,18 +13155,18 @@
         "ObjectId": 392,
         "Sterbefall": 987,
         "Genesungsfall": 22496,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2218,
         "Zuwachs_Fallzahl": 125,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 6,
         "Zuwachs_Genesung": 104,
         "BelegteBetten": null,
-        "Inzidenz": 137.8,
+        "Inzidenz": 137.75638492762,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 61,
-        "Zeitraum": "26.03.2021 - 01.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 68,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 126.6,
         "Fallzahl_aktiv": 1630,
         "Krh_I_belegt": 245,
@@ -13180,6 +13180,39 @@
         "Mutation": 1179,
         "Zuwachs_Mutation": 92
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.04.2021",
+        "Fallzahl": 25146,
+        "ObjectId": 393,
+        "Sterbefall": 990,
+        "Genesungsfall": 22559,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2219,
+        "Zuwachs_Fallzahl": 33,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 63,
+        "BelegteBetten": null,
+        "Inzidenz": 126.800531628291,
+        "Datum_neu": 1617408000000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "27.03.2021 - 02.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 122.7,
+        "Fallzahl_aktiv": 1597,
+        "Krh_I_belegt": 232,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": -33,
+        "Krh_I": 275,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 42,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 185.9,
+        "Mutation": 1194,
+        "Zuwachs_Mutation": 15
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
