### PR TITLE
New data set: 2021-06-06T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-05T100203Z.json
+pjson/2021-06-06T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-05T100203Z.json pjson/2021-06-06T100203Z.json```:
```
--- pjson/2021-06-05T100203Z.json	2021-06-05 10:02:03.755165819 +0000
+++ pjson/2021-06-06T100203Z.json	2021-06-06 10:02:03.948535301 +0000
@@ -15043,12 +15043,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
-        "Inzidenz": 34.5,
+        "Inzidenz": null,
         "Datum_neu": 1622246400000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 30.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15057,7 +15057,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 42.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15232,13 +15232,13 @@
         "Datum": "04.06.2021",
         "Fallzahl": 30497,
         "ObjectId": 455,
-        "Sterbefall": 1094,
-        "Genesungsfall": 29009,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2630,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 31,
         "BelegteBetten": null,
         "Inzidenz": 24.4261647329286,
@@ -15247,10 +15247,10 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 23.9,
-        "Fallzahl_aktiv": 394,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -27,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15267,7 +15267,7 @@
         "ObjectId": 456,
         "Sterbefall": 1095,
         "Genesungsfall": 29036,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2630,
         "Zuwachs_Fallzahl": 13,
         "Zuwachs_Sterbefall": 1,
@@ -15276,19 +15276,52 @@
         "BelegteBetten": null,
         "Inzidenz": 21.1932899888645,
         "Datum_neu": 1622851200000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "29.05.2021 - 04.06.2021",
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 20.5,
         "Fallzahl_aktiv": 379,
-        "Krh_I_belegt": 248,
-        "Krh_I_frei": 34,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -15,
-        "Krh_I": 282,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 37,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 25.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.06.2021",
+        "Fallzahl": 30516,
+        "ObjectId": 457,
+        "Sterbefall": 1095,
+        "Genesungsfall": 29056,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2630,
+        "Zuwachs_Fallzahl": 6,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 20,
+        "BelegteBetten": null,
+        "Inzidenz": 19.3972484643845,
+        "Datum_neu": 1622937600000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "30.05.2021 - 05.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 18.9,
+        "Fallzahl_aktiv": 365,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 46,
+        "Fallzahl_aktiv_Zuwachs": -14,
+        "Krh_I": 282,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 36,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 24.6,
         "Mutation": 24,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
