### PR TITLE
New data set: 2021-04-26T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-25T100503Z.json
+pjson/2021-04-26T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-25T100503Z.json pjson/2021-04-26T100603Z.json```:
```
--- pjson/2021-04-25T100503Z.json	2021-04-25 10:05:03.767808264 +0000
+++ pjson/2021-04-26T100603Z.json	2021-04-26 10:06:03.797440339 +0000
@@ -12176,7 +12176,7 @@
         "Datum_neu": 1614729600000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12605,7 +12605,7 @@
         "Datum_neu": 1615852800000,
         "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12867,9 +12867,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13133,7 +13133,7 @@
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13659,7 +13659,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13690,12 +13690,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 25,
         "BelegteBetten": null,
-        "Inzidenz": 151.6,
+        "Inzidenz": null,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 136.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13704,7 +13704,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 233.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13725,7 +13725,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 164,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 153.4,
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": 144,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 121.4,
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.1,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 118.5,
@@ -13804,7 +13804,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 200.8,
-        "Mutation": null,
+        "Mutation": 2285,
         "Zuwachs_Mutation": null
       }
     },
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.6,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 126.3,
@@ -13837,7 +13837,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 201.8,
-        "Mutation": null,
+        "Mutation": 2376,
         "Zuwachs_Mutation": null
       }
     },
@@ -13857,9 +13857,9 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 129.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13870,7 +13870,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 209.3,
-        "Mutation": null,
+        "Mutation": 2478,
         "Zuwachs_Mutation": null
       }
     },
@@ -13890,9 +13890,9 @@
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619222400000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 141.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13901,9 +13901,9 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 212.5,
-        "Mutation": null,
+        "Mutation": 2572,
         "Zuwachs_Mutation": null
       }
     },
@@ -13914,31 +13914,64 @@
         "ObjectId": 415,
         "Sterbefall": 1039,
         "Genesungsfall": 24913,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2413,
         "Zuwachs_Fallzahl": 79,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 1,
         "Zuwachs_Genesung": 12,
         "BelegteBetten": null,
-        "Inzidenz": 158.1,
+        "Inzidenz": 158.051654154244,
         "Datum_neu": 1619308800000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "18.04.2021 - 24.04.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 144.6,
         "Fallzahl_aktiv": 1887,
-        "Krh_I_belegt": 247,
-        "Krh_I_frei": 34,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 67,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 49,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 218.8,
         "Mutation": 2597,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.04.2021",
+        "Fallzahl": 27864,
+        "ObjectId": 416,
+        "Sterbefall": 1040,
+        "Genesungsfall": 25080,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2430,
+        "Zuwachs_Fallzahl": 25,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 167,
+        "BelegteBetten": null,
+        "Inzidenz": 161.464133050756,
+        "Datum_neu": 1619395200000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "19.04.2021 - 25.04.2021",
+        "Hosp_Meldedatum": 13,
+        "Inzidenz_RKI": 155.2,
+        "Fallzahl_aktiv": 1744,
+        "Krh_I_belegt": 245,
+        "Krh_I_frei": 36,
+        "Fallzahl_aktiv_Zuwachs": -143,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 52,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 232,
+        "Mutation": 2617,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
