### PR TITLE
New data set: 2021-05-04T100703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-03T100302Z.json
+pjson/2021-05-04T100703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-03T100302Z.json pjson/2021-05-04T100703Z.json```:
```
--- pjson/2021-05-03T100302Z.json	2021-05-03 10:03:02.924427358 +0000
+++ pjson/2021-05-04T100703Z.json	2021-05-04 10:07:03.442143270 +0000
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13954,12 +13954,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 167,
         "BelegteBetten": null,
-        "Inzidenz": 161.5,
+        "Inzidenz": null,
         "Datum_neu": 1619395200000,
         "F\u00e4lle_Meldedatum": 187,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
-        "Inzidenz_RKI": 155.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -13968,7 +13968,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 232,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": 159.7,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 134.3,
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": 157,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 140.8,
@@ -14066,7 +14066,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 214.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14088,7 +14088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 134.9,
@@ -14123,7 +14123,7 @@
         "Datum_neu": 1619827200000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 130.8,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14154,9 +14154,9 @@
         "BelegteBetten": null,
         "Inzidenz": 148.7,
         "Datum_neu": 1619913600000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 143.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14176,31 +14176,64 @@
         "Datum": "03.05.2021",
         "Fallzahl": 28685,
         "ObjectId": 423,
-        "Sterbefall": 1049,
-        "Genesungsfall": 25879,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2489,
-        "Zuwachs_Fallzahl": 28,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 125,
         "BelegteBetten": null,
         "Inzidenz": 148,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 11,
-        "Zeitraum": "26.04.2021 - 02.05.2021",
-        "Hosp_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 99,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 144.9,
-        "Fallzahl_aktiv": 1757,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 62,
-        "Fallzahl_aktiv_Zuwachs": -98,
-        "Krh_I": 294,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 51,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 215.5,
-        "Mutation": 3048,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.05.2021",
+        "Fallzahl": 28819,
+        "ObjectId": 424,
+        "Sterbefall": 1050,
+        "Genesungsfall": 26095,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2498,
+        "Zuwachs_Fallzahl": 134,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 216,
+        "BelegteBetten": null,
+        "Inzidenz": 133.1,
+        "Datum_neu": 1620086400000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "27.04.2021 - 03.05.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 116.2,
+        "Fallzahl_aktiv": 1674,
+        "Krh_I_belegt": 243,
+        "Krh_I_frei": 51,
+        "Fallzahl_aktiv_Zuwachs": -83,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 52,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 204.2,
+        "Mutation": 3087,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
