### PR TITLE
New data set: 2021-05-24T100703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-23T100203Z.json
+pjson/2021-05-24T100703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-23T100203Z.json pjson/2021-05-24T100703Z.json```:
```
--- pjson/2021-05-23T100203Z.json	2021-05-23 10:02:03.999406243 +0000
+++ pjson/2021-05-24T100703Z.json	2021-05-24 10:07:03.202845653 +0000
@@ -14614,12 +14614,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 22,
         "BelegteBetten": null,
-        "Inzidenz": 83.7,
+        "Inzidenz": null,
         "Datum_neu": 1621123200000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 79.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14628,7 +14628,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 111.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14779,7 +14779,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 91,
         "BelegteBetten": null,
-        "Inzidenz": 76.870577247746,
+        "Inzidenz": 76.9,
         "Datum_neu": 1621555200000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
@@ -14812,7 +14812,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 61,
         "BelegteBetten": null,
-        "Inzidenz": 76.331764790402,
+        "Inzidenz": 76.3,
         "Datum_neu": 1621641600000,
         "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
@@ -14836,30 +14836,63 @@
         "Datum": "23.05.2021",
         "Fallzahl": 30217,
         "ObjectId": 443,
-        "Sterbefall": 1074,
-        "Genesungsfall": 28181,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2605,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
         "Inzidenz": 68.6,
         "Datum_neu": 1621728000000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "16.05.2021 - 22.05.2021",
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 68.1,
-        "Fallzahl_aktiv": 962,
-        "Krh_I_belegt": 241,
-        "Krh_I_frei": 54,
-        "Fallzahl_aktiv_Zuwachs": -5,
-        "Krh_I": 295,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 44,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 81.7,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.05.2021",
+        "Fallzahl": 30223,
+        "ObjectId": 444,
+        "Sterbefall": 1074,
+        "Genesungsfall": 28278,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2606,
+        "Zuwachs_Fallzahl": 6,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 97,
+        "BelegteBetten": null,
+        "Inzidenz": 68.6,
+        "Datum_neu": 1621814400000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "17.05.2021 - 23.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 68.2,
+        "Fallzahl_aktiv": 871,
+        "Krh_I_belegt": 237,
+        "Krh_I_frei": 58,
+        "Fallzahl_aktiv_Zuwachs": -91,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 43,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 80.6,
         "Mutation": 18,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
