### PR TITLE
New data set: 2021-05-10T104703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-09T095803Z.json
+pjson/2021-05-10T104703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-10T070403Z.json pjson/2021-05-10T104703Z.json```:
```
--- pjson/2021-05-10T070403Z.json	2021-05-10 07:04:03.544859340 +0000
+++ pjson/2021-05-10T104703Z.json	2021-05-10 10:47:03.534757230 +0000
@@ -13197,7 +13197,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617408000000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -14066,7 +14066,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14088,7 +14088,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -14119,12 +14119,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 100,
         "BelegteBetten": null,
-        "Inzidenz": 146.2,
+        "Inzidenz": null,
         "Datum_neu": 1619827200000,
         "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 130.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14133,7 +14133,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 204.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 144.9,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.1,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 182,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 116.2,
@@ -14286,7 +14286,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 108.8,
@@ -14297,7 +14297,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 179.9,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14314,14 +14314,14 @@
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
         "Inzidenz": 129.135385610115,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 112.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14341,25 +14341,25 @@
         "Datum": "08.05.2021",
         "Fallzahl": 29284,
         "ObjectId": 428,
-        "Sterbefall": 1055,
-        "Genesungsfall": 26655,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2518,
-        "Zuwachs_Fallzahl": 60,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 66,
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 115.1,
-        "Fallzahl_aktiv": 1574,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
-        "Krh_I_frei": 49,
-        "Fallzahl_aktiv_Zuwachs": -6,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14376,7 +14376,7 @@
         "ObjectId": 429,
         "Sterbefall": 1055,
         "Genesungsfall": 26688,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2519,
         "Zuwachs_Fallzahl": 76,
         "Zuwachs_Sterbefall": 0,
@@ -14386,18 +14386,51 @@
         "Inzidenz": 124.465677646467,
         "Datum_neu": 1620518400000,
         "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "02.05.2021 - 08.05.2021",
-        "Hosp_Meldedatum": 0,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 112.6,
         "Fallzahl_aktiv": 1617,
-        "Krh_I_belegt": 237,
-        "Krh_I_frei": 57,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 43,
-        "Krh_I": 294,
+        "Krh_I": null,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 53,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 172.8,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.05.2021",
+        "Fallzahl": 29379,
+        "ObjectId": 430,
+        "Sterbefall": 1057,
+        "Genesungsfall": 26843,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2527,
+        "Zuwachs_Fallzahl": 19,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 155,
+        "BelegteBetten": null,
+        "Inzidenz": 123.388052731779,
+        "Datum_neu": 1620604800000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "03.05.2021 - 09.05.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 122.3,
+        "Fallzahl_aktiv": 1479,
+        "Krh_I_belegt": 243,
+        "Krh_I_frei": 49,
+        "Fallzahl_aktiv_Zuwachs": -138,
+        "Krh_I": 292,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 56,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 176.4,
         "Mutation": 12,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
