### PR TITLE
New data set: 2021-05-18T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-17T103703Z.json
+pjson/2021-05-18T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-17T103703Z.json pjson/2021-05-18T101103Z.json```:
```
--- pjson/2021-05-17T103703Z.json	2021-05-17 10:37:03.961196571 +0000
+++ pjson/2021-05-18T101103Z.json	2021-05-18 10:11:03.984198263 +0000
@@ -14165,7 +14165,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -14231,7 +14231,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14264,7 +14264,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14319,7 +14319,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -14416,12 +14416,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 155,
         "BelegteBetten": null,
-        "Inzidenz": 123.4,
+        "Inzidenz": null,
         "Datum_neu": 1620604800000,
         "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 122.3,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14430,7 +14430,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 176.4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14451,7 +14451,7 @@
         "BelegteBetten": null,
         "Inzidenz": 116.4,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 97.2,
@@ -14484,9 +14484,9 @@
         "BelegteBetten": null,
         "Inzidenz": 104,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 92.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14519,7 +14519,7 @@
         "Datum_neu": 1620864000000,
         "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 92,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14550,9 +14550,9 @@
         "BelegteBetten": null,
         "Inzidenz": 89.1,
         "Datum_neu": 1620950400000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 87.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14583,7 +14583,7 @@
         "BelegteBetten": null,
         "Inzidenz": 82.8,
         "Datum_neu": 1621036800000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 74.9,
@@ -14596,7 +14596,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 122.6,
-        "Mutation": 14,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -14605,31 +14605,31 @@
         "Datum": "16.05.2021",
         "Fallzahl": 29823,
         "ObjectId": 436,
-        "Sterbefall": 1060,
-        "Genesungsfall": 27497,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2562,
-        "Zuwachs_Fallzahl": 21,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 22,
         "BelegteBetten": null,
         "Inzidenz": 83.7,
         "Datum_neu": 1621123200000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 79.9,
-        "Fallzahl_aktiv": 1266,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 111.5,
-        "Mutation": 14,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -14640,7 +14640,7 @@
         "ObjectId": 437,
         "Sterbefall": 1060,
         "Genesungsfall": 27607,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2569,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
@@ -14649,20 +14649,53 @@
         "BelegteBetten": null,
         "Inzidenz": 83.3363267358741,
         "Datum_neu": 1621209600000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "10.05.2021 - 16.05.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 82.6,
         "Fallzahl_aktiv": 1162,
-        "Krh_I_belegt": 257,
-        "Krh_I_frei": 38,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -104,
-        "Krh_I": 295,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 59,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 112.3,
-        "Mutation": 14,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.05.2021",
+        "Fallzahl": 29963,
+        "ObjectId": 438,
+        "Sterbefall": 1065,
+        "Genesungsfall": 27771,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2587,
+        "Zuwachs_Fallzahl": 134,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 164,
+        "BelegteBetten": null,
+        "Inzidenz": 74.7153274183699,
+        "Datum_neu": 1621296000000,
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": "11.05.2021 - 17.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 67,
+        "Fallzahl_aktiv": 1127,
+        "Krh_I_belegt": 254,
+        "Krh_I_frei": 41,
+        "Fallzahl_aktiv_Zuwachs": -35,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 58,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 104.8,
+        "Mutation": 16,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
