### PR TITLE
New data set: 2021-05-22T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-21T100803Z.json
+pjson/2021-05-22T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-21T100803Z.json pjson/2021-05-22T100203Z.json```:
```
--- pjson/2021-05-21T100803Z.json	2021-05-21 10:08:03.473979314 +0000
+++ pjson/2021-05-22T100203Z.json	2021-05-22 10:02:03.693105571 +0000
@@ -14187,7 +14187,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620000000000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -14253,7 +14253,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620172800000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14418,7 +14418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -14429,7 +14429,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14451,7 +14451,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620691200000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -14462,7 +14462,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14484,7 +14484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -14495,7 +14495,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14548,12 +14548,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
-        "Inzidenz": 89.1,
+        "Inzidenz": null,
         "Datum_neu": 1620950400000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 87.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14562,7 +14562,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 133.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14649,7 +14649,7 @@
         "BelegteBetten": null,
         "Inzidenz": 83.3,
         "Datum_neu": 1621209600000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 82.6,
@@ -14682,7 +14682,7 @@
         "BelegteBetten": null,
         "Inzidenz": 74.7,
         "Datum_neu": 1621296000000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 67,
@@ -14715,7 +14715,7 @@
         "BelegteBetten": null,
         "Inzidenz": 81.4,
         "Datum_neu": 1621382400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 74.4,
@@ -14737,25 +14737,25 @@
         "Datum": "20.05.2021",
         "Fallzahl": 30138,
         "ObjectId": 440,
-        "Sterbefall": 1065,
-        "Genesungsfall": 28016,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2594,
-        "Zuwachs_Fallzahl": 61,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 119,
         "BelegteBetten": null,
         "Inzidenz": 80.5,
         "Datum_neu": 1621468800000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 75.8,
-        "Fallzahl_aktiv": 1057,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -58,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14772,7 +14772,7 @@
         "ObjectId": 441,
         "Sterbefall": 1071,
         "Genesungsfall": 28107,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2598,
         "Zuwachs_Fallzahl": 34,
         "Zuwachs_Sterbefall": 6,
@@ -14781,19 +14781,52 @@
         "BelegteBetten": null,
         "Inzidenz": 76.870577247746,
         "Datum_neu": 1621555200000,
-        "F\u00e4lle_Meldedatum": 20,
-        "Zeitraum": "14.05.2021 - 20.05.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 74.2,
         "Fallzahl_aktiv": 994,
-        "Krh_I_belegt": 252,
-        "Krh_I_frei": 43,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -63,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 86.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.05.2021",
+        "Fallzahl": 30209,
+        "ObjectId": 442,
+        "Sterbefall": 1074,
+        "Genesungsfall": 28168,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2602,
+        "Zuwachs_Fallzahl": 37,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 61,
+        "BelegteBetten": null,
+        "Inzidenz": 76.331764790402,
+        "Datum_neu": 1621641600000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "15.05.2021 - 21.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 73.5,
+        "Fallzahl_aktiv": 967,
+        "Krh_I_belegt": 238,
+        "Krh_I_frei": 57,
+        "Fallzahl_aktiv_Zuwachs": -27,
         "Krh_I": 295,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 50,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 86.6,
+        "Inzi_SN_RKI": 85.6,
         "Mutation": 18,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
