### PR TITLE
New data set: 2021-06-07T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-06T100203Z.json
+pjson/2021-06-07T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-06T100203Z.json pjson/2021-06-07T100403Z.json```:
```
--- pjson/2021-06-06T100203Z.json	2021-06-06 10:02:03.948535301 +0000
+++ pjson/2021-06-07T100403Z.json	2021-06-07 10:04:03.155433232 +0000
@@ -9699,7 +9699,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 459,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -13725,7 +13725,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618790400000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -14484,7 +14484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -15076,12 +15076,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
-        "Inzidenz": 34.3,
+        "Inzidenz": null,
         "Datum_neu": 1622332800000,
         "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 33.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15090,7 +15090,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 39.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15265,25 +15265,25 @@
         "Datum": "05.06.2021",
         "Fallzahl": 30510,
         "ObjectId": 456,
-        "Sterbefall": 1095,
-        "Genesungsfall": 29036,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2630,
-        "Zuwachs_Fallzahl": 13,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 27,
         "BelegteBetten": null,
         "Inzidenz": 21.1932899888645,
         "Datum_neu": 1622851200000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 20.5,
-        "Fallzahl_aktiv": 379,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -15,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15300,28 +15300,61 @@
         "ObjectId": 457,
         "Sterbefall": 1095,
         "Genesungsfall": 29056,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2630,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
-        "Inzidenz": 19.3972484643845,
+        "Inzidenz": 19.4,
         "Datum_neu": 1622937600000,
         "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "30.05.2021 - 05.06.2021",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 18.9,
         "Fallzahl_aktiv": 365,
-        "Krh_I_belegt": 236,
-        "Krh_I_frei": 46,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -14,
-        "Krh_I": 282,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 36,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 24.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.06.2021",
+        "Fallzahl": 30520,
+        "ObjectId": 458,
+        "Sterbefall": 1095,
+        "Genesungsfall": 29071,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2631,
+        "Zuwachs_Fallzahl": 4,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 15,
+        "BelegteBetten": null,
+        "Inzidenz": 19.0380401594885,
+        "Datum_neu": 1623024000000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "31.05.2021 - 06.06.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 18.9,
+        "Fallzahl_aktiv": 354,
+        "Krh_I_belegt": 233,
+        "Krh_I_frei": 49,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": 282,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 34,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 25.5,
         "Mutation": 24,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
