### PR TITLE
New data set: 2021-05-16T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-15T100130Z.json
+pjson/2021-05-16T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-15T100130Z.json pjson/2021-05-16T100903Z.json```:
```
--- pjson/2021-05-15T100130Z.json	2021-05-15 10:01:31.088685938 +0000
+++ pjson/2021-05-16T100903Z.json	2021-05-16 10:09:03.677222091 +0000
@@ -9930,7 +9930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -10953,7 +10953,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -14350,12 +14350,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 66,
         "BelegteBetten": null,
-        "Inzidenz": 122.3,
+        "Inzidenz": null,
         "Datum_neu": 1620432000000,
         "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 115.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14364,7 +14364,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 177.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14539,25 +14539,25 @@
         "Datum": "14.05.2021",
         "Fallzahl": 29718,
         "ObjectId": 434,
-        "Sterbefall": 1060,
-        "Genesungsfall": 27399,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2553,
-        "Zuwachs_Fallzahl": 42,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
-        "Inzidenz": 89.0836596142103,
+        "Inzidenz": 89.1,
         "Datum_neu": 1620950400000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 87.3,
-        "Fallzahl_aktiv": 1259,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -71,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14572,30 +14572,63 @@
         "Datum": "15.05.2021",
         "Fallzahl": 29802,
         "ObjectId": 435,
-        "Sterbefall": 1060,
-        "Genesungsfall": 27475,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2561,
-        "Zuwachs_Fallzahl": 84,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 76,
         "BelegteBetten": null,
-        "Inzidenz": 82.7975142785301,
+        "Inzidenz": 82.8,
         "Datum_neu": 1621036800000,
-        "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "08.05.2021 - 14.05.2021",
+        "F\u00e4lle_Meldedatum": 64,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 74.9,
-        "Fallzahl_aktiv": 1267,
-        "Krh_I_belegt": 258,
-        "Krh_I_frei": 36,
-        "Fallzahl_aktiv_Zuwachs": 8,
-        "Krh_I": 294,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 59,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 122.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.05.2021",
+        "Fallzahl": 29823,
+        "ObjectId": 436,
+        "Sterbefall": 1060,
+        "Genesungsfall": 27497,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2562,
+        "Zuwachs_Fallzahl": 21,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 22,
+        "BelegteBetten": null,
+        "Inzidenz": 83.7,
+        "Datum_neu": 1621123200000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "09.05.2021 - 15.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 79.9,
+        "Fallzahl_aktiv": 1266,
+        "Krh_I_belegt": 252,
+        "Krh_I_frei": 42,
+        "Fallzahl_aktiv_Zuwachs": -1,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 56,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 111.5,
         "Mutation": 14,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
