### PR TITLE
New data set: 2021-04-10T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-09T100503Z.json
+pjson/2021-04-10T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-09T100503Z.json pjson/2021-04-10T100603Z.json```:
```
--- pjson/2021-04-09T100503Z.json	2021-04-09 10:05:03.688223293 +0000
+++ pjson/2021-04-10T100603Z.json	2021-04-10 10:06:03.826406799 +0000
@@ -12405,7 +12405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615334400000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -13131,7 +13131,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -13162,12 +13162,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 104,
         "BelegteBetten": null,
-        "Inzidenz": 137.75638492762,
+        "Inzidenz": null,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 126.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13176,7 +13176,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 189.7,
+        "Inzi_SN_RKI": null,
         "Mutation": 1179,
         "Zuwachs_Mutation": 92
       }
@@ -13197,7 +13197,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.8,
         "Datum_neu": 1617408000000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 122.7,
@@ -13230,7 +13230,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.722906713603,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 117.3,
@@ -13263,7 +13263,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1617580800000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 124.1,
@@ -13296,7 +13296,7 @@
         "BelegteBetten": null,
         "Inzidenz": 114.407845109379,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 156,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 101.1,
@@ -13329,7 +13329,7 @@
         "BelegteBetten": null,
         "Inzidenz": 102.913179352707,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 223,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.1,
@@ -13351,25 +13351,25 @@
         "Datum": "08.04.2021",
         "Fallzahl": 25710,
         "ObjectId": 398,
-        "Sterbefall": 995,
-        "Genesungsfall": 23175,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2261,
-        "Zuwachs_Fallzahl": 192,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 192,
         "BelegteBetten": null,
         "Inzidenz": 111.174970365315,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 97.5,
-        "Fallzahl_aktiv": 1540,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -13386,7 +13386,7 @@
         "ObjectId": 399,
         "Sterbefall": 996,
         "Genesungsfall": 23324,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2268,
         "Zuwachs_Fallzahl": 162,
         "Zuwachs_Sterbefall": 1,
@@ -13395,22 +13395,55 @@
         "BelegteBetten": null,
         "Inzidenz": 124.645281798915,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 65,
-        "Zeitraum": "02.04.2021 - 08.04.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 175,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 106.5,
         "Fallzahl_aktiv": 1552,
-        "Krh_I_belegt": 255,
-        "Krh_I_frei": 23,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 12,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 48,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 150.9,
         "Mutation": 1484,
         "Zuwachs_Mutation": 99
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.04.2021",
+        "Fallzahl": 26001,
+        "ObjectId": 400,
+        "Sterbefall": 996,
+        "Genesungsfall": 23396,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2270,
+        "Zuwachs_Fallzahl": 129,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 72,
+        "BelegteBetten": null,
+        "Inzidenz": 148.891842379396,
+        "Datum_neu": 1618012800000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "03.04.2021 - 09.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 125.2,
+        "Fallzahl_aktiv": 1609,
+        "Krh_I_belegt": 245,
+        "Krh_I_frei": 33,
+        "Fallzahl_aktiv_Zuwachs": 57,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 42,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 182,
+        "Mutation": 1546,
+        "Zuwachs_Mutation": 62
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
