### PR TITLE
New data set: 2021-04-21T105605Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-20T100903Z.json
+pjson/2021-04-21T105605Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-20T100903Z.json pjson/2021-04-21T105605Z.json```:
```
--- pjson/2021-04-20T100903Z.json	2021-04-20 10:09:03.339869831 +0000
+++ pjson/2021-04-21T105605Z.json	2021-04-21 10:56:05.197850436 +0000
@@ -12383,7 +12383,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13065,7 +13065,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13076,7 +13076,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13164,7 +13164,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13263,7 +13263,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617580800000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -13274,7 +13274,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13296,7 +13296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13329,7 +13329,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13340,7 +13340,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13362,7 +13362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13373,7 +13373,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13406,7 +13406,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13472,7 +13472,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13525,12 +13525,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
-        "Inzidenz": 154.8,
+        "Inzidenz": null,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 136.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13539,7 +13539,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 212.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": 171.5,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 147.6,
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": 167.4,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 147.6,
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": 164.7,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 146.9,
@@ -13692,7 +13692,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 136.7,
@@ -13725,9 +13725,9 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 153.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13747,32 +13747,65 @@
         "Datum": "20.04.2021",
         "Fallzahl": 27118,
         "ObjectId": 410,
-        "Sterbefall": 1013,
-        "Genesungsfall": 24303,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2380,
-        "Zuwachs_Fallzahl": 175,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 142,
         "BelegteBetten": null,
         "Inzidenz": 144,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 74,
-        "Zeitraum": "13.04.2021 - 19.04.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 166,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 121.4,
-        "Fallzahl_aktiv": 1802,
-        "Krh_I_belegt": 237,
-        "Krh_I_frei": 43,
-        "Fallzahl_aktiv_Zuwachs": 32,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 220.9,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.04.2021",
+        "Fallzahl": 27364,
+        "ObjectId": 411,
+        "Sterbefall": 1022,
+        "Genesungsfall": 24531,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2394,
+        "Zuwachs_Fallzahl": 246,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 228,
+        "BelegteBetten": null,
+        "Inzidenz": 143.1,
+        "Datum_neu": 1618963200000,
+        "F\u00e4lle_Meldedatum": 107,
+        "Zeitraum": "14.04.2021 - 20.04.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 118.5,
+        "Fallzahl_aktiv": 1811,
+        "Krh_I_belegt": 244,
+        "Krh_I_frei": 36,
+        "Fallzahl_aktiv_Zuwachs": 9,
         "Krh_I": 280,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 46,
+        "Krh_I_covid": 47,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 220.9,
-        "Mutation": 2121,
-        "Zuwachs_Mutation": 39
+        "Inzi_SN_RKI": 200.8,
+        "Mutation": 2285,
+        "Zuwachs_Mutation": 164
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
