### PR TITLE
New data set: 2021-05-10T070403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-09T095803Z.json
+pjson/2021-05-10T070403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-09T095803Z.json pjson/2021-05-10T070403Z.json```:
```
--- pjson/2021-05-09T095803Z.json	2021-05-09 09:58:03.152192380 +0000
+++ pjson/2021-05-10T070403Z.json	2021-05-10 07:04:03.544859340 +0000
@@ -14398,7 +14398,7 @@
         "Krh_I_covid": 53,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 172.8,
-        "Mutation": 3405,
+        "Mutation": 12,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
