### PR TITLE
New data set: 2021-04-08T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-07T100504Z.json
+pjson/2021-04-08T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-07T100504Z.json pjson/2021-04-08T100603Z.json```:
```
--- pjson/2021-04-07T100504Z.json	2021-04-07 10:05:04.281733181 +0000
+++ pjson/2021-04-08T100603Z.json	2021-04-08 10:06:03.660227658 +0000
@@ -12438,7 +12438,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12803,7 +12803,7 @@
         "Datum_neu": 1616371200000,
         "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 171,
+        "F\u00e4lle_Meldedatum": 170,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12878,7 +12878,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 534,
         "Zuwachs_Mutation": 65
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -12933,7 +12933,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13032,7 +13032,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13065,7 +13065,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 218,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13096,12 +13096,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 118,
         "BelegteBetten": null,
-        "Inzidenz": 150.1,
+        "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 115.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13110,7 +13110,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 182.3,
+        "Inzi_SN_RKI": null,
         "Mutation": 975,
         "Zuwachs_Mutation": 82
       }
@@ -13131,7 +13131,7 @@
         "BelegteBetten": null,
         "Inzidenz": 146.6,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 137.2,
@@ -13164,7 +13164,7 @@
         "BelegteBetten": null,
         "Inzidenz": 137.75638492762,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 126.6,
@@ -13197,7 +13197,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.8,
         "Datum_neu": 1617408000000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 122.7,
@@ -13230,7 +13230,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.722906713603,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 117.3,
@@ -13263,7 +13263,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1617580800000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 124.1,
@@ -13285,25 +13285,25 @@
         "Datum": "06.04.2021",
         "Fallzahl": 25286,
         "ObjectId": 396,
-        "Sterbefall": 992,
-        "Genesungsfall": 22872,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2242,
-        "Zuwachs_Fallzahl": 80,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 163,
         "BelegteBetten": null,
         "Inzidenz": 114.407845109379,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 101.1,
-        "Fallzahl_aktiv": 1422,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -85,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -13320,7 +13320,7 @@
         "ObjectId": 397,
         "Sterbefall": 993,
         "Genesungsfall": 22983,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2254,
         "Zuwachs_Fallzahl": 232,
         "Zuwachs_Sterbefall": 1,
@@ -13329,22 +13329,55 @@
         "BelegteBetten": null,
         "Inzidenz": 102.913179352707,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 86,
-        "Zeitraum": "31.03.2021 - 06.04.2021",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 137,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 75.1,
         "Fallzahl_aktiv": 1542,
-        "Krh_I_belegt": 245,
-        "Krh_I_frei": 35,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 120,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 47,
-        "SterbeF_Sterbedatum": 0,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 149.6,
         "Mutation": 1268,
         "Zuwachs_Mutation": 36
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.04.2021",
+        "Fallzahl": 25710,
+        "ObjectId": 398,
+        "Sterbefall": 995,
+        "Genesungsfall": 23175,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2261,
+        "Zuwachs_Fallzahl": 192,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 192,
+        "BelegteBetten": null,
+        "Inzidenz": 111.174970365315,
+        "Datum_neu": 1617840000000,
+        "F\u00e4lle_Meldedatum": 120,
+        "Zeitraum": "01.04.2021 - 07.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 97.5,
+        "Fallzahl_aktiv": 1540,
+        "Krh_I_belegt": 247,
+        "Krh_I_frei": 33,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 50,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 143,
+        "Mutation": 1385,
+        "Zuwachs_Mutation": 117
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
