### PR TITLE
New data set: 2021-05-07T100803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-06T100604Z.json
+pjson/2021-05-07T100803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-06T100604Z.json pjson/2021-05-07T100803Z.json```:
```
--- pjson/2021-05-06T100604Z.json	2021-05-06 10:06:04.857642492 +0000
+++ pjson/2021-05-07T100803Z.json	2021-05-07 10:08:03.302019248 +0000
@@ -9336,7 +9336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 378,
+        "F\u00e4lle_Meldedatum": 377,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -13362,7 +13362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13395,7 +13395,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13527,7 +13527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618272000000,
-        "F\u00e4lle_Meldedatum": 200,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13560,7 +13560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618358400000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -13593,7 +13593,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -13604,7 +13604,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13626,7 +13626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13659,7 +13659,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13791,7 +13791,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 176,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13923,7 +13923,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619308800000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -14053,12 +14053,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 136,
         "BelegteBetten": null,
-        "Inzidenz": 157,
+        "Inzidenz": null,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 140.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14067,7 +14067,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 214.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14121,7 +14121,7 @@
         "BelegteBetten": null,
         "Inzidenz": 146.2,
         "Datum_neu": 1619827200000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 130.8,
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 144.9,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.1,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 116.2,
@@ -14253,9 +14253,9 @@
         "BelegteBetten": null,
         "Inzidenz": 126.4,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 106.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14275,31 +14275,64 @@
         "Datum": "06.05.2021",
         "Fallzahl": 29112,
         "ObjectId": 426,
-        "Sterbefall": 1054,
-        "Genesungsfall": 26440,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2508,
-        "Zuwachs_Fallzahl": 123,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 157,
         "BelegteBetten": null,
         "Inzidenz": 125.2,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 40,
-        "Zeitraum": "29.04.2021 - 05.05.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 103,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 108.8,
-        "Fallzahl_aktiv": 1618,
-        "Krh_I_belegt": 246,
-        "Krh_I_frei": 48,
-        "Fallzahl_aktiv_Zuwachs": -36,
-        "Krh_I": 294,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 48,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 179.9,
-        "Mutation": 3291,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.05.2021",
+        "Fallzahl": 29224,
+        "ObjectId": 427,
+        "Sterbefall": 1055,
+        "Genesungsfall": 26589,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2517,
+        "Zuwachs_Fallzahl": 112,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 149,
+        "BelegteBetten": null,
+        "Inzidenz": 129.1,
+        "Datum_neu": 1620345600000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "30.04.2021 - 06.05.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 112.4,
+        "Fallzahl_aktiv": 1580,
+        "Krh_I_belegt": 245,
+        "Krh_I_frei": 50,
+        "Fallzahl_aktiv_Zuwachs": -38,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 49,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 184.3,
+        "Mutation": 3335,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
