### PR TITLE
New data set: 2021-05-26T100204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-25T100303Z.json
+pjson/2021-05-26T100204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-25T100303Z.json pjson/2021-05-26T100204Z.json```:
```
--- pjson/2021-05-25T100303Z.json	2021-05-25 10:03:03.876249943 +0000
+++ pjson/2021-05-26T100204Z.json	2021-05-26 10:02:04.276031283 +0000
@@ -9371,7 +9371,7 @@
         "Datum_neu": 1607385600000,
         "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 41,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9866,7 +9866,7 @@
         "Datum_neu": 1608681600000,
         "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 41,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12407,7 +12407,7 @@
         "Datum_neu": 1615334400000,
         "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12506,7 +12506,7 @@
         "Datum_neu": 1615593600000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13835,7 +13835,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14528,7 +14528,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14680,12 +14680,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 164,
         "BelegteBetten": null,
-        "Inzidenz": 74.7,
+        "Inzidenz": null,
         "Datum_neu": 1621296000000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 67,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14694,7 +14694,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 104.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14715,7 +14715,7 @@
         "BelegteBetten": null,
         "Inzidenz": 81.4,
         "Datum_neu": 1621382400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 74.4,
@@ -14781,9 +14781,9 @@
         "BelegteBetten": null,
         "Inzidenz": 76.9,
         "Datum_neu": 1621555200000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 74.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14847,7 +14847,7 @@
         "BelegteBetten": null,
         "Inzidenz": 68.6,
         "Datum_neu": 1621728000000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 68.1,
@@ -14880,7 +14880,7 @@
         "BelegteBetten": null,
         "Inzidenz": 68.6,
         "Datum_neu": 1621814400000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 68.2,
@@ -14904,28 +14904,61 @@
         "ObjectId": 445,
         "Sterbefall": 1074,
         "Genesungsfall": 28365,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2609,
         "Zuwachs_Fallzahl": 34,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 3,
         "Zuwachs_Genesung": 87,
         "BelegteBetten": null,
-        "Inzidenz": 59.4,
+        "Inzidenz": 59.4489744602895,
         "Datum_neu": 1621900800000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "18.05.2021 - 24.05.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 55.5,
         "Fallzahl_aktiv": 818,
-        "Krh_I_belegt": 239,
-        "Krh_I_frei": 56,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -53,
-        "Krh_I": 295,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 43,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 70,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.05.2021",
+        "Fallzahl": 30307,
+        "ObjectId": 446,
+        "Sterbefall": 1076,
+        "Genesungsfall": 28475,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2613,
+        "Zuwachs_Fallzahl": 50,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 110,
+        "BelegteBetten": null,
+        "Inzidenz": 47.0562879413772,
+        "Datum_neu": 1621987200000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "19.05.2021 - 25.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 41.3,
+        "Fallzahl_aktiv": 756,
+        "Krh_I_belegt": 240,
+        "Krh_I_frei": 55,
+        "Fallzahl_aktiv_Zuwachs": -62,
+        "Krh_I": 295,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 44,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 47.2,
         "Mutation": 18,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
