### PR TITLE
New data set: 2021-04-17T100304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-16T100403Z.json
+pjson/2021-04-17T100304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-16T100403Z.json pjson/2021-04-17T100304Z.json```:
```
--- pjson/2021-04-16T100403Z.json	2021-04-16 10:04:03.962152992 +0000
+++ pjson/2021-04-17T100304Z.json	2021-04-17 10:03:04.172259394 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -9435,7 +9435,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 465,
+        "F\u00e4lle_Meldedatum": 466,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -13164,9 +13164,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13265,7 +13265,7 @@
         "Datum_neu": 1617580800000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13298,7 +13298,7 @@
         "Datum_neu": 1617667200000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13364,7 +13364,7 @@
         "Datum_neu": 1617840000000,
         "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13395,9 +13395,9 @@
         "BelegteBetten": null,
         "Inzidenz": 124.645281798915,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 106.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13428,7 +13428,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.891842379396,
         "Datum_neu": 1618012800000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 125.2,
@@ -13494,7 +13494,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 178,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 144.9,
@@ -13527,9 +13527,9 @@
         "BelegteBetten": null,
         "Inzidenz": 154.81877941018,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 136.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": 171.521965587844,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 147.6,
@@ -13582,27 +13582,27 @@
         "Datum": "15.04.2021",
         "Fallzahl": 26645,
         "ObjectId": 405,
-        "Sterbefall": 1006,
-        "Genesungsfall": 23976,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2327,
-        "Zuwachs_Fallzahl": 137,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
         "Inzidenz": 167.39107008154,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 147.6,
-        "Fallzahl_aktiv": 1663,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 5,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 235.3,
@@ -13617,18 +13617,18 @@
         "ObjectId": 406,
         "Sterbefall": 1012,
         "Genesungsfall": 24019,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2346,
         "Zuwachs_Fallzahl": 116,
         "Zuwachs_Sterbefall": 6,
         "Zuwachs_Krankenhauseinweisung": 19,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 164.69700779482,
+        "Inzidenz": 164.7,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "09.04.2021 - 15.04.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 146.9,
         "Fallzahl_aktiv": 1730,
         "Krh_I_belegt": 248,
@@ -13636,12 +13636,45 @@
         "Fallzahl_aktiv_Zuwachs": 67,
         "Krh_I": 280,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 48,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 229.5,
         "Mutation": 1967,
         "Zuwachs_Mutation": 65
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.04.2021",
+        "Fallzahl": 26818,
+        "ObjectId": 407,
+        "Sterbefall": 1012,
+        "Genesungsfall": 24083,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2348,
+        "Zuwachs_Fallzahl": 57,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 64,
+        "BelegteBetten": null,
+        "Inzidenz": 139.193218147204,
+        "Datum_neu": 1618617600000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": "10.04.2021 - 16.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 134.5,
+        "Fallzahl_aktiv": 1723,
+        "Krh_I_belegt": 274,
+        "Krh_I_frei": 33,
+        "Fallzahl_aktiv_Zuwachs": -7,
+        "Krh_I": 307,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 50,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 231.5,
+        "Mutation": 2042,
+        "Zuwachs_Mutation": 75
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
