### PR TITLE
New data set: 2021-04-25T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-24T100703Z.json
+pjson/2021-04-25T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-24T100703Z.json pjson/2021-04-25T100503Z.json```:
```
--- pjson/2021-04-24T100703Z.json	2021-04-24 10:07:03.096600653 +0000
+++ pjson/2021-04-25T100503Z.json	2021-04-25 10:05:03.767808264 +0000
@@ -7521,7 +7521,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602547200000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -8544,7 +8544,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -13657,12 +13657,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 64,
         "BelegteBetten": null,
-        "Inzidenz": 139.2,
+        "Inzidenz": null,
         "Datum_neu": 1618617600000,
         "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 134.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13671,7 +13671,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 231.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13692,7 +13692,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 136.7,
@@ -13725,7 +13725,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 164,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 153.4,
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.1,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 182,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 118.5,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.6,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 126.3,
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 129.5,
@@ -13879,31 +13879,64 @@
         "Datum": "24.04.2021",
         "Fallzahl": 27760,
         "ObjectId": 414,
-        "Sterbefall": 1039,
-        "Genesungsfall": 24901,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2412,
-        "Zuwachs_Fallzahl": 114,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 41,
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619222400000,
-        "F\u00e4lle_Meldedatum": 46,
-        "Zeitraum": "17.04.2021 - 23.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 88,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 141.3,
-        "Fallzahl_aktiv": 1820,
-        "Krh_I_belegt": 248,
-        "Krh_I_frei": 33,
-        "Fallzahl_aktiv_Zuwachs": 72,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 212.5,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.04.2021",
+        "Fallzahl": 27839,
+        "ObjectId": 415,
+        "Sterbefall": 1039,
+        "Genesungsfall": 24913,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2413,
+        "Zuwachs_Fallzahl": 79,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 12,
+        "BelegteBetten": null,
+        "Inzidenz": 158.1,
+        "Datum_neu": 1619308800000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "18.04.2021 - 24.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 144.6,
+        "Fallzahl_aktiv": 1887,
+        "Krh_I_belegt": 247,
+        "Krh_I_frei": 34,
+        "Fallzahl_aktiv_Zuwachs": 67,
         "Krh_I": 281,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 48,
+        "Krh_I_covid": 49,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 212.5,
-        "Mutation": 2572,
+        "Inzi_SN_RKI": 218.8,
+        "Mutation": 2597,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
