### PR TITLE
New data set: 2021-06-02T101204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-01T100803Z.json
+pjson/2021-06-02T101204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-01T100803Z.json pjson/2021-06-02T101204Z.json```:
```
--- pjson/2021-06-01T100803Z.json	2021-06-01 10:08:04.092033699 +0000
+++ pjson/2021-06-02T101204Z.json	2021-06-02 10:12:04.120423767 +0000
@@ -8775,7 +8775,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -13296,7 +13296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -14055,7 +14055,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14792,7 +14792,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14858,7 +14858,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14891,7 +14891,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -14911,12 +14911,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 87,
         "BelegteBetten": null,
-        "Inzidenz": 59.4489744602895,
+        "Inzidenz": null,
         "Datum_neu": 1621900800000,
         "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 55.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14925,7 +14925,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 70,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -14957,7 +14957,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": 47.2,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15010,7 +15010,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
-        "Inzidenz": 36.2800387944969,
+        "Inzidenz": 36.3,
         "Datum_neu": 1622160000000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
@@ -15043,7 +15043,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
-        "Inzidenz": 34.4839972700169,
+        "Inzidenz": 34.5,
         "Datum_neu": 1622246400000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
@@ -15089,7 +15089,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 39.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15109,11 +15109,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 63,
         "BelegteBetten": null,
-        "Inzidenz": 31.7899349832968,
+        "Inzidenz": 31.8,
         "Datum_neu": 1622419200000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 31.8,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15133,31 +15133,64 @@
         "Datum": "01.06.2021",
         "Fallzahl": 30455,
         "ObjectId": 452,
-        "Sterbefall": 1086,
-        "Genesungsfall": 28833,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2624,
-        "Zuwachs_Fallzahl": 43,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 112,
         "BelegteBetten": null,
         "Inzidenz": 33.2,
         "Datum_neu": 1622505600000,
-        "F\u00e4lle_Meldedatum": 21,
-        "Zeitraum": "25.05.2021 - 31.05.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 29.5,
-        "Fallzahl_aktiv": 536,
-        "Krh_I_belegt": 239,
-        "Krh_I_frei": 51,
-        "Fallzahl_aktiv_Zuwachs": -69,
-        "Krh_I": 290,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 40,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 42.6,
-        "Mutation": 20,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.06.2021",
+        "Fallzahl": 30475,
+        "ObjectId": 453,
+        "Sterbefall": 1091,
+        "Genesungsfall": 28927,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2628,
+        "Zuwachs_Fallzahl": 20,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 94,
+        "BelegteBetten": null,
+        "Inzidenz": 31.6,
+        "Datum_neu": 1622592000000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "26.05.2021 - 01.06.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 29.3,
+        "Fallzahl_aktiv": 457,
+        "Krh_I_belegt": 244,
+        "Krh_I_frei": 48,
+        "Fallzahl_aktiv_Zuwachs": -79,
+        "Krh_I": 292,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 38,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 39.7,
+        "Mutation": 21,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
