### PR TITLE
New data set: 2021-04-22T102504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-21T105605Z.json
+pjson/2021-04-22T102504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-21T105605Z.json pjson/2021-04-22T102504Z.json```:
```
--- pjson/2021-04-21T105605Z.json	2021-04-21 10:56:05.197850436 +0000
+++ pjson/2021-04-22T102504Z.json	2021-04-22 10:25:04.216775263 +0000
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -12966,7 +12966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13131,7 +13131,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13175,7 +13175,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13307,7 +13307,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13329,7 +13329,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 233,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13373,7 +13373,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13439,7 +13439,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13558,12 +13558,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 109,
         "BelegteBetten": null,
-        "Inzidenz": 171.5,
+        "Inzidenz": null,
         "Datum_neu": 1618358400000,
         "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 147.6,
+        "Hosp_Meldedatum": 15,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13572,7 +13572,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 227.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": 167.4,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 147.6,
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": 164.7,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 146.9,
@@ -13692,7 +13692,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 136.7,
@@ -13725,9 +13725,9 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 153.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": 144,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 166,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 121.4,
@@ -13780,32 +13780,65 @@
         "Datum": "21.04.2021",
         "Fallzahl": 27364,
         "ObjectId": 411,
-        "Sterbefall": 1022,
-        "Genesungsfall": 24531,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2394,
-        "Zuwachs_Fallzahl": 246,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 228,
         "BelegteBetten": null,
         "Inzidenz": 143.1,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 107,
-        "Zeitraum": "14.04.2021 - 20.04.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 156,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 118.5,
-        "Fallzahl_aktiv": 1811,
-        "Krh_I_belegt": 244,
-        "Krh_I_frei": 36,
-        "Fallzahl_aktiv_Zuwachs": 9,
-        "Krh_I": 280,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 47,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 200.8,
-        "Mutation": 2285,
-        "Zuwachs_Mutation": 164
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.04.2021",
+        "Fallzahl": 27501,
+        "ObjectId": 412,
+        "Sterbefall": 1027,
+        "Genesungsfall": 24673,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2398,
+        "Zuwachs_Fallzahl": 137,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 142,
+        "BelegteBetten": null,
+        "Inzidenz": 147.6,
+        "Datum_neu": 1619049600000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "15.04.2021 - 21.04.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 126.3,
+        "Fallzahl_aktiv": 1801,
+        "Krh_I_belegt": 246,
+        "Krh_I_frei": 34,
+        "Fallzahl_aktiv_Zuwachs": -10,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 48,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 201.8,
+        "Mutation": 2376,
+        "Zuwachs_Mutation": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
