### PR TITLE
New data set: 2021-05-21T100803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-20T100903Z.json
+pjson/2021-05-21T100803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-20T100903Z.json pjson/2021-05-21T100803Z.json```:
```
--- pjson/2021-05-20T100903Z.json	2021-05-20 10:09:03.932651886 +0000
+++ pjson/2021-05-21T100803Z.json	2021-05-21 10:08:03.473979314 +0000
@@ -8544,7 +8544,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605225600000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -13802,7 +13802,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14165,7 +14165,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14220,7 +14220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -14231,7 +14231,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14264,7 +14264,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14297,7 +14297,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14319,7 +14319,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -14330,7 +14330,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14363,7 +14363,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14396,7 +14396,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14418,9 +14418,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14429,7 +14429,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14451,7 +14451,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -14515,12 +14515,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 99.5,
+        "Inzidenz": null,
         "Datum_neu": 1620864000000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 92,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14529,7 +14529,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 140.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14616,9 +14616,9 @@
         "BelegteBetten": null,
         "Inzidenz": 83.7,
         "Datum_neu": 1621123200000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 79.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14649,7 +14649,7 @@
         "BelegteBetten": null,
         "Inzidenz": 83.3,
         "Datum_neu": 1621209600000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 82.6,
@@ -14682,7 +14682,7 @@
         "BelegteBetten": null,
         "Inzidenz": 74.7,
         "Datum_neu": 1621296000000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 67,
@@ -14704,13 +14704,13 @@
         "Datum": "19.05.2021",
         "Fallzahl": 30077,
         "ObjectId": 439,
-        "Sterbefall": 1065,
-        "Genesungsfall": 27897,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2592,
-        "Zuwachs_Fallzahl": 114,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
         "Inzidenz": 81.4,
@@ -14719,10 +14719,10 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 74.4,
-        "Fallzahl_aktiv": 1115,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14739,28 +14739,61 @@
         "ObjectId": 440,
         "Sterbefall": 1065,
         "Genesungsfall": 28016,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2594,
         "Zuwachs_Fallzahl": 61,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 2,
         "Zuwachs_Genesung": 119,
         "BelegteBetten": null,
-        "Inzidenz": 80.4626602967061,
+        "Inzidenz": 80.5,
         "Datum_neu": 1621468800000,
-        "F\u00e4lle_Meldedatum": 20,
-        "Zeitraum": "13.05.2021 - 19.05.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 75.8,
         "Fallzahl_aktiv": 1057,
-        "Krh_I_belegt": 248,
-        "Krh_I_frei": 47,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -58,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 85.5,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.05.2021",
+        "Fallzahl": 30172,
+        "ObjectId": 441,
+        "Sterbefall": 1071,
+        "Genesungsfall": 28107,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2598,
+        "Zuwachs_Fallzahl": 34,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 91,
+        "BelegteBetten": null,
+        "Inzidenz": 76.870577247746,
+        "Datum_neu": 1621555200000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": "14.05.2021 - 20.05.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 74.2,
+        "Fallzahl_aktiv": 994,
+        "Krh_I_belegt": 252,
+        "Krh_I_frei": 43,
+        "Fallzahl_aktiv_Zuwachs": -63,
         "Krh_I": 295,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 50,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 85.5,
+        "Inzi_SN_RKI": 86.6,
         "Mutation": 18,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
