### PR TITLE
New data set: 2021-04-09T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-08T100603Z.json
+pjson/2021-04-09T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-08T100603Z.json pjson/2021-04-09T100503Z.json```:
```
--- pjson/2021-04-08T100603Z.json	2021-04-08 10:06:03.660227658 +0000
+++ pjson/2021-04-09T100503Z.json	2021-04-09 10:05:03.688223293 +0000
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10293,7 +10293,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 389,
+        "F\u00e4lle_Meldedatum": 390,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -10337,7 +10337,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -10986,7 +10986,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -13032,7 +13032,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13129,12 +13129,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
-        "Inzidenz": 146.6,
+        "Inzidenz": null,
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 137.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13143,7 +13143,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 190.3,
+        "Inzi_SN_RKI": null,
         "Mutation": 1087,
         "Zuwachs_Mutation": 112
       }
@@ -13230,7 +13230,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.722906713603,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 117.3,
@@ -13318,27 +13318,27 @@
         "Datum": "07.04.2021",
         "Fallzahl": 25518,
         "ObjectId": 397,
-        "Sterbefall": 993,
-        "Genesungsfall": 22983,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2254,
-        "Zuwachs_Fallzahl": 232,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 111,
         "BelegteBetten": null,
         "Inzidenz": 102.913179352707,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.1,
-        "Fallzahl_aktiv": 1542,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 120,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 149.6,
@@ -13353,7 +13353,7 @@
         "ObjectId": 398,
         "Sterbefall": 995,
         "Genesungsfall": 23175,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2261,
         "Zuwachs_Fallzahl": 192,
         "Zuwachs_Sterbefall": 2,
@@ -13362,22 +13362,55 @@
         "BelegteBetten": null,
         "Inzidenz": 111.174970365315,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 120,
-        "Zeitraum": "01.04.2021 - 07.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 125,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": 1540,
-        "Krh_I_belegt": 247,
-        "Krh_I_frei": 33,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -2,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 50,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 143,
         "Mutation": 1385,
         "Zuwachs_Mutation": 117
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.04.2021",
+        "Fallzahl": 25872,
+        "ObjectId": 399,
+        "Sterbefall": 996,
+        "Genesungsfall": 23324,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2268,
+        "Zuwachs_Fallzahl": 162,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 149,
+        "BelegteBetten": null,
+        "Inzidenz": 124.645281798915,
+        "Datum_neu": 1617926400000,
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": "02.04.2021 - 08.04.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 106.5,
+        "Fallzahl_aktiv": 1552,
+        "Krh_I_belegt": 255,
+        "Krh_I_frei": 23,
+        "Fallzahl_aktiv_Zuwachs": 12,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 48,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 150.9,
+        "Mutation": 1484,
+        "Zuwachs_Mutation": 99
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
