### PR TITLE
New data set: 2021-04-13T103802Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-12T101603Z.json
+pjson/2021-04-13T103802Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-12T101603Z.json pjson/2021-04-13T103802Z.json```:
```
--- pjson/2021-04-12T101603Z.json	2021-04-12 10:16:03.521881292 +0000
+++ pjson/2021-04-13T103802Z.json	2021-04-13 10:38:03.064868638 +0000
@@ -9105,7 +9105,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 212,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -12647,7 +12647,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": 284,
         "Zuwachs_Mutation": 44
@@ -12977,7 +12977,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 751,
         "Zuwachs_Mutation": 44
@@ -13001,7 +13001,7 @@
         "Datum_neu": 1616889600000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13034,7 +13034,7 @@
         "Datum_neu": 1616976000000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13043,7 +13043,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 786,
         "Zuwachs_Mutation": 8
@@ -13065,9 +13065,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13076,7 +13076,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 893,
         "Zuwachs_Mutation": 107
@@ -13098,9 +13098,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13109,7 +13109,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": 975,
         "Zuwachs_Mutation": 82
@@ -13133,7 +13133,7 @@
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13166,7 +13166,7 @@
         "Datum_neu": 1617321600000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13175,7 +13175,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 1179,
         "Zuwachs_Mutation": 92
@@ -13199,7 +13199,7 @@
         "Datum_neu": 1617408000000,
         "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13208,7 +13208,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 1194,
         "Zuwachs_Mutation": 15
@@ -13230,9 +13230,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13261,12 +13261,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 122,
         "BelegteBetten": null,
-        "Inzidenz": 125.184094256259,
+        "Inzidenz": null,
         "Datum_neu": 1617580800000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 124.1,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13274,8 +13274,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 189.7,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
         "Mutation": 1215,
         "Zuwachs_Mutation": 9
       }
@@ -13298,7 +13298,7 @@
         "Datum_neu": 1617667200000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 101.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13329,9 +13329,9 @@
         "BelegteBetten": null,
         "Inzidenz": 102.913179352707,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 75.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13340,7 +13340,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 149.6,
         "Mutation": 1268,
         "Zuwachs_Mutation": 36
@@ -13362,9 +13362,9 @@
         "BelegteBetten": null,
         "Inzidenz": 111.174970365315,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13395,9 +13395,9 @@
         "BelegteBetten": null,
         "Inzidenz": 124.645281798915,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 106.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13450,27 +13450,27 @@
         "Datum": "11.04.2021",
         "Fallzahl": 26044,
         "ObjectId": 401,
-        "Sterbefall": 996,
-        "Genesungsfall": 23417,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2273,
-        "Zuwachs_Fallzahl": 43,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
         "Inzidenz": 146.556988397572,
         "Datum_neu": 1618099200000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 136.3,
-        "Fallzahl_aktiv": 1631,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 22,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
@@ -13485,7 +13485,7 @@
         "ObjectId": 402,
         "Sterbefall": 998,
         "Genesungsfall": 23538,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2282,
         "Zuwachs_Fallzahl": 10,
         "Zuwachs_Sterbefall": 2,
@@ -13494,22 +13494,55 @@
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "05.04.2021 - 11.04.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 99,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 144.9,
         "Fallzahl_aktiv": 1518,
-        "Krh_I_belegt": 233,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -113,
-        "Krh_I": 276,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 40,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 203.6,
         "Mutation": 1567,
         "Zuwachs_Mutation": 3
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.04.2021",
+        "Fallzahl": 26288,
+        "ObjectId": 403,
+        "Sterbefall": 1006,
+        "Genesungsfall": 23735,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2297,
+        "Zuwachs_Fallzahl": 234,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 197,
+        "BelegteBetten": null,
+        "Inzidenz": 154.81877941018,
+        "Datum_neu": 1618272000000,
+        "F\u00e4lle_Meldedatum": 128,
+        "Zeitraum": "06.04.2021 - 12.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 136.3,
+        "Fallzahl_aktiv": 1547,
+        "Krh_I_belegt": 242,
+        "Krh_I_frei": 36,
+        "Fallzahl_aktiv_Zuwachs": 29,
+        "Krh_I": 278,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 44,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 212.1,
+        "Mutation": 1684,
+        "Zuwachs_Mutation": 117
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
