### PR TITLE
New data set: 2021-05-09T095803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-08T100403Z.json
+pjson/2021-05-09T095803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-08T100403Z.json pjson/2021-05-09T095803Z.json```:
```
--- pjson/2021-05-08T100403Z.json	2021-05-08 10:04:03.811631317 +0000
+++ pjson/2021-05-09T095803Z.json	2021-05-09 09:58:03.152192380 +0000
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14121,7 +14121,7 @@
         "BelegteBetten": null,
         "Inzidenz": 146.2,
         "Datum_neu": 1619827200000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 130.8,
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 144.9,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.1,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 116.2,
@@ -14253,7 +14253,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.4,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 106.1,
@@ -14286,7 +14286,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 108.8,
@@ -14308,25 +14308,25 @@
         "Datum": "07.05.2021",
         "Fallzahl": 29224,
         "ObjectId": 427,
-        "Sterbefall": 1055,
-        "Genesungsfall": 26589,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2517,
-        "Zuwachs_Fallzahl": 112,
-        "Zuwachs_Sterbefall": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": 9,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
         "Inzidenz": 129.135385610115,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 112.4,
-        "Fallzahl_aktiv": 1580,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -38,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14343,7 +14343,7 @@
         "ObjectId": 428,
         "Sterbefall": 1055,
         "Genesungsfall": 26655,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2518,
         "Zuwachs_Fallzahl": 60,
         "Zuwachs_Sterbefall": 0,
@@ -14352,20 +14352,53 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "01.05.2021 - 07.05.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 115.1,
         "Fallzahl_aktiv": 1574,
-        "Krh_I_belegt": 245,
+        "Krh_I_belegt": null,
         "Krh_I_frei": 49,
         "Fallzahl_aktiv_Zuwachs": -6,
-        "Krh_I": 294,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 51,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 177.6,
-        "Mutation": 3382,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.05.2021",
+        "Fallzahl": 29360,
+        "ObjectId": 429,
+        "Sterbefall": 1055,
+        "Genesungsfall": 26688,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2519,
+        "Zuwachs_Fallzahl": 76,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 33,
+        "BelegteBetten": null,
+        "Inzidenz": 124.465677646467,
+        "Datum_neu": 1620518400000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "02.05.2021 - 08.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 112.6,
+        "Fallzahl_aktiv": 1617,
+        "Krh_I_belegt": 237,
+        "Krh_I_frei": 57,
+        "Fallzahl_aktiv_Zuwachs": 43,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 53,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 172.8,
+        "Mutation": 3405,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
