### PR TITLE
New data set: 2021-05-11T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-10T104703Z.json
+pjson/2021-05-11T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-10T104703Z.json pjson/2021-05-11T100603Z.json```:
```
--- pjson/2021-05-10T104703Z.json	2021-05-10 10:47:03.534757230 +0000
+++ pjson/2021-05-11T100603Z.json	2021-05-11 10:06:04.030396026 +0000
@@ -13857,7 +13857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -13934,7 +13934,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14088,7 +14088,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -14152,12 +14152,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
-        "Inzidenz": 148.7,
+        "Inzidenz": null,
         "Datum_neu": 1619913600000,
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 143.3,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14166,7 +14166,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 208.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14185,12 +14185,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 125,
         "BelegteBetten": null,
-        "Inzidenz": 148,
+        "Inzidenz": null,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 144.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14199,7 +14199,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 215.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14220,9 +14220,9 @@
         "BelegteBetten": null,
         "Inzidenz": 133.1,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 116.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14253,9 +14253,9 @@
         "BelegteBetten": null,
         "Inzidenz": 126.4,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 106.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14286,7 +14286,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 108.8,
@@ -14319,7 +14319,7 @@
         "BelegteBetten": null,
         "Inzidenz": 129.135385610115,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 112.4,
@@ -14352,7 +14352,7 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 115.1,
@@ -14374,27 +14374,27 @@
         "Datum": "09.05.2021",
         "Fallzahl": 29360,
         "ObjectId": 429,
-        "Sterbefall": 1055,
-        "Genesungsfall": 26688,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2519,
-        "Zuwachs_Fallzahl": 76,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
         "Inzidenz": 124.465677646467,
         "Datum_neu": 1620518400000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 112.6,
-        "Fallzahl_aktiv": 1617,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 43,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 172.8,
@@ -14409,7 +14409,7 @@
         "ObjectId": 430,
         "Sterbefall": 1057,
         "Genesungsfall": 26843,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2527,
         "Zuwachs_Fallzahl": 19,
         "Zuwachs_Sterbefall": 2,
@@ -14418,20 +14418,53 @@
         "BelegteBetten": null,
         "Inzidenz": 123.388052731779,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 14,
-        "Zeitraum": "03.05.2021 - 09.05.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 92,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 122.3,
         "Fallzahl_aktiv": 1479,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -138,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 176.4,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.05.2021",
+        "Fallzahl": 29495,
+        "ObjectId": 431,
+        "Sterbefall": 1058,
+        "Genesungsfall": 27024,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2537,
+        "Zuwachs_Fallzahl": 116,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 181,
+        "BelegteBetten": null,
+        "Inzidenz": 116.383490786307,
+        "Datum_neu": 1620691200000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "04.05.2021 - 10.05.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 97.2,
+        "Fallzahl_aktiv": 1413,
         "Krh_I_belegt": 243,
         "Krh_I_frei": 49,
-        "Fallzahl_aktiv_Zuwachs": -138,
+        "Fallzahl_aktiv_Zuwachs": -66,
         "Krh_I": 292,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 56,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 176.4,
-        "Mutation": 12,
+        "Inzi_SN_RKI": 167.6,
+        "Mutation": 13,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
