### PR TITLE
New data set: 2021-05-20T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-19T100215Z.json
+pjson/2021-05-20T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-19T100215Z.json pjson/2021-05-20T100903Z.json```:
```
--- pjson/2021-05-19T100215Z.json	2021-05-19 10:02:15.776258463 +0000
+++ pjson/2021-05-20T100903Z.json	2021-05-20 10:09:03.932651886 +0000
@@ -8544,7 +8544,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 206,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -14253,7 +14253,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14482,12 +14482,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 152,
         "BelegteBetten": null,
-        "Inzidenz": 104,
+        "Inzidenz": null,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 92.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14496,7 +14496,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 144.4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14649,7 +14649,7 @@
         "BelegteBetten": null,
         "Inzidenz": 83.3,
         "Datum_neu": 1621209600000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 82.6,
@@ -14682,7 +14682,7 @@
         "BelegteBetten": null,
         "Inzidenz": 74.7,
         "Datum_neu": 1621296000000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 67,
@@ -14706,7 +14706,7 @@
         "ObjectId": 439,
         "Sterbefall": 1065,
         "Genesungsfall": 27897,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2592,
         "Zuwachs_Fallzahl": 114,
         "Zuwachs_Sterbefall": 0,
@@ -14715,20 +14715,53 @@
         "BelegteBetten": null,
         "Inzidenz": 81.4,
         "Datum_neu": 1621382400000,
-        "F\u00e4lle_Meldedatum": 52,
-        "Zeitraum": "12.05.2021 - 18.05.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 80,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 74.4,
         "Fallzahl_aktiv": 1115,
-        "Krh_I_belegt": 250,
-        "Krh_I_frei": 45,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -12,
-        "Krh_I": 295,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 53,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 87.9,
-        "Mutation": 17,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.05.2021",
+        "Fallzahl": 30138,
+        "ObjectId": 440,
+        "Sterbefall": 1065,
+        "Genesungsfall": 28016,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2594,
+        "Zuwachs_Fallzahl": 61,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 119,
+        "BelegteBetten": null,
+        "Inzidenz": 80.4626602967061,
+        "Datum_neu": 1621468800000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": "13.05.2021 - 19.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 75.8,
+        "Fallzahl_aktiv": 1057,
+        "Krh_I_belegt": 248,
+        "Krh_I_frei": 47,
+        "Fallzahl_aktiv_Zuwachs": -58,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 50,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 85.5,
+        "Mutation": 18,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
