### PR TITLE
New data set: 2021-06-03T102303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-02T101204Z.json
+pjson/2021-06-03T102303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-02T101204Z.json pjson/2021-06-03T102303Z.json```:
```
--- pjson/2021-06-02T101204Z.json	2021-06-02 10:12:04.120423767 +0000
+++ pjson/2021-06-03T102303Z.json	2021-06-03 10:23:03.536629773 +0000
@@ -14814,7 +14814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1621641600000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -14944,12 +14944,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 110,
         "BelegteBetten": null,
-        "Inzidenz": 47.1,
+        "Inzidenz": null,
         "Datum_neu": 1621987200000,
         "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 41.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -14958,7 +14958,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
-        "Inzi_SN_RKI": 47.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15144,7 +15144,7 @@
         "BelegteBetten": null,
         "Inzidenz": 33.2,
         "Datum_neu": 1622505600000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 29.5,
@@ -15166,30 +15166,63 @@
         "Datum": "02.06.2021",
         "Fallzahl": 30475,
         "ObjectId": 453,
-        "Sterbefall": 1091,
-        "Genesungsfall": 28927,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2628,
-        "Zuwachs_Fallzahl": 20,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 94,
         "BelegteBetten": null,
         "Inzidenz": 31.6,
         "Datum_neu": 1622592000000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "26.05.2021 - 01.06.2021",
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 29.3,
-        "Fallzahl_aktiv": 457,
-        "Krh_I_belegt": 244,
-        "Krh_I_frei": 48,
-        "Fallzahl_aktiv_Zuwachs": -79,
-        "Krh_I": 292,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 38,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 39.7,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.06.2021",
+        "Fallzahl": 30491,
+        "ObjectId": 454,
+        "Sterbefall": 1091,
+        "Genesungsfall": 28978,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2629,
+        "Zuwachs_Fallzahl": 16,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 51,
+        "BelegteBetten": null,
+        "Inzidenz": 28.2,
+        "Datum_neu": 1622678400000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "27.05.2021 - 02.06.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 27.8,
+        "Fallzahl_aktiv": 422,
+        "Krh_I_belegt": 233,
+        "Krh_I_frei": 59,
+        "Fallzahl_aktiv_Zuwachs": -35,
+        "Krh_I": 292,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 37,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 35.2,
         "Mutation": 21,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
