### PR TITLE
New data set: 2021-04-16T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-15T100604Z.json
+pjson/2021-04-16T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-15T100604Z.json pjson/2021-04-16T100403Z.json```:
```
--- pjson/2021-04-15T100604Z.json	2021-04-15 10:06:04.381854571 +0000
+++ pjson/2021-04-16T100403Z.json	2021-04-16 10:04:03.962152992 +0000
@@ -9831,7 +9831,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -10293,7 +10293,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 96,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 99,
+        "Zuwachs_Mutation": 3
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 104,
+        "Zuwachs_Mutation": 5
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 105,
+        "Zuwachs_Mutation": 1
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 118,
+        "Zuwachs_Mutation": 13
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 138,
+        "Zuwachs_Mutation": 20
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 146,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 173,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 206,
+        "Zuwachs_Mutation": 33
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 210,
+        "Zuwachs_Mutation": 4
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 212,
+        "Zuwachs_Mutation": 2
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 240,
+        "Zuwachs_Mutation": 28
       }
     },
     {
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 284,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -12669,7 +12669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -12682,8 +12682,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 322,
+        "Zuwachs_Mutation": 38
       }
     },
     {
@@ -12715,8 +12715,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 370,
+        "Zuwachs_Mutation": 48
       }
     },
     {
@@ -12748,8 +12748,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 416,
+        "Zuwachs_Mutation": 46
       }
     },
     {
@@ -12781,8 +12781,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 430,
+        "Zuwachs_Mutation": 14
       }
     },
     {
@@ -12814,8 +12814,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 439,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -12847,8 +12847,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 469,
+        "Zuwachs_Mutation": 30
       }
     },
     {
@@ -12880,8 +12880,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 534,
+        "Zuwachs_Mutation": 65
       }
     },
     {
@@ -12913,8 +12913,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 626,
+        "Zuwachs_Mutation": 92
       }
     },
     {
@@ -12946,8 +12946,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 707,
+        "Zuwachs_Mutation": 81
       }
     },
     {
@@ -12979,8 +12979,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 751,
+        "Zuwachs_Mutation": 44
       }
     },
     {
@@ -13012,8 +13012,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 778,
+        "Zuwachs_Mutation": 27
       }
     },
     {
@@ -13045,8 +13045,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 786,
+        "Zuwachs_Mutation": 8
       }
     },
     {
@@ -13067,7 +13067,7 @@
         "Datum_neu": 1617062400000,
         "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13078,8 +13078,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 893,
+        "Zuwachs_Mutation": 107
       }
     },
     {
@@ -13111,8 +13111,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 975,
+        "Zuwachs_Mutation": 82
       }
     },
     {
@@ -13142,10 +13142,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1087,
+        "Zuwachs_Mutation": 112
       }
     },
     {
@@ -13164,7 +13164,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13177,8 +13177,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1179,
+        "Zuwachs_Mutation": 92
       }
     },
     {
@@ -13210,8 +13210,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1194,
+        "Zuwachs_Mutation": 15
       }
     },
     {
@@ -13241,10 +13241,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1206,
+        "Zuwachs_Mutation": 12
       }
     },
     {
@@ -13274,10 +13274,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1215,
+        "Zuwachs_Mutation": 9
       }
     },
     {
@@ -13307,10 +13307,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1232,
+        "Zuwachs_Mutation": 17
       }
     },
     {
@@ -13340,10 +13340,10 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1268,
+        "Zuwachs_Mutation": 36
       }
     },
     {
@@ -13360,12 +13360,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 192,
         "BelegteBetten": null,
-        "Inzidenz": 111.174970365315,
+        "Inzidenz": null,
         "Datum_neu": 1617840000000,
         "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 97.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13374,9 +13374,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 143,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Inzi_SN_RKI": null,
+        "Mutation": 1385,
+        "Zuwachs_Mutation": 117
       }
     },
     {
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": 124.645281798915,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 106.5,
@@ -13408,8 +13408,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 150.9,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1484,
+        "Zuwachs_Mutation": 99
       }
     },
     {
@@ -13441,8 +13441,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 182,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1546,
+        "Zuwachs_Mutation": 62
       }
     },
     {
@@ -13474,8 +13474,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 193.4,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1564,
+        "Zuwachs_Mutation": 18
       }
     },
     {
@@ -13496,7 +13496,7 @@
         "Datum_neu": 1618185600000,
         "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 144.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13507,8 +13507,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 203.6,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1567,
+        "Zuwachs_Mutation": 3
       }
     },
     {
@@ -13529,7 +13529,7 @@
         "Datum_neu": 1618272000000,
         "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 136.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13540,8 +13540,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 212.1,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1684,
+        "Zuwachs_Mutation": 117
       }
     },
     {
@@ -13560,9 +13560,9 @@
         "BelegteBetten": null,
         "Inzidenz": 171.521965587844,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 167,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 147.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13573,8 +13573,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 227.8,
-        "Mutation": null,
-        "Zuwachs_Mutation": null
+        "Mutation": 1804,
+        "Zuwachs_Mutation": 120
       }
     },
     {
@@ -13584,7 +13584,7 @@
         "ObjectId": 405,
         "Sterbefall": 1006,
         "Genesungsfall": 23976,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2327,
         "Zuwachs_Fallzahl": 137,
         "Zuwachs_Sterbefall": 0,
@@ -13593,22 +13593,55 @@
         "BelegteBetten": null,
         "Inzidenz": 167.39107008154,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 35,
-        "Zeitraum": "08.04.2021 - 14.04.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 121,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 147.6,
         "Fallzahl_aktiv": 1663,
-        "Krh_I_belegt": 252,
-        "Krh_I_frei": 29,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 5,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 49,
-        "SterbeF_Sterbedatum": 0,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 235.3,
         "Mutation": 1902,
         "Zuwachs_Mutation": 98
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.04.2021",
+        "Fallzahl": 26761,
+        "ObjectId": 406,
+        "Sterbefall": 1012,
+        "Genesungsfall": 24019,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2346,
+        "Zuwachs_Fallzahl": 116,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 43,
+        "BelegteBetten": null,
+        "Inzidenz": 164.69700779482,
+        "Datum_neu": 1618531200000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": "09.04.2021 - 15.04.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 146.9,
+        "Fallzahl_aktiv": 1730,
+        "Krh_I_belegt": 248,
+        "Krh_I_frei": 32,
+        "Fallzahl_aktiv_Zuwachs": 67,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 48,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 229.5,
+        "Mutation": 1967,
+        "Zuwachs_Mutation": 65
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
