### PR TITLE
New data set: 2021-05-23T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-22T100203Z.json
+pjson/2021-05-23T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-22T100203Z.json pjson/2021-05-23T100203Z.json```:
```
--- pjson/2021-05-22T100203Z.json	2021-05-22 10:02:03.693105571 +0000
+++ pjson/2021-05-23T100203Z.json	2021-05-23 10:02:03.999406243 +0000
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -14484,7 +14484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -14550,7 +14550,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620950400000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -14581,12 +14581,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 76,
         "BelegteBetten": null,
-        "Inzidenz": 82.8,
+        "Inzidenz": null,
         "Datum_neu": 1621036800000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 74.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14595,7 +14595,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 122.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14770,13 +14770,13 @@
         "Datum": "21.05.2021",
         "Fallzahl": 30172,
         "ObjectId": 441,
-        "Sterbefall": 1071,
-        "Genesungsfall": 28107,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2598,
-        "Zuwachs_Fallzahl": 34,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 91,
         "BelegteBetten": null,
         "Inzidenz": 76.870577247746,
@@ -14785,10 +14785,10 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 74.2,
-        "Fallzahl_aktiv": 994,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -63,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14803,30 +14803,63 @@
         "Datum": "22.05.2021",
         "Fallzahl": 30209,
         "ObjectId": 442,
-        "Sterbefall": 1074,
-        "Genesungsfall": 28168,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2602,
-        "Zuwachs_Fallzahl": 37,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 61,
         "BelegteBetten": null,
         "Inzidenz": 76.331764790402,
         "Datum_neu": 1621641600000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "15.05.2021 - 21.05.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 73.5,
-        "Fallzahl_aktiv": 967,
-        "Krh_I_belegt": 238,
-        "Krh_I_frei": 57,
-        "Fallzahl_aktiv_Zuwachs": -27,
-        "Krh_I": 295,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 50,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 85.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.05.2021",
+        "Fallzahl": 30217,
+        "ObjectId": 443,
+        "Sterbefall": 1074,
+        "Genesungsfall": 28181,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2605,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 13,
+        "BelegteBetten": null,
+        "Inzidenz": 68.6,
+        "Datum_neu": 1621728000000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "16.05.2021 - 22.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 68.1,
+        "Fallzahl_aktiv": 962,
+        "Krh_I_belegt": 241,
+        "Krh_I_frei": 54,
+        "Fallzahl_aktiv_Zuwachs": -5,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 44,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 81.7,
         "Mutation": 18,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
