### PR TITLE
New data set: 2021-04-14T101702Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-13T103802Z.json
+pjson/2021-04-14T101702Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-13T103802Z.json pjson/2021-04-14T101702Z.json```:
```
--- pjson/2021-04-13T103802Z.json	2021-04-13 10:38:03.064868638 +0000
+++ pjson/2021-04-14T101702Z.json	2021-04-14 10:17:02.856391325 +0000
@@ -9600,7 +9600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 417,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -10260,7 +10260,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -10359,7 +10359,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -10392,7 +10392,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -10590,7 +10590,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -10623,7 +10623,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -10656,7 +10656,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610755200000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -10821,7 +10821,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10953,7 +10953,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -11283,7 +11283,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -11547,7 +11547,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 104,
-        "Zuwachs_Mutation": 5
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 105,
-        "Zuwachs_Mutation": 1
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 118,
-        "Zuwachs_Mutation": 13
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 138,
-        "Zuwachs_Mutation": 20
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 146,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12471,7 +12471,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 173,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 206,
-        "Zuwachs_Mutation": 33
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 210,
-        "Zuwachs_Mutation": 4
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": 212,
-        "Zuwachs_Mutation": 2
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 240,
-        "Zuwachs_Mutation": 28
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12636,7 +12636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 284,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12682,8 +12682,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 322,
-        "Zuwachs_Mutation": 38
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12715,8 +12715,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 370,
-        "Zuwachs_Mutation": 48
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12748,8 +12748,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 416,
-        "Zuwachs_Mutation": 46
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12781,8 +12781,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 430,
-        "Zuwachs_Mutation": 14
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12814,8 +12814,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 439,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12847,8 +12847,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 469,
-        "Zuwachs_Mutation": 30
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12880,8 +12880,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 534,
-        "Zuwachs_Mutation": 65
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12913,8 +12913,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 626,
-        "Zuwachs_Mutation": 92
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12946,8 +12946,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 707,
-        "Zuwachs_Mutation": 81
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12979,8 +12979,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 751,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13001,7 +13001,7 @@
         "Datum_neu": 1616889600000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13012,8 +13012,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 778,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13034,7 +13034,7 @@
         "Datum_neu": 1616976000000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13045,8 +13045,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 786,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13067,7 +13067,7 @@
         "Datum_neu": 1617062400000,
         "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13078,8 +13078,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 893,
-        "Zuwachs_Mutation": 107
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13098,9 +13098,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13111,8 +13111,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 975,
-        "Zuwachs_Mutation": 82
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13133,7 +13133,7 @@
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13144,8 +13144,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1087,
-        "Zuwachs_Mutation": 112
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13166,7 +13166,7 @@
         "Datum_neu": 1617321600000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13177,8 +13177,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 1179,
-        "Zuwachs_Mutation": 92
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13199,7 +13199,7 @@
         "Datum_neu": 1617408000000,
         "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13210,8 +13210,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 1194,
-        "Zuwachs_Mutation": 15
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13232,7 +13232,7 @@
         "Datum_neu": 1617494400000,
         "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13243,8 +13243,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 1206,
-        "Zuwachs_Mutation": 12
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13265,7 +13265,7 @@
         "Datum_neu": 1617580800000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13276,8 +13276,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 1215,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13294,12 +13294,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 163,
         "BelegteBetten": null,
-        "Inzidenz": 114.407845109379,
+        "Inzidenz": null,
         "Datum_neu": 1617667200000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 101.1,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13308,9 +13308,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 180.7,
-        "Mutation": 1232,
-        "Zuwachs_Mutation": 17
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13329,9 +13329,9 @@
         "BelegteBetten": null,
         "Inzidenz": 102.913179352707,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 75.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13342,8 +13342,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 149.6,
-        "Mutation": 1268,
-        "Zuwachs_Mutation": 36
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13364,7 +13364,7 @@
         "Datum_neu": 1617840000000,
         "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13375,8 +13375,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 143,
-        "Mutation": 1385,
-        "Zuwachs_Mutation": 117
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13395,9 +13395,9 @@
         "BelegteBetten": null,
         "Inzidenz": 124.645281798915,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 106.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13408,8 +13408,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 150.9,
-        "Mutation": 1484,
-        "Zuwachs_Mutation": 99
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13428,7 +13428,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.891842379396,
         "Datum_neu": 1618012800000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 125.2,
@@ -13441,8 +13441,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 182,
-        "Mutation": 1546,
-        "Zuwachs_Mutation": 62
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13461,9 +13461,9 @@
         "BelegteBetten": null,
         "Inzidenz": 146.556988397572,
         "Datum_neu": 1618099200000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 136.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13474,8 +13474,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
-        "Mutation": 1564,
-        "Zuwachs_Mutation": 18
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13483,32 +13483,32 @@
         "Datum": "12.04.2021",
         "Fallzahl": 26054,
         "ObjectId": 402,
-        "Sterbefall": 998,
-        "Genesungsfall": 23538,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2282,
-        "Zuwachs_Fallzahl": 10,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 121,
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 144.9,
-        "Fallzahl_aktiv": 1518,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -113,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 203.6,
-        "Mutation": 1567,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13516,32 +13516,65 @@
         "Datum": "13.04.2021",
         "Fallzahl": 26288,
         "ObjectId": 403,
-        "Sterbefall": 1006,
-        "Genesungsfall": 23735,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2297,
-        "Zuwachs_Fallzahl": 234,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
         "Inzidenz": 154.81877941018,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 128,
-        "Zeitraum": "06.04.2021 - 12.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 222,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 136.3,
-        "Fallzahl_aktiv": 1547,
-        "Krh_I_belegt": 242,
-        "Krh_I_frei": 36,
-        "Fallzahl_aktiv_Zuwachs": 29,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 212.1,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.04.2021",
+        "Fallzahl": 26508,
+        "ObjectId": 404,
+        "Sterbefall": 1006,
+        "Genesungsfall": 23844,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2317,
+        "Zuwachs_Fallzahl": 220,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 109,
+        "BelegteBetten": null,
+        "Inzidenz": 171.521965587844,
+        "Datum_neu": 1618358400000,
+        "F\u00e4lle_Meldedatum": 103,
+        "Zeitraum": "07.04.2021 - 13.04.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 147.6,
+        "Fallzahl_aktiv": 1658,
+        "Krh_I_belegt": 249,
+        "Krh_I_frei": 29,
+        "Fallzahl_aktiv_Zuwachs": 111,
         "Krh_I": 278,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 44,
+        "Krh_I_covid": 50,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 212.1,
-        "Mutation": 1684,
-        "Zuwachs_Mutation": 117
+        "Inzi_SN_RKI": 227.8,
+        "Mutation": 1804,
+        "Zuwachs_Mutation": 120
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
