### PR TITLE
New data set: 2021-05-30T100302Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-29T100503Z.json
+pjson/2021-05-30T100302Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-29T100503Z.json pjson/2021-05-30T100302Z.json```:
```
--- pjson/2021-05-29T100503Z.json	2021-05-29 10:05:03.730095524 +0000
+++ pjson/2021-05-30T100302Z.json	2021-05-30 10:03:02.980354137 +0000
@@ -14812,12 +14812,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 61,
         "BelegteBetten": null,
-        "Inzidenz": 76.3,
+        "Inzidenz": null,
         "Datum_neu": 1621641600000,
         "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 73.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14826,7 +14826,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 85.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15001,25 +15001,25 @@
         "Datum": "28.05.2021",
         "Fallzahl": 30367,
         "ObjectId": 448,
-        "Sterbefall": 1077,
-        "Genesungsfall": 28585,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2624,
-        "Zuwachs_Fallzahl": 21,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
         "Inzidenz": 36.2800387944969,
         "Datum_neu": 1622160000000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 34.1,
-        "Fallzahl_aktiv": 705,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -29,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15036,7 +15036,7 @@
         "ObjectId": 449,
         "Sterbefall": 1086,
         "Genesungsfall": 28647,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2624,
         "Zuwachs_Fallzahl": 37,
         "Zuwachs_Sterbefall": 9,
@@ -15045,19 +15045,52 @@
         "BelegteBetten": null,
         "Inzidenz": 34.4839972700169,
         "Datum_neu": 1622246400000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "22.05.2021 - 28.05.2021",
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 30.9,
         "Fallzahl_aktiv": 671,
-        "Krh_I_belegt": 244,
-        "Krh_I_frei": 50,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -34,
-        "Krh_I": 294,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 40,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 42.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.05.2021",
+        "Fallzahl": 30410,
+        "ObjectId": 450,
+        "Sterbefall": 1086,
+        "Genesungsfall": 28658,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2624,
+        "Zuwachs_Fallzahl": 6,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 11,
+        "BelegteBetten": null,
+        "Inzidenz": 34.3043931175689,
+        "Datum_neu": 1622332800000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "23.05.2021 - 29.05.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 33.4,
+        "Fallzahl_aktiv": 666,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 58,
+        "Fallzahl_aktiv_Zuwachs": -5,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 41,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 39.3,
         "Mutation": 20,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
