### PR TITLE
New data set: 2021-04-11T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-10T100603Z.json
+pjson/2021-04-11T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-10T100603Z.json pjson/2021-04-11T100403Z.json```:
```
--- pjson/2021-04-10T100603Z.json	2021-04-10 10:06:03.826406799 +0000
+++ pjson/2021-04-11T100403Z.json	2021-04-11 10:04:03.999196293 +0000
@@ -12405,7 +12405,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615334400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -13032,7 +13032,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -13131,7 +13131,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -13164,7 +13164,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13195,12 +13195,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 63,
         "BelegteBetten": null,
-        "Inzidenz": 126.8,
+        "Inzidenz": null,
         "Datum_neu": 1617408000000,
         "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 122.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13209,7 +13209,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 185.9,
+        "Inzi_SN_RKI": null,
         "Mutation": 1194,
         "Zuwachs_Mutation": 15
       }
@@ -13230,7 +13230,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.722906713603,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 117.3,
@@ -13263,7 +13263,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1617580800000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 124.1,
@@ -13296,7 +13296,7 @@
         "BelegteBetten": null,
         "Inzidenz": 114.407845109379,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 101.1,
@@ -13329,7 +13329,7 @@
         "BelegteBetten": null,
         "Inzidenz": 102.913179352707,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.1,
@@ -13362,9 +13362,9 @@
         "BelegteBetten": null,
         "Inzidenz": 111.174970365315,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13384,27 +13384,27 @@
         "Datum": "09.04.2021",
         "Fallzahl": 25872,
         "ObjectId": 399,
-        "Sterbefall": 996,
-        "Genesungsfall": 23324,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2268,
-        "Zuwachs_Fallzahl": 162,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
         "Inzidenz": 124.645281798915,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 106.5,
-        "Fallzahl_aktiv": 1552,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 150.9,
@@ -13419,7 +13419,7 @@
         "ObjectId": 400,
         "Sterbefall": 996,
         "Genesungsfall": 23396,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2270,
         "Zuwachs_Fallzahl": 129,
         "Zuwachs_Sterbefall": 0,
@@ -13428,22 +13428,55 @@
         "BelegteBetten": null,
         "Inzidenz": 148.891842379396,
         "Datum_neu": 1618012800000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "03.04.2021 - 09.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 34,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 125.2,
         "Fallzahl_aktiv": 1609,
-        "Krh_I_belegt": 245,
-        "Krh_I_frei": 33,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 57,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 42,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 182,
         "Mutation": 1546,
         "Zuwachs_Mutation": 62
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.04.2021",
+        "Fallzahl": 26044,
+        "ObjectId": 401,
+        "Sterbefall": 996,
+        "Genesungsfall": 23417,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2273,
+        "Zuwachs_Fallzahl": 43,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 21,
+        "BelegteBetten": null,
+        "Inzidenz": 146.556988397572,
+        "Datum_neu": 1618099200000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "04.04.2021 - 10.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 136.3,
+        "Fallzahl_aktiv": 1631,
+        "Krh_I_belegt": 234,
+        "Krh_I_frei": 44,
+        "Fallzahl_aktiv_Zuwachs": 22,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 41,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 193.4,
+        "Mutation": 1564,
+        "Zuwachs_Mutation": 18
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
