### PR TITLE
New data set: 2021-04-20T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-19T103704Z.json
+pjson/2021-04-20T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-19T103704Z.json pjson/2021-04-20T100903Z.json```:
```
--- pjson/2021-04-19T103704Z.json	2021-04-19 10:37:04.119316356 +0000
+++ pjson/2021-04-20T100903Z.json	2021-04-20 10:09:03.339869831 +0000
@@ -8643,7 +8643,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -9171,7 +9171,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9435,7 +9435,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 466,
+        "F\u00e4lle_Meldedatum": 465,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10392,7 +10392,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 212,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -10491,7 +10491,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -12374,7 +12374,7 @@
         "Datum_neu": 1615248000000,
         "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12539,7 +12539,7 @@
         "Datum_neu": 1615680000000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12669,7 +12669,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -12803,7 +12803,7 @@
         "Datum_neu": 1616371200000,
         "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13065,7 +13065,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13164,9 +13164,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13296,9 +13296,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13329,7 +13329,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 233,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13362,7 +13362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13428,7 +13428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618012800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -13492,12 +13492,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 121,
         "BelegteBetten": null,
-        "Inzidenz": 147.5,
+        "Inzidenz": null,
         "Datum_neu": 1618185600000,
         "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 144.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13506,7 +13506,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 203.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": 154.8,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 136.3,
@@ -13562,7 +13562,7 @@
         "Datum_neu": 1618358400000,
         "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 147.6,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": 167.4,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 147.6,
@@ -13604,7 +13604,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 235.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": 164.7,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 146.9,
@@ -13659,7 +13659,7 @@
         "BelegteBetten": null,
         "Inzidenz": 139.2,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 134.5,
@@ -13692,7 +13692,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 29,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 136.7,
@@ -13714,32 +13714,65 @@
         "Datum": "19.04.2021",
         "Fallzahl": 26943,
         "ObjectId": 409,
-        "Sterbefall": 1012,
-        "Genesungsfall": 24161,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2359,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "12.04.2021 - 18.04.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 116,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 153.4,
-        "Fallzahl_aktiv": 1770,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 236.5,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.04.2021",
+        "Fallzahl": 27118,
+        "ObjectId": 410,
+        "Sterbefall": 1013,
+        "Genesungsfall": 24303,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2380,
+        "Zuwachs_Fallzahl": 175,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 142,
+        "BelegteBetten": null,
+        "Inzidenz": 144,
+        "Datum_neu": 1618876800000,
+        "F\u00e4lle_Meldedatum": 74,
+        "Zeitraum": "13.04.2021 - 19.04.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 121.4,
+        "Fallzahl_aktiv": 1802,
         "Krh_I_belegt": 237,
         "Krh_I_frei": 43,
-        "Fallzahl_aktiv_Zuwachs": -45,
+        "Fallzahl_aktiv_Zuwachs": 32,
         "Krh_I": 280,
-        "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 48,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 46,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 236.5,
-        "Mutation": 2082,
-        "Zuwachs_Mutation": 10
+        "Inzi_SN_RKI": 220.9,
+        "Mutation": 2121,
+        "Zuwachs_Mutation": 39
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
