### PR TITLE
New data set: 2021-04-07T100504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-06T101003Z.json
+pjson/2021-04-07T100504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-06T101003Z.json pjson/2021-04-07T100504Z.json```:
```
--- pjson/2021-04-06T101003Z.json	2021-04-06 10:10:03.416145251 +0000
+++ pjson/2021-04-07T100504Z.json	2021-04-07 10:05:04.281733181 +0000
@@ -6564,7 +6564,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1600041600000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -10326,7 +10326,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 348,
+        "F\u00e4lle_Meldedatum": 347,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -12372,7 +12372,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12933,7 +12933,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13032,7 +13032,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13063,12 +13063,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 115,
         "BelegteBetten": null,
-        "Inzidenz": 142.2,
+        "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 217,
+        "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 118.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13077,7 +13077,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 193.4,
+        "Inzi_SN_RKI": null,
         "Mutation": 893,
         "Zuwachs_Mutation": 107
       }
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.1,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 115.5,
@@ -13109,7 +13109,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 182.3,
         "Mutation": 975,
         "Zuwachs_Mutation": 82
@@ -13131,7 +13131,7 @@
         "BelegteBetten": null,
         "Inzidenz": 146.6,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 137.2,
@@ -13164,7 +13164,7 @@
         "BelegteBetten": null,
         "Inzidenz": 137.75638492762,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 126.6,
@@ -13252,25 +13252,25 @@
         "Datum": "05.04.2021",
         "Fallzahl": 25206,
         "ObjectId": 395,
-        "Sterbefall": 990,
-        "Genesungsfall": 22709,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2232,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 122,
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1617580800000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 124.1,
-        "Fallzahl_aktiv": 1507,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -116,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -13287,7 +13287,7 @@
         "ObjectId": 396,
         "Sterbefall": 992,
         "Genesungsfall": 22872,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2242,
         "Zuwachs_Fallzahl": 80,
         "Zuwachs_Sterbefall": 2,
@@ -13296,22 +13296,55 @@
         "BelegteBetten": null,
         "Inzidenz": 114.407845109379,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "30.03.2021 - 05.04.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 148,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 101.1,
         "Fallzahl_aktiv": 1422,
-        "Krh_I_belegt": 246,
-        "Krh_I_frei": 30,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -85,
-        "Krh_I": 276,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 45,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 180.7,
         "Mutation": 1232,
         "Zuwachs_Mutation": 17
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.04.2021",
+        "Fallzahl": 25518,
+        "ObjectId": 397,
+        "Sterbefall": 993,
+        "Genesungsfall": 22983,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2254,
+        "Zuwachs_Fallzahl": 232,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 111,
+        "BelegteBetten": null,
+        "Inzidenz": 102.913179352707,
+        "Datum_neu": 1617753600000,
+        "F\u00e4lle_Meldedatum": 86,
+        "Zeitraum": "31.03.2021 - 06.04.2021",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 75.1,
+        "Fallzahl_aktiv": 1542,
+        "Krh_I_belegt": 245,
+        "Krh_I_frei": 35,
+        "Fallzahl_aktiv_Zuwachs": 120,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 47,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 149.6,
+        "Mutation": 1268,
+        "Zuwachs_Mutation": 36
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
