### PR TITLE
New data set: 2021-05-13T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-12T101104Z.json
+pjson/2021-05-13T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-12T101104Z.json pjson/2021-05-13T100303Z.json```:
```
--- pjson/2021-05-12T101104Z.json	2021-05-12 10:11:04.129359350 +0000
+++ pjson/2021-05-13T100303Z.json	2021-05-13 10:03:03.339435639 +0000
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -13989,7 +13989,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619481600000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14132,7 +14132,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14154,7 +14154,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619913600000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 176,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -14251,12 +14251,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 188,
         "BelegteBetten": null,
-        "Inzidenz": 126.4,
+        "Inzidenz": null,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 106.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14264,8 +14264,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 177.3,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14286,7 +14286,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.184094256259,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 108.8,
@@ -14319,7 +14319,7 @@
         "BelegteBetten": null,
         "Inzidenz": 129.135385610115,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 112.4,
@@ -14352,7 +14352,7 @@
         "BelegteBetten": null,
         "Inzidenz": 122.310427817091,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 115.1,
@@ -14418,9 +14418,9 @@
         "BelegteBetten": null,
         "Inzidenz": 123.388052731779,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 122.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14440,25 +14440,25 @@
         "Datum": "11.05.2021",
         "Fallzahl": 29495,
         "ObjectId": 431,
-        "Sterbefall": 1058,
-        "Genesungsfall": 27024,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2537,
-        "Zuwachs_Fallzahl": 116,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 181,
         "BelegteBetten": null,
         "Inzidenz": 116.383490786307,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.2,
-        "Fallzahl_aktiv": 1413,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -66,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14475,7 +14475,7 @@
         "ObjectId": 432,
         "Sterbefall": 1058,
         "Genesungsfall": 27176,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2552,
         "Zuwachs_Fallzahl": 125,
         "Zuwachs_Sterbefall": 0,
@@ -14484,19 +14484,52 @@
         "BelegteBetten": null,
         "Inzidenz": 103.990804267395,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 55,
-        "Zeitraum": "05.05.2021 - 11.05.2021",
+        "F\u00e4lle_Meldedatum": 82,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 92.9,
         "Fallzahl_aktiv": 1386,
-        "Krh_I_belegt": 252,
-        "Krh_I_frei": 42,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -27,
-        "Krh_I": 294,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 54,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 144.4,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.05.2021",
+        "Fallzahl": 29676,
+        "ObjectId": 433,
+        "Sterbefall": 1060,
+        "Genesungsfall": 27286,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2553,
+        "Zuwachs_Fallzahl": 56,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 110,
+        "BelegteBetten": null,
+        "Inzidenz": 99.5007004561946,
+        "Datum_neu": 1620864000000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "06.05.2021 - 12.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 92,
+        "Fallzahl_aktiv": 1330,
+        "Krh_I_belegt": 249,
+        "Krh_I_frei": 45,
+        "Fallzahl_aktiv_Zuwachs": -56,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 52,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 140.1,
         "Mutation": 13,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
