### PR TITLE
New data set: 2021-05-27T100304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-26T100204Z.json
+pjson/2021-05-27T100304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-26T100204Z.json pjson/2021-05-27T100304Z.json```:
```
--- pjson/2021-05-26T100204Z.json	2021-05-26 10:02:04.276031283 +0000
+++ pjson/2021-05-27T100304Z.json	2021-05-27 10:03:05.057906796 +0000
@@ -7950,7 +7950,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14022,7 +14022,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -14088,7 +14088,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -14352,7 +14352,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -14418,7 +14418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620604800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -14484,7 +14484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -14517,7 +14517,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620864000000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -14616,7 +14616,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1621123200000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -14684,7 +14684,7 @@
         "Datum_neu": 1621296000000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14713,12 +14713,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
-        "Inzidenz": 81.4,
+        "Inzidenz": null,
         "Datum_neu": 1621382400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 74.4,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14727,7 +14727,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 87.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14783,7 +14783,7 @@
         "Datum_neu": 1621555200000,
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 74.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14882,7 +14882,7 @@
         "Datum_neu": 1621814400000,
         "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 68.2,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14902,25 +14902,25 @@
         "Datum": "25.05.2021",
         "Fallzahl": 30257,
         "ObjectId": 445,
-        "Sterbefall": 1074,
-        "Genesungsfall": 28365,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2609,
-        "Zuwachs_Fallzahl": 34,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 87,
         "BelegteBetten": null,
         "Inzidenz": 59.4489744602895,
         "Datum_neu": 1621900800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 55.5,
-        "Fallzahl_aktiv": 818,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -53,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -14935,31 +14935,64 @@
         "Datum": "26.05.2021",
         "Fallzahl": 30307,
         "ObjectId": 446,
-        "Sterbefall": 1076,
-        "Genesungsfall": 28475,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2613,
-        "Zuwachs_Fallzahl": 50,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 47.0562879413772,
+        "Inzidenz": 47.1,
         "Datum_neu": 1621987200000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "19.05.2021 - 25.05.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 30,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 41.3,
-        "Fallzahl_aktiv": 756,
-        "Krh_I_belegt": 240,
-        "Krh_I_frei": 55,
-        "Fallzahl_aktiv_Zuwachs": -62,
-        "Krh_I": 295,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 44,
-        "SterbeF_Sterbedatum": 0,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 47.2,
-        "Mutation": 18,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.05.2021",
+        "Fallzahl": 30346,
+        "ObjectId": 447,
+        "Sterbefall": 1077,
+        "Genesungsfall": 28535,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2623,
+        "Zuwachs_Fallzahl": 39,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 60,
+        "BelegteBetten": null,
+        "Inzidenz": 39,
+        "Datum_neu": 1622073600000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "20.05.2021 - 26.05.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 37.4,
+        "Fallzahl_aktiv": 734,
+        "Krh_I_belegt": 247,
+        "Krh_I_frei": 49,
+        "Fallzahl_aktiv_Zuwachs": -22,
+        "Krh_I": 296,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 43,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 39.4,
+        "Mutation": 19,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
