### PR TITLE
New data set: 2021-05-06T100604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-05T100403Z.json
+pjson/2021-05-06T100604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-05T100403Z.json pjson/2021-05-06T100604Z.json```:
```
--- pjson/2021-05-05T100403Z.json	2021-05-05 10:04:03.548985936 +0000
+++ pjson/2021-05-06T100604Z.json	2021-05-06 10:06:04.857642492 +0000
@@ -9336,7 +9336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 377,
+        "F\u00e4lle_Meldedatum": 378,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 201,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13758,7 +13758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -14000,7 +14000,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14020,12 +14020,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
-        "Inzidenz": 165.1,
+        "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 139.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14034,7 +14034,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 210.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": 157,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 140.8,
@@ -14066,7 +14066,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 214.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14088,7 +14088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.4,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 134.9,
@@ -14154,7 +14154,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.7,
         "Datum_neu": 1619913600000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 143.3,
@@ -14187,9 +14187,9 @@
         "BelegteBetten": null,
         "Inzidenz": 148,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 144.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.1,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 116.2,
@@ -14242,31 +14242,64 @@
         "Datum": "05.05.2021",
         "Fallzahl": 28989,
         "ObjectId": 425,
-        "Sterbefall": 1052,
-        "Genesungsfall": 26283,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2506,
-        "Zuwachs_Fallzahl": 170,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 188,
         "BelegteBetten": null,
         "Inzidenz": 126.4,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 54,
-        "Zeitraum": "28.04.2021 - 04.05.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 80,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 106.1,
-        "Fallzahl_aktiv": 1654,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 177.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.05.2021",
+        "Fallzahl": 29112,
+        "ObjectId": 426,
+        "Sterbefall": 1054,
+        "Genesungsfall": 26440,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2508,
+        "Zuwachs_Fallzahl": 123,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 157,
+        "BelegteBetten": null,
+        "Inzidenz": 125.2,
+        "Datum_neu": 1620259200000,
+        "F\u00e4lle_Meldedatum": 40,
+        "Zeitraum": "29.04.2021 - 05.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 108.8,
+        "Fallzahl_aktiv": 1618,
         "Krh_I_belegt": 246,
         "Krh_I_frei": 48,
-        "Fallzahl_aktiv_Zuwachs": -20,
+        "Fallzahl_aktiv_Zuwachs": -36,
         "Krh_I": 294,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 48,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 177.3,
-        "Mutation": 3216,
+        "Inzi_SN_RKI": 179.9,
+        "Mutation": 3291,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
