### PR TITLE
New data set: 2021-05-05T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-04T100703Z.json
+pjson/2021-05-05T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-04T100703Z.json pjson/2021-05-05T100403Z.json```:
```
--- pjson/2021-05-04T100703Z.json	2021-05-04 10:07:03.442143270 +0000
+++ pjson/2021-05-05T100403Z.json	2021-05-05 10:04:03.548985936 +0000
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13987,12 +13987,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 196,
         "BelegteBetten": null,
-        "Inzidenz": 159.7,
+        "Inzidenz": null,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 134.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14001,7 +14001,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 226.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": 165.1,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 139.7,
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": 157,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 140.8,
@@ -14088,9 +14088,9 @@
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 134.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14121,7 +14121,7 @@
         "BelegteBetten": null,
         "Inzidenz": 146.2,
         "Datum_neu": 1619827200000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 130.8,
@@ -14154,7 +14154,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.7,
         "Datum_neu": 1619913600000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 143.3,
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 144.9,
@@ -14198,7 +14198,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 215.5,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14209,31 +14209,64 @@
         "Datum": "04.05.2021",
         "Fallzahl": 28819,
         "ObjectId": 424,
-        "Sterbefall": 1050,
-        "Genesungsfall": 26095,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2498,
-        "Zuwachs_Fallzahl": 134,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
         "Inzidenz": 133.1,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "27.04.2021 - 03.05.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 129,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 116.2,
-        "Fallzahl_aktiv": 1674,
-        "Krh_I_belegt": 243,
-        "Krh_I_frei": 51,
-        "Fallzahl_aktiv_Zuwachs": -83,
-        "Krh_I": 294,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 52,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 204.2,
-        "Mutation": 3087,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.05.2021",
+        "Fallzahl": 28989,
+        "ObjectId": 425,
+        "Sterbefall": 1052,
+        "Genesungsfall": 26283,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2506,
+        "Zuwachs_Fallzahl": 170,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 188,
+        "BelegteBetten": null,
+        "Inzidenz": 126.4,
+        "Datum_neu": 1620172800000,
+        "F\u00e4lle_Meldedatum": 54,
+        "Zeitraum": "28.04.2021 - 04.05.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 106.1,
+        "Fallzahl_aktiv": 1654,
+        "Krh_I_belegt": 246,
+        "Krh_I_frei": 48,
+        "Fallzahl_aktiv_Zuwachs": -20,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 48,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 177.3,
+        "Mutation": 3216,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
