### PR TITLE
New data set: 2021-04-04T100404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-03T095603Z.json
+pjson/2021-04-04T100404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-03T095603Z.json pjson/2021-04-04T100404Z.json```:
```
--- pjson/2021-04-03T095603Z.json	2021-04-03 09:56:03.732930761 +0000
+++ pjson/2021-04-04T100404Z.json	2021-04-04 10:04:04.325487559 +0000
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 104,
-        "Zuwachs_Mutation": 5
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 105,
-        "Zuwachs_Mutation": 1
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 118,
-        "Zuwachs_Mutation": 13
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 138,
-        "Zuwachs_Mutation": 20
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 146,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 173,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 206,
-        "Zuwachs_Mutation": 33
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 210,
-        "Zuwachs_Mutation": 4
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": 212,
-        "Zuwachs_Mutation": 2
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 240,
-        "Zuwachs_Mutation": 28
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 284,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12682,8 +12682,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 322,
-        "Zuwachs_Mutation": 38
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12715,8 +12715,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 370,
-        "Zuwachs_Mutation": 48
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12748,8 +12748,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 416,
-        "Zuwachs_Mutation": 46
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12781,8 +12781,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 430,
-        "Zuwachs_Mutation": 14
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12814,8 +12814,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 439,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 169,
+        "F\u00e4lle_Meldedatum": 170,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12847,8 +12847,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 469,
-        "Zuwachs_Mutation": 30
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12880,8 +12880,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 534,
-        "Zuwachs_Mutation": 65
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12913,8 +12913,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 626,
-        "Zuwachs_Mutation": 92
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12931,12 +12931,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
-        "Inzidenz": 134.343906031107,
+        "Inzidenz": null,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 107.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12945,9 +12945,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 169.1,
-        "Mutation": 707,
-        "Zuwachs_Mutation": 81
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12979,8 +12979,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 176.4,
-        "Mutation": 751,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13012,8 +13012,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 183,
-        "Mutation": 778,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13045,8 +13045,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 200.4,
-        "Mutation": 786,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13065,7 +13065,7 @@
         "BelegteBetten": null,
         "Inzidenz": 142.2,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 118.9,
@@ -13078,8 +13078,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
-        "Mutation": 893,
-        "Zuwachs_Mutation": 107
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.1,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 115.5,
@@ -13111,8 +13111,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 182.3,
-        "Mutation": 975,
-        "Zuwachs_Mutation": 82
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13123,29 +13123,29 @@
         "Sterbefall": null,
         "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2212,
-        "Zuwachs_Fallzahl": 144,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
         "Inzidenz": 146.6,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 137.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 31,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 190.3,
-        "Mutation": 1087,
-        "Zuwachs_Mutation": 112
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13153,32 +13153,32 @@
         "Datum": "02.04.2021",
         "Fallzahl": 25113,
         "ObjectId": 392,
-        "Sterbefall": 987,
-        "Genesungsfall": 22496,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2218,
-        "Zuwachs_Fallzahl": 125,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 104,
         "BelegteBetten": null,
         "Inzidenz": 137.75638492762,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 126.6,
-        "Fallzahl_aktiv": 1630,
-        "Krh_I_belegt": 245,
-        "Krh_I_frei": 31,
-        "Fallzahl_aktiv_Zuwachs": 21,
-        "Krh_I": 276,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 44,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 189.7,
-        "Mutation": 1179,
-        "Zuwachs_Mutation": 92
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13186,32 +13186,65 @@
         "Datum": "03.04.2021",
         "Fallzahl": 25146,
         "ObjectId": 393,
-        "Sterbefall": 990,
-        "Genesungsfall": 22559,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2219,
-        "Zuwachs_Fallzahl": 33,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 63,
         "BelegteBetten": null,
-        "Inzidenz": 126.800531628291,
+        "Inzidenz": 126.8,
         "Datum_neu": 1617408000000,
-        "F\u00e4lle_Meldedatum": 11,
-        "Zeitraum": "27.03.2021 - 02.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 122.7,
-        "Fallzahl_aktiv": 1597,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 185.9,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.04.2021",
+        "Fallzahl": 25200,
+        "ObjectId": 394,
+        "Sterbefall": 990,
+        "Genesungsfall": 22587,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2223,
+        "Zuwachs_Fallzahl": 54,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 28,
+        "BelegteBetten": null,
+        "Inzidenz": 125.7,
+        "Datum_neu": 1617494400000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "28.03.2021 - 03.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 117.3,
+        "Fallzahl_aktiv": 1623,
         "Krh_I_belegt": 232,
         "Krh_I_frei": 43,
-        "Fallzahl_aktiv_Zuwachs": -33,
+        "Fallzahl_aktiv_Zuwachs": 26,
         "Krh_I": 275,
-        "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 42,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 45,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 185.9,
-        "Mutation": 1194,
-        "Zuwachs_Mutation": 15
+        "Inzi_SN_RKI": 184.9,
+        "Mutation": 1206,
+        "Zuwachs_Mutation": 12
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
