### PR TITLE
New data set: 2021-05-14T100205Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-13T100303Z.json
+pjson/2021-05-14T100205Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-13T100303Z.json pjson/2021-05-14T100205Z.json```:
```
--- pjson/2021-05-13T100303Z.json	2021-05-13 10:03:03.339435639 +0000
+++ pjson/2021-05-14T100205Z.json	2021-05-14 10:02:05.457074595 +0000
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -14253,7 +14253,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14284,12 +14284,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 157,
         "BelegteBetten": null,
-        "Inzidenz": 125.184094256259,
+        "Inzidenz": null,
         "Datum_neu": 1620259200000,
         "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 108.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14298,7 +14298,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 179.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14317,9 +14317,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
-        "Inzidenz": 129.135385610115,
+        "Inzidenz": 129.1,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 112.4,
@@ -14350,7 +14350,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 66,
         "BelegteBetten": null,
-        "Inzidenz": 122.310427817091,
+        "Inzidenz": 122.3,
         "Datum_neu": 1620432000000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
@@ -14383,7 +14383,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
-        "Inzidenz": 124.465677646467,
+        "Inzidenz": 124.5,
         "Datum_neu": 1620518400000,
         "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
@@ -14416,9 +14416,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 155,
         "BelegteBetten": null,
-        "Inzidenz": 123.388052731779,
+        "Inzidenz": 123.4,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 122.3,
@@ -14449,9 +14449,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 181,
         "BelegteBetten": null,
-        "Inzidenz": 116.383490786307,
+        "Inzidenz": 116.4,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.2,
@@ -14473,25 +14473,25 @@
         "Datum": "12.05.2021",
         "Fallzahl": 29620,
         "ObjectId": 432,
-        "Sterbefall": 1058,
-        "Genesungsfall": 27176,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2552,
-        "Zuwachs_Fallzahl": 125,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 152,
         "BelegteBetten": null,
-        "Inzidenz": 103.990804267395,
+        "Inzidenz": 104,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 92.9,
-        "Fallzahl_aktiv": 1386,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -27,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14506,31 +14506,64 @@
         "Datum": "13.05.2021",
         "Fallzahl": 29676,
         "ObjectId": 433,
-        "Sterbefall": 1060,
-        "Genesungsfall": 27286,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2553,
-        "Zuwachs_Fallzahl": 56,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 99.5007004561946,
+        "Inzidenz": 99.5,
         "Datum_neu": 1620864000000,
-        "F\u00e4lle_Meldedatum": 26,
-        "Zeitraum": "06.05.2021 - 12.05.2021",
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 92,
-        "Fallzahl_aktiv": 1330,
-        "Krh_I_belegt": 249,
-        "Krh_I_frei": 45,
-        "Fallzahl_aktiv_Zuwachs": -56,
-        "Krh_I": 294,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 52,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 140.1,
-        "Mutation": 13,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.05.2021",
+        "Fallzahl": 29718,
+        "ObjectId": 434,
+        "Sterbefall": 1060,
+        "Genesungsfall": 27399,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2553,
+        "Zuwachs_Fallzahl": 42,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 113,
+        "BelegteBetten": null,
+        "Inzidenz": 89.1,
+        "Datum_neu": 1620950400000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "07.05.2021 - 13.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 87.3,
+        "Fallzahl_aktiv": 1259,
+        "Krh_I_belegt": 256,
+        "Krh_I_frei": 38,
+        "Fallzahl_aktiv_Zuwachs": -71,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 56,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 133.9,
+        "Mutation": 14,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
