### PR TITLE
New data set: 2021-05-19T100215Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-18T101103Z.json
+pjson/2021-05-19T100215Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-18T101103Z.json pjson/2021-05-19T100215Z.json```:
```
--- pjson/2021-05-18T101103Z.json	2021-05-18 10:11:03.984198263 +0000
+++ pjson/2021-05-19T100215Z.json	2021-05-19 10:02:15.776258463 +0000
@@ -11085,7 +11085,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12702,7 +12702,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -14420,7 +14420,7 @@
         "Datum_neu": 1620604800000,
         "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14449,12 +14449,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 181,
         "BelegteBetten": null,
-        "Inzidenz": 116.4,
+        "Inzidenz": null,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 97.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14463,7 +14463,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 167.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14484,7 +14484,7 @@
         "BelegteBetten": null,
         "Inzidenz": 104,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 92.9,
@@ -14550,9 +14550,9 @@
         "BelegteBetten": null,
         "Inzidenz": 89.1,
         "Datum_neu": 1620950400000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 87.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14583,7 +14583,7 @@
         "BelegteBetten": null,
         "Inzidenz": 82.8,
         "Datum_neu": 1621036800000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 74.9,
@@ -14616,7 +14616,7 @@
         "BelegteBetten": null,
         "Inzidenz": 83.7,
         "Datum_neu": 1621123200000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 79.9,
@@ -14638,25 +14638,25 @@
         "Datum": "17.05.2021",
         "Fallzahl": 29829,
         "ObjectId": 437,
-        "Sterbefall": 1060,
-        "Genesungsfall": 27607,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2569,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 83.3363267358741,
+        "Inzidenz": 83.3,
         "Datum_neu": 1621209600000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 82.6,
-        "Fallzahl_aktiv": 1162,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -104,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14671,31 +14671,64 @@
         "Datum": "18.05.2021",
         "Fallzahl": 29963,
         "ObjectId": 438,
-        "Sterbefall": 1065,
-        "Genesungsfall": 27771,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2587,
-        "Zuwachs_Fallzahl": 134,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 164,
         "BelegteBetten": null,
-        "Inzidenz": 74.7153274183699,
+        "Inzidenz": 74.7,
         "Datum_neu": 1621296000000,
-        "F\u00e4lle_Meldedatum": 71,
-        "Zeitraum": "11.05.2021 - 17.05.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 111,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 67,
-        "Fallzahl_aktiv": 1127,
-        "Krh_I_belegt": 254,
-        "Krh_I_frei": 41,
-        "Fallzahl_aktiv_Zuwachs": -35,
-        "Krh_I": 295,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 58,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 104.8,
-        "Mutation": 16,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.05.2021",
+        "Fallzahl": 30077,
+        "ObjectId": 439,
+        "Sterbefall": 1065,
+        "Genesungsfall": 27897,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2592,
+        "Zuwachs_Fallzahl": 114,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 126,
+        "BelegteBetten": null,
+        "Inzidenz": 81.4,
+        "Datum_neu": 1621382400000,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": "12.05.2021 - 18.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 74.4,
+        "Fallzahl_aktiv": 1115,
+        "Krh_I_belegt": 250,
+        "Krh_I_frei": 45,
+        "Fallzahl_aktiv_Zuwachs": -12,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 53,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 87.9,
+        "Mutation": 17,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
