### PR TITLE
New data set: 2021-05-31T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-05-30T100302Z.json
+pjson/2021-05-31T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-05-30T100302Z.json pjson/2021-05-31T100603Z.json```:
```
--- pjson/2021-05-30T100302Z.json	2021-05-30 10:03:02.980354137 +0000
+++ pjson/2021-05-31T100603Z.json	2021-05-31 10:06:03.376174000 +0000
@@ -14845,12 +14845,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
-        "Inzidenz": 68.6,
+        "Inzidenz": null,
         "Datum_neu": 1621728000000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 68.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14859,7 +14859,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 81.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14981,7 +14981,7 @@
         "Datum_neu": 1622073600000,
         "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 37.4,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15014,7 +15014,7 @@
         "Datum_neu": 1622160000000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 34.1,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15034,13 +15034,13 @@
         "Datum": "29.05.2021",
         "Fallzahl": 30404,
         "ObjectId": 449,
-        "Sterbefall": 1086,
-        "Genesungsfall": 28647,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2624,
-        "Zuwachs_Fallzahl": 37,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
         "Inzidenz": 34.4839972700169,
@@ -15049,10 +15049,10 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 30.9,
-        "Fallzahl_aktiv": 671,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -34,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15069,28 +15069,61 @@
         "ObjectId": 450,
         "Sterbefall": 1086,
         "Genesungsfall": 28658,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2624,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 11,
+        "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
-        "Inzidenz": 34.3043931175689,
+        "Inzidenz": 34.3,
         "Datum_neu": 1622332800000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "23.05.2021 - 29.05.2021",
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 33.4,
         "Fallzahl_aktiv": 666,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 58,
-        "Fallzahl_aktiv_Zuwachs": -5,
-        "Krh_I": 294,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -54,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 41,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 39.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.05.2021",
+        "Fallzahl": 30412,
+        "ObjectId": 451,
+        "Sterbefall": 1086,
+        "Genesungsfall": 28721,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2624,
+        "Zuwachs_Fallzahl": 2,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 63,
+        "BelegteBetten": null,
+        "Inzidenz": 31.7899349832968,
+        "Datum_neu": 1622419200000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "24.05.2021 - 30.05.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 31.8,
+        "Fallzahl_aktiv": 605,
+        "Krh_I_belegt": 239,
+        "Krh_I_frei": 55,
+        "Fallzahl_aktiv_Zuwachs": -61,
+        "Krh_I": 294,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 40,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 42,
         "Mutation": 20,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
