### PR TITLE
New data set: 2021-04-15T100604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-14T101702Z.json
+pjson/2021-04-15T100604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-14T101702Z.json pjson/2021-04-15T100604Z.json```:
```
--- pjson/2021-04-14T101702Z.json	2021-04-14 10:17:02.856391325 +0000
+++ pjson/2021-04-15T100604Z.json	2021-04-15 10:06:04.381854571 +0000
@@ -10359,7 +10359,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 271,
+        "F\u00e4lle_Meldedatum": 270,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -10392,7 +10392,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -10623,7 +10623,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -12603,7 +12603,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615852800000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12636,7 +12636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615939200000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -12801,7 +12801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -13065,7 +13065,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 223,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13131,7 +13131,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13197,7 +13197,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617408000000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13230,7 +13230,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617494400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -13327,12 +13327,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 111,
         "BelegteBetten": null,
-        "Inzidenz": 102.913179352707,
+        "Inzidenz": null,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 75.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13341,7 +13341,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 149.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13362,9 +13362,9 @@
         "BelegteBetten": null,
         "Inzidenz": 111.174970365315,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 97.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13494,7 +13494,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 144.9,
@@ -13527,9 +13527,9 @@
         "BelegteBetten": null,
         "Inzidenz": 154.81877941018,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 136.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13549,32 +13549,65 @@
         "Datum": "14.04.2021",
         "Fallzahl": 26508,
         "ObjectId": 404,
-        "Sterbefall": 1006,
-        "Genesungsfall": 23844,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2317,
-        "Zuwachs_Fallzahl": 220,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 109,
         "BelegteBetten": null,
         "Inzidenz": 171.521965587844,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 103,
-        "Zeitraum": "07.04.2021 - 13.04.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 167,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 147.6,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 227.8,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.04.2021",
+        "Fallzahl": 26645,
+        "ObjectId": 405,
+        "Sterbefall": 1006,
+        "Genesungsfall": 23976,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2327,
+        "Zuwachs_Fallzahl": 137,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 132,
+        "BelegteBetten": null,
+        "Inzidenz": 167.39107008154,
+        "Datum_neu": 1618444800000,
+        "F\u00e4lle_Meldedatum": 35,
+        "Zeitraum": "08.04.2021 - 14.04.2021",
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 147.6,
-        "Fallzahl_aktiv": 1658,
-        "Krh_I_belegt": 249,
+        "Fallzahl_aktiv": 1663,
+        "Krh_I_belegt": 252,
         "Krh_I_frei": 29,
-        "Fallzahl_aktiv_Zuwachs": 111,
-        "Krh_I": 278,
+        "Fallzahl_aktiv_Zuwachs": 5,
+        "Krh_I": 281,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 50,
+        "Krh_I_covid": 49,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 227.8,
-        "Mutation": 1804,
-        "Zuwachs_Mutation": 120
+        "Inzi_SN_RKI": 235.3,
+        "Mutation": 1902,
+        "Zuwachs_Mutation": 98
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
