### PR TITLE
New data set: 2021-04-28T100504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-27T100603Z.json
+pjson/2021-04-28T100504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-27T100603Z.json pjson/2021-04-28T100504Z.json```:
```
--- pjson/2021-04-27T100603Z.json	2021-04-27 10:06:03.487122313 +0000
+++ pjson/2021-04-28T100504Z.json	2021-04-28 10:05:04.300019584 +0000
@@ -8709,7 +8709,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605657600000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -9105,7 +9105,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -9468,7 +9468,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 338,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -9534,7 +9534,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -9633,7 +9633,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 360,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -9699,7 +9699,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -9798,7 +9798,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 461,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -10359,7 +10359,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 269,
+        "F\u00e4lle_Meldedatum": 268,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -11052,7 +11052,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -11085,7 +11085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -11250,7 +11250,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612310400000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -12834,7 +12834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 170,
+        "F\u00e4lle_Meldedatum": 171,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -12900,7 +12900,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -13065,7 +13065,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 221,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13098,7 +13098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13659,7 +13659,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13725,7 +13725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -13756,12 +13756,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 142,
         "BelegteBetten": null,
-        "Inzidenz": 144,
+        "Inzidenz": null,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 121.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13770,7 +13770,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 220.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.1,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 176,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 118.5,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.6,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 164,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 126.3,
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 129.5,
@@ -13923,7 +13923,7 @@
         "BelegteBetten": null,
         "Inzidenz": 158.051654154244,
         "Datum_neu": 1619308800000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 144.6,
@@ -13945,25 +13945,25 @@
         "Datum": "26.04.2021",
         "Fallzahl": 27864,
         "ObjectId": 416,
-        "Sterbefall": 1040,
-        "Genesungsfall": 25080,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2430,
-        "Zuwachs_Fallzahl": 25,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 167,
         "BelegteBetten": null,
         "Inzidenz": 161.464133050756,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 155.2,
-        "Fallzahl_aktiv": 1744,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -143,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -13980,31 +13980,64 @@
         "ObjectId": 417,
         "Sterbefall": 1041,
         "Genesungsfall": 25276,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2445,
         "Zuwachs_Fallzahl": 240,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 15,
         "Zuwachs_Genesung": 196,
         "BelegteBetten": null,
-        "Inzidenz": 159.668091526276,
+        "Inzidenz": 159.7,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 121,
-        "Zeitraum": "20.04.2021 - 26.04.2021",
+        "F\u00e4lle_Meldedatum": 154,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 134.3,
         "Fallzahl_aktiv": 1787,
-        "Krh_I_belegt": 240,
-        "Krh_I_frei": 41,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 43,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 48,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 226.5,
         "Mutation": 2697,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.04.2021",
+        "Fallzahl": 28282,
+        "ObjectId": 418,
+        "Sterbefall": 1041,
+        "Genesungsfall": 25473,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2445,
+        "Zuwachs_Fallzahl": 178,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 197,
+        "BelegteBetten": null,
+        "Inzidenz": 165.056216099716,
+        "Datum_neu": 1619568000000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "21.04.2021 - 27.04.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 139.7,
+        "Fallzahl_aktiv": 1768,
+        "Krh_I_belegt": 247,
+        "Krh_I_frei": 34,
+        "Fallzahl_aktiv_Zuwachs": -19,
+        "Krh_I": 281,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 53,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 210.3,
+        "Mutation": 2830,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
