### PR TITLE
New data set: 2021-05-29T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-28T100904Z.json
+pjson/2021-05-29T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-28T100904Z.json pjson/2021-05-29T100503Z.json```:
```
--- pjson/2021-05-28T100904Z.json	2021-05-28 10:09:04.168153300 +0000
+++ pjson/2021-05-29T100503Z.json	2021-05-29 10:05:03.730095524 +0000
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -14363,7 +14363,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14528,7 +14528,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14561,7 +14561,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14660,7 +14660,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14779,12 +14779,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 91,
         "BelegteBetten": null,
-        "Inzidenz": 76.9,
+        "Inzidenz": null,
         "Datum_neu": 1621555200000,
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 74.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14792,8 +14792,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 86.6,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14968,25 +14968,25 @@
         "Datum": "27.05.2021",
         "Fallzahl": 30346,
         "ObjectId": 447,
-        "Sterbefall": 1077,
-        "Genesungsfall": 28535,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2623,
-        "Zuwachs_Fallzahl": 39,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
         "Inzidenz": 39,
         "Datum_neu": 1622073600000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 37.4,
-        "Fallzahl_aktiv": 734,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -22,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15003,7 +15003,7 @@
         "ObjectId": 448,
         "Sterbefall": 1077,
         "Genesungsfall": 28585,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2624,
         "Zuwachs_Fallzahl": 21,
         "Zuwachs_Sterbefall": 0,
@@ -15012,20 +15012,53 @@
         "BelegteBetten": null,
         "Inzidenz": 36.2800387944969,
         "Datum_neu": 1622160000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "21.05.2021 - 27.05.2021",
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 34.1,
         "Fallzahl_aktiv": 705,
-        "Krh_I_belegt": 239,
-        "Krh_I_frei": 56,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -29,
-        "Krh_I": 295,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 40,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 42.7,
-        "Mutation": 19,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.05.2021",
+        "Fallzahl": 30404,
+        "ObjectId": 449,
+        "Sterbefall": 1086,
+        "Genesungsfall": 28647,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2624,
+        "Zuwachs_Fallzahl": 37,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 62,
+        "BelegteBetten": null,
+        "Inzidenz": 34.4839972700169,
+        "Datum_neu": 1622246400000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "22.05.2021 - 28.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 30.9,
+        "Fallzahl_aktiv": 671,
+        "Krh_I_belegt": 244,
+        "Krh_I_frei": 50,
+        "Fallzahl_aktiv_Zuwachs": -34,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 40,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 42.3,
+        "Mutation": 20,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
