### PR TITLE
New data set: 2021-04-30T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-28T100504Z.json
+pjson/2021-04-30T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-29T100703Z.json pjson/2021-04-30T100403Z.json```:
```
--- pjson/2021-04-29T100703Z.json	2021-04-29 10:07:03.315411546 +0000
+++ pjson/2021-04-30T100403Z.json	2021-04-30 10:04:03.851480195 +0000
@@ -9435,7 +9435,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 465,
+        "F\u00e4lle_Meldedatum": 464,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -13164,7 +13164,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617321600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13362,7 +13362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 187,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13461,7 +13461,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618099200000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -13494,7 +13494,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13659,7 +13659,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13692,7 +13692,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -13725,7 +13725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -13791,9 +13791,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13802,7 +13802,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13822,12 +13822,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 142,
         "BelegteBetten": null,
-        "Inzidenz": 147.6,
+        "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 126.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13836,8 +13836,8 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 201.8,
-        "Mutation": 2376,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -13857,9 +13857,9 @@
         "BelegteBetten": null,
         "Inzidenz": 151.6,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 129.5,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13890,7 +13890,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619222400000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 141.3,
@@ -13923,7 +13923,7 @@
         "BelegteBetten": null,
         "Inzidenz": 158.051654154244,
         "Datum_neu": 1619308800000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 144.6,
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": 161.464133050756,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 178,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 155.2,
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": 159.7,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 134.3,
@@ -14011,25 +14011,25 @@
         "Datum": "28.04.2021",
         "Fallzahl": 28282,
         "ObjectId": 418,
-        "Sterbefall": 1041,
-        "Genesungsfall": 25473,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2445,
-        "Zuwachs_Fallzahl": 178,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
         "Inzidenz": 165.056216099716,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 139.7,
-        "Fallzahl_aktiv": 1768,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -19,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14046,7 +14046,7 @@
         "ObjectId": 419,
         "Sterbefall": 1047,
         "Genesungsfall": 25609,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2457,
         "Zuwachs_Fallzahl": 130,
         "Zuwachs_Sterbefall": 6,
@@ -14055,22 +14055,55 @@
         "BelegteBetten": null,
         "Inzidenz": 156.974029239556,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 43,
-        "Zeitraum": "22.04.2021 - 28.04.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 101,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 140.8,
         "Fallzahl_aktiv": 1756,
-        "Krh_I_belegt": 239,
-        "Krh_I_frei": 42,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -12,
-        "Krh_I": 281,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 49,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 214.3,
         "Mutation": 2922,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.04.2021",
+        "Fallzahl": 28515,
+        "ObjectId": 420,
+        "Sterbefall": 1048,
+        "Genesungsfall": 25630,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2469,
+        "Zuwachs_Fallzahl": 103,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 21,
+        "BelegteBetten": null,
+        "Inzidenz": 153.381946190596,
+        "Datum_neu": 1619740800000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "23.04.2021 - 29.04.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 134.9,
+        "Fallzahl_aktiv": 1837,
+        "Krh_I_belegt": 234,
+        "Krh_I_frei": 46,
+        "Fallzahl_aktiv_Zuwachs": 81,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 45,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 210.7,
+        "Mutation": 2984,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
