### PR TITLE
New data set: 2021-05-17T103703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-16T100903Z.json
+pjson/2021-05-17T103703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-16T100903Z.json pjson/2021-05-17T103703Z.json```:
```
--- pjson/2021-05-16T100903Z.json	2021-05-16 10:09:03.677222091 +0000
+++ pjson/2021-05-17T103703Z.json	2021-05-17 10:37:03.961196571 +0000
@@ -14286,7 +14286,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620259200000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -14383,12 +14383,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
-        "Inzidenz": 124.5,
+        "Inzidenz": null,
         "Datum_neu": 1620518400000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 112.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14397,7 +14397,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 172.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14418,7 +14418,7 @@
         "BelegteBetten": null,
         "Inzidenz": 123.4,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 122.3,
@@ -14451,7 +14451,7 @@
         "BelegteBetten": null,
         "Inzidenz": 116.4,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.2,
@@ -14484,7 +14484,7 @@
         "BelegteBetten": null,
         "Inzidenz": 104,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 92.9,
@@ -14550,7 +14550,7 @@
         "BelegteBetten": null,
         "Inzidenz": 89.1,
         "Datum_neu": 1620950400000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 87.3,
@@ -14583,7 +14583,7 @@
         "BelegteBetten": null,
         "Inzidenz": 82.8,
         "Datum_neu": 1621036800000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 74.9,
@@ -14596,7 +14596,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 122.6,
-        "Mutation": null,
+        "Mutation": 14,
         "Zuwachs_Mutation": null
       }
     },
@@ -14607,7 +14607,7 @@
         "ObjectId": 436,
         "Sterbefall": 1060,
         "Genesungsfall": 27497,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2562,
         "Zuwachs_Fallzahl": 21,
         "Zuwachs_Sterbefall": 0,
@@ -14616,22 +14616,55 @@
         "BelegteBetten": null,
         "Inzidenz": 83.7,
         "Datum_neu": 1621123200000,
-        "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "09.05.2021 - 15.05.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 79.9,
         "Fallzahl_aktiv": 1266,
-        "Krh_I_belegt": 252,
-        "Krh_I_frei": 42,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -1,
-        "Krh_I": 294,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 56,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 111.5,
         "Mutation": 14,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.05.2021",
+        "Fallzahl": 29829,
+        "ObjectId": 437,
+        "Sterbefall": 1060,
+        "Genesungsfall": 27607,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2569,
+        "Zuwachs_Fallzahl": 6,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 110,
+        "BelegteBetten": null,
+        "Inzidenz": 83.3363267358741,
+        "Datum_neu": 1621209600000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "10.05.2021 - 16.05.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 82.6,
+        "Fallzahl_aktiv": 1162,
+        "Krh_I_belegt": 257,
+        "Krh_I_frei": 38,
+        "Fallzahl_aktiv_Zuwachs": -104,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 59,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 112.3,
+        "Mutation": 14,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
