### PR TITLE
New data set: 2021-04-18T095903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-17T100304Z.json
+pjson/2021-04-18T095903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-17T100304Z.json pjson/2021-04-18T095903Z.json```:
```
--- pjson/2021-04-17T100304Z.json	2021-04-17 10:03:04.172259394 +0000
+++ pjson/2021-04-18T095903Z.json	2021-04-18 09:59:03.469668492 +0000
@@ -8643,7 +8643,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -9534,7 +9534,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -9633,7 +9633,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -11250,7 +11250,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -13329,7 +13329,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 232,
+        "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13393,12 +13393,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
-        "Inzidenz": 124.645281798915,
+        "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 106.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13407,7 +13407,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 150.9,
+        "Inzi_SN_RKI": null,
         "Mutation": 1484,
         "Zuwachs_Mutation": 99
       }
@@ -13426,12 +13426,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
-        "Inzidenz": 148.891842379396,
+        "Inzidenz": null,
         "Datum_neu": 1618012800000,
         "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 125.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13440,7 +13440,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 182,
+        "Inzi_SN_RKI": null,
         "Mutation": 1546,
         "Zuwachs_Mutation": 62
       }
@@ -13494,7 +13494,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 144.9,
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": 154.81877941018,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 136.3,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": 171.521965587844,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 147.6,
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": 167.39107008154,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 147.6,
@@ -13615,27 +13615,27 @@
         "Datum": "16.04.2021",
         "Fallzahl": 26761,
         "ObjectId": 406,
-        "Sterbefall": 1012,
-        "Genesungsfall": 24019,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2346,
-        "Zuwachs_Fallzahl": 116,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
         "Inzidenz": 164.7,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 146.9,
-        "Fallzahl_aktiv": 1730,
-        "Krh_I_belegt": 248,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": 32,
-        "Fallzahl_aktiv_Zuwachs": 67,
-        "Krh_I": 280,
-        "Vorz_akt_Faelle": "+",
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 229.5,
@@ -13650,7 +13650,7 @@
         "ObjectId": 407,
         "Sterbefall": 1012,
         "Genesungsfall": 24083,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2348,
         "Zuwachs_Fallzahl": 57,
         "Zuwachs_Sterbefall": 0,
@@ -13659,22 +13659,55 @@
         "BelegteBetten": null,
         "Inzidenz": 139.193218147204,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "10.04.2021 - 16.04.2021",
+        "F\u00e4lle_Meldedatum": 74,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 134.5,
         "Fallzahl_aktiv": 1723,
-        "Krh_I_belegt": 274,
+        "Krh_I_belegt": 247,
         "Krh_I_frei": 33,
         "Fallzahl_aktiv_Zuwachs": -7,
-        "Krh_I": 307,
+        "Krh_I": 280,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 50,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 231.5,
         "Mutation": 2042,
         "Zuwachs_Mutation": 75
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.04.2021",
+        "Fallzahl": 26935,
+        "ObjectId": 408,
+        "Sterbefall": 1012,
+        "Genesungsfall": 24108,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2348,
+        "Zuwachs_Fallzahl": 117,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 25,
+        "BelegteBetten": null,
+        "Inzidenz": 151.585904666116,
+        "Datum_neu": 1618704000000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "11.04.2021 - 17.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 136.7,
+        "Fallzahl_aktiv": 1815,
+        "Krh_I_belegt": 241,
+        "Krh_I_frei": 39,
+        "Fallzahl_aktiv_Zuwachs": 92,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 46,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 233.6,
+        "Mutation": 2072,
+        "Zuwachs_Mutation": 30
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
