### PR TITLE
New data set: 2021-04-05T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-04T100404Z.json
+pjson/2021-04-05T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-04T100404Z.json pjson/2021-04-05T100103Z.json```:
```
--- pjson/2021-04-04T100404Z.json	2021-04-04 10:04:04.325487559 +0000
+++ pjson/2021-04-05T100103Z.json	2021-04-05 10:01:03.743623733 +0000
@@ -10095,7 +10095,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 451,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 96,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 99,
+        "Zuwachs_Mutation": 3
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 104,
+        "Zuwachs_Mutation": 5
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 105,
+        "Zuwachs_Mutation": 1
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 118,
+        "Zuwachs_Mutation": 13
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 138,
+        "Zuwachs_Mutation": 20
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 146,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 173,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 206,
+        "Zuwachs_Mutation": 33
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 210,
+        "Zuwachs_Mutation": 4
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 212,
+        "Zuwachs_Mutation": 2
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 240,
+        "Zuwachs_Mutation": 28
       }
     },
     {
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 284,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -12682,8 +12682,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 322,
+        "Zuwachs_Mutation": 38
       }
     },
     {
@@ -12715,8 +12715,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 370,
+        "Zuwachs_Mutation": 48
       }
     },
     {
@@ -12748,8 +12748,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 416,
+        "Zuwachs_Mutation": 46
       }
     },
     {
@@ -12781,8 +12781,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 430,
+        "Zuwachs_Mutation": 14
       }
     },
     {
@@ -12814,8 +12814,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 439,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12847,8 +12847,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 469,
+        "Zuwachs_Mutation": 30
       }
     },
     {
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12880,8 +12880,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 534,
+        "Zuwachs_Mutation": 65
       }
     },
     {
@@ -12913,8 +12913,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 626,
+        "Zuwachs_Mutation": 92
       }
     },
     {
@@ -12946,8 +12946,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 707,
+        "Zuwachs_Mutation": 81
       }
     },
     {
@@ -12964,12 +12964,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
-        "Inzidenz": 135.780739250691,
+        "Inzidenz": null,
         "Datum_neu": 1616803200000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 121.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -12978,9 +12978,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 176.4,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Inzi_SN_RKI": null,
+        "Mutation": 751,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -12997,12 +12997,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
-        "Inzidenz": 141.34846797658,
+        "Inzidenz": null,
         "Datum_neu": 1616889600000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 125,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13011,9 +13011,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 183,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Inzi_SN_RKI": null,
+        "Mutation": 778,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -13045,8 +13045,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 200.4,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 786,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -13065,7 +13065,7 @@
         "BelegteBetten": null,
         "Inzidenz": 142.2,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 118.9,
@@ -13078,8 +13078,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 893,
+        "Zuwachs_Mutation": 107
       }
     },
     {
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.1,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 115.5,
@@ -13111,8 +13111,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 182.3,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 975,
+        "Zuwachs_Mutation": 82
       }
     },
     {
@@ -13131,9 +13131,9 @@
         "BelegteBetten": null,
         "Inzidenz": 146.6,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 137.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13144,8 +13144,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 190.3,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1087,
+        "Zuwachs_Mutation": 112
       }
     },
     {
@@ -13164,9 +13164,9 @@
         "BelegteBetten": null,
         "Inzidenz": 137.75638492762,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 126.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13177,8 +13177,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 189.7,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1179,
+        "Zuwachs_Mutation": 92
       }
     },
     {
@@ -13197,7 +13197,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.8,
         "Datum_neu": 1617408000000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 122.7,
@@ -13210,8 +13210,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 185.9,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1194,
+        "Zuwachs_Mutation": 15
       }
     },
     {
@@ -13221,31 +13221,64 @@
         "ObjectId": 394,
         "Sterbefall": 990,
         "Genesungsfall": 22587,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2223,
         "Zuwachs_Fallzahl": 54,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 4,
         "Zuwachs_Genesung": 28,
         "BelegteBetten": null,
-        "Inzidenz": 125.7,
+        "Inzidenz": 125.722906713603,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "28.03.2021 - 03.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 117.3,
         "Fallzahl_aktiv": 1623,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 26,
-        "Krh_I": 275,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 45,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 184.9,
         "Mutation": 1206,
         "Zuwachs_Mutation": 12
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.04.2021",
+        "Fallzahl": 25206,
+        "ObjectId": 395,
+        "Sterbefall": 990,
+        "Genesungsfall": 22709,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2232,
+        "Zuwachs_Fallzahl": 6,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 122,
+        "BelegteBetten": null,
+        "Inzidenz": 125.184094256259,
+        "Datum_neu": 1617580800000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "29.03.2021 - 04.04.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 124.1,
+        "Fallzahl_aktiv": 1507,
+        "Krh_I_belegt": 235,
+        "Krh_I_frei": 40,
+        "Fallzahl_aktiv_Zuwachs": -116,
+        "Krh_I": 275,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 46,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 189.7,
+        "Mutation": 1215,
+        "Zuwachs_Mutation": 9
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
