### PR TITLE
New data set: 2021-05-15T100130Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-14T100205Z.json
+pjson/2021-05-15T100130Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-14T100205Z.json pjson/2021-05-15T100130Z.json```:
```
--- pjson/2021-05-14T100205Z.json	2021-05-14 10:02:05.457074595 +0000
+++ pjson/2021-05-15T100130Z.json	2021-05-15 10:01:31.088685938 +0000
@@ -13956,7 +13956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -14121,7 +14121,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619827200000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 176,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -14253,7 +14253,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14317,12 +14317,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
-        "Inzidenz": 129.1,
+        "Inzidenz": null,
         "Datum_neu": 1620345600000,
         "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 112.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14331,7 +14331,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 184.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14352,7 +14352,7 @@
         "BelegteBetten": null,
         "Inzidenz": 122.3,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 115.1,
@@ -14385,7 +14385,7 @@
         "BelegteBetten": null,
         "Inzidenz": 124.5,
         "Datum_neu": 1620518400000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 112.6,
@@ -14418,7 +14418,7 @@
         "BelegteBetten": null,
         "Inzidenz": 123.4,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 122.3,
@@ -14451,7 +14451,7 @@
         "BelegteBetten": null,
         "Inzidenz": 116.4,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.2,
@@ -14484,7 +14484,7 @@
         "BelegteBetten": null,
         "Inzidenz": 104,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 92.9,
@@ -14517,7 +14517,7 @@
         "BelegteBetten": null,
         "Inzidenz": 99.5,
         "Datum_neu": 1620864000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 92,
@@ -14541,28 +14541,61 @@
         "ObjectId": 434,
         "Sterbefall": 1060,
         "Genesungsfall": 27399,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2553,
         "Zuwachs_Fallzahl": 42,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
-        "Inzidenz": 89.1,
+        "Inzidenz": 89.0836596142103,
         "Datum_neu": 1620950400000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "07.05.2021 - 13.05.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 87.3,
         "Fallzahl_aktiv": 1259,
-        "Krh_I_belegt": 256,
-        "Krh_I_frei": 38,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -71,
-        "Krh_I": 294,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 56,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 133.9,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.05.2021",
+        "Fallzahl": 29802,
+        "ObjectId": 435,
+        "Sterbefall": 1060,
+        "Genesungsfall": 27475,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2561,
+        "Zuwachs_Fallzahl": 84,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 76,
+        "BelegteBetten": null,
+        "Inzidenz": 82.7975142785301,
+        "Datum_neu": 1621036800000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "08.05.2021 - 14.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 74.9,
+        "Fallzahl_aktiv": 1267,
+        "Krh_I_belegt": 258,
+        "Krh_I_frei": 36,
+        "Fallzahl_aktiv_Zuwachs": 8,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 59,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 122.6,
         "Mutation": 14,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
