### PR TITLE
New data set: 2021-05-01T100207Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-04-30T100403Z.json
+pjson/2021-05-01T100207Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-04-30T100403Z.json pjson/2021-05-01T100207Z.json```:
```
--- pjson/2021-04-30T100403Z.json	2021-04-30 10:04:03.851480195 +0000
+++ pjson/2021-05-01T100207Z.json	2021-05-01 10:02:07.282411790 +0000
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -10986,7 +10986,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -13362,7 +13362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13692,7 +13692,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -13725,7 +13725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13855,12 +13855,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 187,
         "BelegteBetten": null,
-        "Inzidenz": 151.6,
+        "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 129.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13869,8 +13869,8 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 209.3,
-        "Mutation": 2478,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -13890,7 +13890,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619222400000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 141.3,
@@ -13923,7 +13923,7 @@
         "BelegteBetten": null,
         "Inzidenz": 158.051654154244,
         "Datum_neu": 1619308800000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 144.6,
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": 161.464133050756,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 155.2,
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": 159.7,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 197,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 134.3,
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": 165.056216099716,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 139.7,
@@ -14044,25 +14044,25 @@
         "Datum": "29.04.2021",
         "Fallzahl": 28412,
         "ObjectId": 419,
-        "Sterbefall": 1047,
-        "Genesungsfall": 25609,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2457,
-        "Zuwachs_Fallzahl": 130,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 136,
         "BelegteBetten": null,
         "Inzidenz": 156.974029239556,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 140.8,
-        "Fallzahl_aktiv": 1756,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14079,7 +14079,7 @@
         "ObjectId": 420,
         "Sterbefall": 1048,
         "Genesungsfall": 25630,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2469,
         "Zuwachs_Fallzahl": 103,
         "Zuwachs_Sterbefall": 1,
@@ -14088,22 +14088,55 @@
         "BelegteBetten": null,
         "Inzidenz": 153.381946190596,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 26,
-        "Zeitraum": "23.04.2021 - 29.04.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 97,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 134.9,
         "Fallzahl_aktiv": 1837,
-        "Krh_I_belegt": 234,
-        "Krh_I_frei": 46,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 81,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 45,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 210.7,
         "Mutation": 2984,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.05.2021",
+        "Fallzahl": 28625,
+        "ObjectId": 421,
+        "Sterbefall": 1048,
+        "Genesungsfall": 25730,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2475,
+        "Zuwachs_Fallzahl": 110,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 100,
+        "BelegteBetten": null,
+        "Inzidenz": 146.197780092676,
+        "Datum_neu": 1619827200000,
+        "F\u00e4lle_Meldedatum": 43,
+        "Zeitraum": "24.04.2021 - 30.04.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 130.8,
+        "Fallzahl_aktiv": 1847,
+        "Krh_I_belegt": 241,
+        "Krh_I_frei": 39,
+        "Fallzahl_aktiv_Zuwachs": 10,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 47,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 204.1,
+        "Mutation": 3021,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
