### PR TITLE
New data set: 2021-05-08T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-07T100803Z.json
+pjson/2021-05-08T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-07T100803Z.json pjson/2021-05-08T100403Z.json```:
```
--- pjson/2021-05-07T100803Z.json	2021-05-07 10:08:03.302019248 +0000
+++ pjson/2021-05-08T100403Z.json	2021-05-08 10:04:03.811631317 +0000
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14086,12 +14086,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
-        "Inzidenz": 153.4,
+        "Inzidenz": null,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 134.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14100,7 +14100,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 210.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 144.9,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.1,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 116.2,
@@ -14253,7 +14253,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.4,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 106.1,
@@ -14284,9 +14284,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 157,
         "BelegteBetten": null,
-        "Inzidenz": 125.2,
+        "Inzidenz": 125.184094256259,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 108.8,
@@ -14310,29 +14310,62 @@
         "ObjectId": 427,
         "Sterbefall": 1055,
         "Genesungsfall": 26589,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2517,
         "Zuwachs_Fallzahl": 112,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 9,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
-        "Inzidenz": 129.1,
+        "Inzidenz": 129.135385610115,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "30.04.2021 - 06.05.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 112.4,
         "Fallzahl_aktiv": 1580,
-        "Krh_I_belegt": 245,
-        "Krh_I_frei": 50,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -38,
-        "Krh_I": 295,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 49,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 184.3,
-        "Mutation": 3335,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.05.2021",
+        "Fallzahl": 29284,
+        "ObjectId": 428,
+        "Sterbefall": 1055,
+        "Genesungsfall": 26655,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2518,
+        "Zuwachs_Fallzahl": 60,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 66,
+        "BelegteBetten": null,
+        "Inzidenz": 122.310427817091,
+        "Datum_neu": 1620432000000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": "01.05.2021 - 07.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 115.1,
+        "Fallzahl_aktiv": 1574,
+        "Krh_I_belegt": 245,
+        "Krh_I_frei": 49,
+        "Fallzahl_aktiv_Zuwachs": -6,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 51,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 177.6,
+        "Mutation": 3382,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
