### PR TITLE
New data set: 2021-04-19T103704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-18T095903Z.json
+pjson/2021-04-19T103704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-18T095903Z.json pjson/2021-04-19T103704Z.json```:
```
--- pjson/2021-04-18T095903Z.json	2021-04-18 09:59:03.469668492 +0000
+++ pjson/2021-04-19T103704Z.json	2021-04-19 10:37:04.119316356 +0000
@@ -7422,7 +7422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602288000000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -9864,7 +9864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 445,
+        "F\u00e4lle_Meldedatum": 444,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -10623,7 +10623,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -12253,8 +12253,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 96,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12286,8 +12286,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 99,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12319,8 +12319,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 104,
-        "Zuwachs_Mutation": 5
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12352,8 +12352,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 105,
-        "Zuwachs_Mutation": 1
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12385,8 +12385,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 118,
-        "Zuwachs_Mutation": 13
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12418,8 +12418,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 138,
-        "Zuwachs_Mutation": 20
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12451,8 +12451,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 146,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12484,8 +12484,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 173,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12517,8 +12517,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
-        "Mutation": 206,
-        "Zuwachs_Mutation": 33
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12550,8 +12550,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 210,
-        "Zuwachs_Mutation": 4
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12583,8 +12583,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": 212,
-        "Zuwachs_Mutation": 2
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12616,8 +12616,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 240,
-        "Zuwachs_Mutation": 28
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12649,8 +12649,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 284,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12682,8 +12682,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 322,
-        "Zuwachs_Mutation": 38
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12715,8 +12715,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 370,
-        "Zuwachs_Mutation": 48
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12748,8 +12748,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 416,
-        "Zuwachs_Mutation": 46
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12781,8 +12781,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 430,
-        "Zuwachs_Mutation": 14
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12814,8 +12814,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 439,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 170,
+        "F\u00e4lle_Meldedatum": 169,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12847,8 +12847,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 469,
-        "Zuwachs_Mutation": 30
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12880,8 +12880,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 534,
-        "Zuwachs_Mutation": 65
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12913,8 +12913,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 626,
-        "Zuwachs_Mutation": 92
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12946,8 +12946,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 707,
-        "Zuwachs_Mutation": 81
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -12979,8 +12979,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 751,
-        "Zuwachs_Mutation": 44
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13012,8 +13012,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 778,
-        "Zuwachs_Mutation": 27
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13045,8 +13045,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 786,
-        "Zuwachs_Mutation": 8
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13078,8 +13078,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 893,
-        "Zuwachs_Mutation": 107
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13111,8 +13111,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 975,
-        "Zuwachs_Mutation": 82
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13144,8 +13144,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 1087,
-        "Zuwachs_Mutation": 112
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13177,8 +13177,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 1179,
-        "Zuwachs_Mutation": 92
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13210,8 +13210,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 1194,
-        "Zuwachs_Mutation": 15
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13243,8 +13243,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 1206,
-        "Zuwachs_Mutation": 12
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13276,8 +13276,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
-        "Mutation": 1215,
-        "Zuwachs_Mutation": 9
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13309,8 +13309,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 1232,
-        "Zuwachs_Mutation": 17
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13342,8 +13342,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 1268,
-        "Zuwachs_Mutation": 36
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13375,8 +13375,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1385,
-        "Zuwachs_Mutation": 117
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13408,8 +13408,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1484,
-        "Zuwachs_Mutation": 99
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13441,8 +13441,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1546,
-        "Zuwachs_Mutation": 62
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13459,12 +13459,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
-        "Inzidenz": 146.556988397572,
+        "Inzidenz": null,
         "Datum_neu": 1618099200000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 136.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13473,9 +13473,9 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 193.4,
-        "Mutation": 1564,
-        "Zuwachs_Mutation": 18
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13492,9 +13492,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 121,
         "BelegteBetten": null,
-        "Inzidenz": 147.455009159812,
+        "Inzidenz": 147.5,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 144.9,
@@ -13507,8 +13507,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 203.6,
-        "Mutation": 1567,
-        "Zuwachs_Mutation": 3
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13525,9 +13525,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
-        "Inzidenz": 154.81877941018,
+        "Inzidenz": 154.8,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 201,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 136.3,
@@ -13540,8 +13540,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 212.1,
-        "Mutation": 1684,
-        "Zuwachs_Mutation": 117
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13558,9 +13558,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 109,
         "BelegteBetten": null,
-        "Inzidenz": 171.521965587844,
+        "Inzidenz": 171.5,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 147.6,
@@ -13573,8 +13573,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 227.8,
-        "Mutation": 1804,
-        "Zuwachs_Mutation": 120
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13591,11 +13591,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
-        "Inzidenz": 167.39107008154,
+        "Inzidenz": 167.4,
         "Datum_neu": 1618444800000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 147.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13606,8 +13606,8 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 235.3,
-        "Mutation": 1902,
-        "Zuwachs_Mutation": 98
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13626,21 +13626,21 @@
         "BelegteBetten": null,
         "Inzidenz": 164.7,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 146.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
-        "Krh_I_frei": 32,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 229.5,
-        "Mutation": 1967,
-        "Zuwachs_Mutation": 65
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13648,32 +13648,32 @@
         "Datum": "17.04.2021",
         "Fallzahl": 26818,
         "ObjectId": 407,
-        "Sterbefall": 1012,
-        "Genesungsfall": 24083,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2348,
-        "Zuwachs_Fallzahl": 57,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 64,
         "BelegteBetten": null,
-        "Inzidenz": 139.193218147204,
+        "Inzidenz": 139.2,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 134.5,
-        "Fallzahl_aktiv": 1723,
-        "Krh_I_belegt": 247,
-        "Krh_I_frei": 33,
-        "Fallzahl_aktiv_Zuwachs": -7,
-        "Krh_I": 280,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 231.5,
-        "Mutation": 2042,
-        "Zuwachs_Mutation": 75
+        "Mutation": null,
+        "Zuwachs_Mutation": null
       }
     },
     {
@@ -13681,32 +13681,65 @@
         "Datum": "18.04.2021",
         "Fallzahl": 26935,
         "ObjectId": 408,
-        "Sterbefall": 1012,
-        "Genesungsfall": 24108,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2348,
-        "Zuwachs_Fallzahl": 117,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 25,
         "BelegteBetten": null,
-        "Inzidenz": 151.585904666116,
+        "Inzidenz": 151.6,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 31,
-        "Zeitraum": "11.04.2021 - 17.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 29,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 136.7,
-        "Fallzahl_aktiv": 1815,
-        "Krh_I_belegt": 241,
-        "Krh_I_frei": 39,
-        "Fallzahl_aktiv_Zuwachs": 92,
-        "Krh_I": 280,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 46,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 233.6,
-        "Mutation": 2072,
-        "Zuwachs_Mutation": 30
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.04.2021",
+        "Fallzahl": 26943,
+        "ObjectId": 409,
+        "Sterbefall": 1012,
+        "Genesungsfall": 24161,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2359,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 53,
+        "BelegteBetten": null,
+        "Inzidenz": 153.6,
+        "Datum_neu": 1618790400000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "12.04.2021 - 18.04.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 153.4,
+        "Fallzahl_aktiv": 1770,
+        "Krh_I_belegt": 237,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": -45,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 48,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 236.5,
+        "Mutation": 2082,
+        "Zuwachs_Mutation": 10
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
