### PR TITLE
New data set: 2021-05-02T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-01T100207Z.json
+pjson/2021-05-02T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-01T100207Z.json pjson/2021-05-02T100203Z.json```:
```
--- pjson/2021-05-01T100207Z.json	2021-05-01 10:02:07.282411790 +0000
+++ pjson/2021-05-02T100203Z.json	2021-05-02 10:02:03.778243016 +0000
@@ -13595,7 +13595,7 @@
         "Datum_neu": 1618444800000,
         "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13659,7 +13659,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13692,7 +13692,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618704000000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 21,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -13725,7 +13725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13888,12 +13888,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 41,
         "BelegteBetten": null,
-        "Inzidenz": 153.4,
+        "Inzidenz": null,
         "Datum_neu": 1619222400000,
         "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 141.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13902,8 +13902,8 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 212.5,
-        "Mutation": 2572,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -13936,7 +13936,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 218.8,
-        "Mutation": 2597,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -13956,9 +13956,9 @@
         "BelegteBetten": null,
         "Inzidenz": 161.464133050756,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 155.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13969,7 +13969,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 232,
-        "Mutation": 2617,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": 159.7,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 134.3,
@@ -14002,7 +14002,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 226.5,
-        "Mutation": 2697,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": 165.056216099716,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 139.7,
@@ -14035,7 +14035,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 210.3,
-        "Mutation": 2830,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": 156.974029239556,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 140.8,
@@ -14068,7 +14068,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 214.3,
-        "Mutation": 2922,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -14077,31 +14077,31 @@
         "Datum": "30.04.2021",
         "Fallzahl": 28515,
         "ObjectId": 420,
-        "Sterbefall": 1048,
-        "Genesungsfall": 25630,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2469,
-        "Zuwachs_Fallzahl": 103,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
         "Inzidenz": 153.381946190596,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 134.9,
-        "Fallzahl_aktiv": 1837,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 81,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 210.7,
-        "Mutation": 2984,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -14112,7 +14112,7 @@
         "ObjectId": 421,
         "Sterbefall": 1048,
         "Genesungsfall": 25730,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2475,
         "Zuwachs_Fallzahl": 110,
         "Zuwachs_Sterbefall": 0,
@@ -14121,20 +14121,53 @@
         "BelegteBetten": null,
         "Inzidenz": 146.197780092676,
         "Datum_neu": 1619827200000,
-        "F\u00e4lle_Meldedatum": 43,
-        "Zeitraum": "24.04.2021 - 30.04.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 72,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 130.8,
         "Fallzahl_aktiv": 1847,
-        "Krh_I_belegt": 241,
-        "Krh_I_frei": 39,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 10,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 47,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 204.1,
-        "Mutation": 3021,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.05.2021",
+        "Fallzahl": 28657,
+        "ObjectId": 422,
+        "Sterbefall": 1048,
+        "Genesungsfall": 25754,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2479,
+        "Zuwachs_Fallzahl": 32,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 24,
+        "BelegteBetten": null,
+        "Inzidenz": 148.712238226948,
+        "Datum_neu": 1619913600000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "25.04.2021 - 01.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 143.3,
+        "Fallzahl_aktiv": 1855,
+        "Krh_I_belegt": 247,
+        "Krh_I_frei": 47,
+        "Fallzahl_aktiv_Zuwachs": 8,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 52,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 208.7,
+        "Mutation": 3030,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
