### PR TITLE
New data set: 2021-05-12T101104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-11T100603Z.json
+pjson/2021-05-12T101104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-11T100603Z.json pjson/2021-05-12T101104Z.json```:
```
--- pjson/2021-05-11T100603Z.json	2021-05-11 10:06:04.030396026 +0000
+++ pjson/2021-05-12T101104Z.json	2021-05-12 10:11:04.129359350 +0000
@@ -11019,7 +11019,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12867,7 +12867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -14154,7 +14154,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619913600000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -14189,7 +14189,7 @@
         "Datum_neu": 1620000000000,
         "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14218,12 +14218,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
-        "Inzidenz": 133.1,
+        "Inzidenz": null,
         "Datum_neu": 1620086400000,
         "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 116.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14232,7 +14232,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 204.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14253,7 +14253,7 @@
         "BelegteBetten": null,
         "Inzidenz": 126.4,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 106.1,
@@ -14286,9 +14286,9 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 108.8,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14319,7 +14319,7 @@
         "BelegteBetten": null,
         "Inzidenz": 129.135385610115,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 112.4,
@@ -14352,7 +14352,7 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 115.1,
@@ -14385,7 +14385,7 @@
         "BelegteBetten": null,
         "Inzidenz": 124.465677646467,
         "Datum_neu": 1620518400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 112.6,
@@ -14407,25 +14407,25 @@
         "Datum": "10.05.2021",
         "Fallzahl": 29379,
         "ObjectId": 430,
-        "Sterbefall": 1057,
-        "Genesungsfall": 26843,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2527,
-        "Zuwachs_Fallzahl": 19,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 155,
         "BelegteBetten": null,
         "Inzidenz": 123.388052731779,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 122.3,
-        "Fallzahl_aktiv": 1479,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -138,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14442,7 +14442,7 @@
         "ObjectId": 431,
         "Sterbefall": 1058,
         "Genesungsfall": 27024,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2537,
         "Zuwachs_Fallzahl": 116,
         "Zuwachs_Sterbefall": 1,
@@ -14451,19 +14451,52 @@
         "BelegteBetten": null,
         "Inzidenz": 116.383490786307,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "04.05.2021 - 10.05.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 88,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.2,
         "Fallzahl_aktiv": 1413,
-        "Krh_I_belegt": 243,
-        "Krh_I_frei": 49,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -66,
-        "Krh_I": 292,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 56,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 167.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.05.2021",
+        "Fallzahl": 29620,
+        "ObjectId": 432,
+        "Sterbefall": 1058,
+        "Genesungsfall": 27176,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2552,
+        "Zuwachs_Fallzahl": 125,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 152,
+        "BelegteBetten": null,
+        "Inzidenz": 103.990804267395,
+        "Datum_neu": 1620777600000,
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": "05.05.2021 - 11.05.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 92.9,
+        "Fallzahl_aktiv": 1386,
+        "Krh_I_belegt": 252,
+        "Krh_I_frei": 42,
+        "Fallzahl_aktiv_Zuwachs": -27,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 54,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 144.4,
         "Mutation": 13,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
