### PR TITLE
New data set: 2021-04-12T101603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-11T100403Z.json
+pjson/2021-04-12T101603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-11T100403Z.json pjson/2021-04-12T101603Z.json```:
```
--- pjson/2021-04-11T100403Z.json	2021-04-11 10:04:03.999196293 +0000
+++ pjson/2021-04-12T101603Z.json	2021-04-12 10:16:03.521881292 +0000
@@ -9105,7 +9105,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -10755,7 +10755,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -12803,7 +12803,7 @@
         "Datum_neu": 1616371200000,
         "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12935,7 +12935,7 @@
         "Datum_neu": 1616716800000,
         "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13076,7 +13076,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 893,
         "Zuwachs_Mutation": 107
@@ -13100,7 +13100,7 @@
         "Datum_neu": 1617148800000,
         "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13133,7 +13133,7 @@
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13228,12 +13228,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 28,
         "BelegteBetten": null,
-        "Inzidenz": 125.722906713603,
+        "Inzidenz": null,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 117.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13242,7 +13242,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 184.9,
+        "Inzi_SN_RKI": null,
         "Mutation": 1206,
         "Zuwachs_Mutation": 12
       }
@@ -13265,7 +13265,7 @@
         "Datum_neu": 1617580800000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 124.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13298,7 +13298,7 @@
         "Datum_neu": 1617667200000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 101.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13331,7 +13331,7 @@
         "Datum_neu": 1617753600000,
         "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 75.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13340,7 +13340,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 149.6,
         "Mutation": 1268,
         "Zuwachs_Mutation": 36
@@ -13362,7 +13362,7 @@
         "BelegteBetten": null,
         "Inzidenz": 111.174970365315,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.5,
@@ -13395,9 +13395,9 @@
         "BelegteBetten": null,
         "Inzidenz": 124.645281798915,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 106.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13417,27 +13417,27 @@
         "Datum": "10.04.2021",
         "Fallzahl": 26001,
         "ObjectId": 400,
-        "Sterbefall": 996,
-        "Genesungsfall": 23396,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2270,
-        "Zuwachs_Fallzahl": 129,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
         "Inzidenz": 148.891842379396,
         "Datum_neu": 1618012800000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 125.2,
-        "Fallzahl_aktiv": 1609,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 57,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 182,
@@ -13452,7 +13452,7 @@
         "ObjectId": 401,
         "Sterbefall": 996,
         "Genesungsfall": 23417,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2273,
         "Zuwachs_Fallzahl": 43,
         "Zuwachs_Sterbefall": 0,
@@ -13461,22 +13461,55 @@
         "BelegteBetten": null,
         "Inzidenz": 146.556988397572,
         "Datum_neu": 1618099200000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "04.04.2021 - 10.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 136.3,
         "Fallzahl_aktiv": 1631,
-        "Krh_I_belegt": 234,
-        "Krh_I_frei": 44,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 22,
-        "Krh_I": 278,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 41,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
         "Mutation": 1564,
         "Zuwachs_Mutation": 18
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.04.2021",
+        "Fallzahl": 26054,
+        "ObjectId": 402,
+        "Sterbefall": 998,
+        "Genesungsfall": 23538,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2282,
+        "Zuwachs_Fallzahl": 10,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 121,
+        "BelegteBetten": null,
+        "Inzidenz": 147.455009159812,
+        "Datum_neu": 1618185600000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "05.04.2021 - 11.04.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 144.9,
+        "Fallzahl_aktiv": 1518,
+        "Krh_I_belegt": 233,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": -113,
+        "Krh_I": 276,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 40,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 203.6,
+        "Mutation": 1567,
+        "Zuwachs_Mutation": 3
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
