### PR TITLE
New data set: 2021-04-06T101003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-05T100103Z.json
+pjson/2021-04-06T101003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-05T100103Z.json pjson/2021-04-06T101003Z.json```:
```
--- pjson/2021-04-05T100103Z.json	2021-04-05 10:01:03.743623733 +0000
+++ pjson/2021-04-06T101003Z.json	2021-04-06 10:10:03.416145251 +0000
@@ -7950,7 +7950,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 170,
+        "F\u00e4lle_Meldedatum": 171,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12966,7 +12966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -13030,12 +13030,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 107,
         "BelegteBetten": null,
-        "Inzidenz": 140.1,
+        "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
-        "Inzidenz_RKI": 137.6,
+        "Hosp_Meldedatum": 23,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13044,7 +13044,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 200.4,
+        "Inzi_SN_RKI": null,
         "Mutation": 786,
         "Zuwachs_Mutation": 8
       }
@@ -13065,9 +13065,9 @@
         "BelegteBetten": null,
         "Inzidenz": 142.2,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 226,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 118.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.1,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 115.5,
@@ -13131,7 +13131,7 @@
         "BelegteBetten": null,
         "Inzidenz": 146.6,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 137.2,
@@ -13197,9 +13197,9 @@
         "BelegteBetten": null,
         "Inzidenz": 126.8,
         "Datum_neu": 1617408000000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 122.7,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13219,29 +13219,29 @@
         "Datum": "04.04.2021",
         "Fallzahl": 25200,
         "ObjectId": 394,
-        "Sterbefall": 990,
-        "Genesungsfall": 22587,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2223,
-        "Zuwachs_Fallzahl": 54,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 28,
         "BelegteBetten": null,
         "Inzidenz": 125.722906713603,
         "Datum_neu": 1617494400000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 117.3,
-        "Fallzahl_aktiv": 1623,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 26,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 184.9,
         "Mutation": 1206,
         "Zuwachs_Mutation": 12
@@ -13254,7 +13254,7 @@
         "ObjectId": 395,
         "Sterbefall": 990,
         "Genesungsfall": 22709,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2232,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
@@ -13263,22 +13263,55 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1617580800000,
-        "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "29.03.2021 - 04.04.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 64,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 124.1,
         "Fallzahl_aktiv": 1507,
-        "Krh_I_belegt": 235,
-        "Krh_I_frei": 40,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -116,
-        "Krh_I": 275,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 46,
-        "SterbeF_Sterbedatum": 0,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 189.7,
         "Mutation": 1215,
         "Zuwachs_Mutation": 9
       }
+    },
+    {
+      "attributes": {
+        "Datum": "06.04.2021",
+        "Fallzahl": 25286,
+        "ObjectId": 396,
+        "Sterbefall": 992,
+        "Genesungsfall": 22872,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2242,
+        "Zuwachs_Fallzahl": 80,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 163,
+        "BelegteBetten": null,
+        "Inzidenz": 114.407845109379,
+        "Datum_neu": 1617667200000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "30.03.2021 - 05.04.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 101.1,
+        "Fallzahl_aktiv": 1422,
+        "Krh_I_belegt": 246,
+        "Krh_I_frei": 30,
+        "Fallzahl_aktiv_Zuwachs": -85,
+        "Krh_I": 276,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 45,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 180.7,
+        "Mutation": 1232,
+        "Zuwachs_Mutation": 17
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
