### PR TITLE
New data set: 2021-04-27T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-26T100603Z.json
+pjson/2021-04-27T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-26T100603Z.json pjson/2021-04-27T100603Z.json```:
```
--- pjson/2021-04-26T100603Z.json	2021-04-26 10:06:03.797440339 +0000
+++ pjson/2021-04-27T100603Z.json	2021-04-27 10:06:03.487122313 +0000
@@ -13296,7 +13296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13659,7 +13659,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13723,12 +13723,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
-        "Inzidenz": 153.6,
+        "Inzidenz": null,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 153.4,
+        "Hosp_Meldedatum": 20,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13736,8 +13736,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 236.5,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": 144,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 121.4,
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.1,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 118.5,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.6,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 126.3,
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 129.5,
@@ -13890,7 +13890,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619222400000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 141.3,
@@ -13912,27 +13912,27 @@
         "Datum": "25.04.2021",
         "Fallzahl": 27839,
         "ObjectId": 415,
-        "Sterbefall": 1039,
-        "Genesungsfall": 24913,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2413,
-        "Zuwachs_Fallzahl": 79,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 12,
         "BelegteBetten": null,
         "Inzidenz": 158.051654154244,
         "Datum_neu": 1619308800000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 144.6,
-        "Fallzahl_aktiv": 1887,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 67,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 218.8,
@@ -13947,7 +13947,7 @@
         "ObjectId": 416,
         "Sterbefall": 1040,
         "Genesungsfall": 25080,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2430,
         "Zuwachs_Fallzahl": 25,
         "Zuwachs_Sterbefall": 1,
@@ -13956,22 +13956,55 @@
         "BelegteBetten": null,
         "Inzidenz": 161.464133050756,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "19.04.2021 - 25.04.2021",
-        "Hosp_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 108,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 155.2,
         "Fallzahl_aktiv": 1744,
-        "Krh_I_belegt": 245,
-        "Krh_I_frei": 36,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -143,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 52,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 232,
         "Mutation": 2617,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.04.2021",
+        "Fallzahl": 28104,
+        "ObjectId": 417,
+        "Sterbefall": 1041,
+        "Genesungsfall": 25276,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2445,
+        "Zuwachs_Fallzahl": 240,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 196,
+        "BelegteBetten": null,
+        "Inzidenz": 159.668091526276,
+        "Datum_neu": 1619481600000,
+        "F\u00e4lle_Meldedatum": 121,
+        "Zeitraum": "20.04.2021 - 26.04.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 134.3,
+        "Fallzahl_aktiv": 1787,
+        "Krh_I_belegt": 240,
+        "Krh_I_frei": 41,
+        "Fallzahl_aktiv_Zuwachs": 43,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 48,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 226.5,
+        "Mutation": 2697,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
