### PR TITLE
New data set: 2021-06-10T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-09T101404Z.json
+pjson/2021-06-10T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-09T101404Z.json pjson/2021-06-10T101103Z.json```:
```
--- pjson/2021-06-09T101404Z.json	2021-06-09 10:14:04.306894937 +0000
+++ pjson/2021-06-10T101103Z.json	2021-06-10 10:11:03.378899138 +0000
@@ -9171,7 +9171,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -14519,7 +14519,7 @@
         "Datum_neu": 1620864000000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14552,7 +14552,7 @@
         "Datum_neu": 1620950400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14651,7 +14651,7 @@
         "Datum_neu": 1621209600000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14684,7 +14684,7 @@
         "Datum_neu": 1621296000000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14717,7 +14717,7 @@
         "Datum_neu": 1621382400000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14750,7 +14750,7 @@
         "Datum_neu": 1621468800000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14915,7 +14915,7 @@
         "Datum_neu": 1621900800000,
         "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15175,12 +15175,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 94,
         "BelegteBetten": null,
-        "Inzidenz": 31.6,
+        "Inzidenz": null,
         "Datum_neu": 1622592000000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 29.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15189,7 +15189,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 39.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15221,7 +15221,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 35.2,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15243,7 +15243,7 @@
         "BelegteBetten": null,
         "Inzidenz": 24.4261647329286,
         "Datum_neu": 1622764800000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 23.9,
@@ -15344,7 +15344,7 @@
         "Datum_neu": 1623024000000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 18.9,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15364,25 +15364,25 @@
         "Datum": "08.06.2021",
         "Fallzahl": 30536,
         "ObjectId": 459,
-        "Sterbefall": 1096,
-        "Genesungsfall": 29110,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2634,
-        "Zuwachs_Fallzahl": 16,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 39,
         "BelegteBetten": null,
         "Inzidenz": 15.8051654154244,
         "Datum_neu": 1623110400000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 14.7,
-        "Fallzahl_aktiv": 330,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -24,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15399,29 +15399,62 @@
         "ObjectId": 460,
         "Sterbefall": 1096,
         "Genesungsfall": 29158,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2635,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 1,
         "Zuwachs_Genesung": 48,
         "BelegteBetten": null,
-        "Inzidenz": 11.4946657566723,
+        "Inzidenz": 11.5,
         "Datum_neu": 1623196800000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "02.06.2021 - 08.06.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 11.1,
         "Fallzahl_aktiv": 288,
-        "Krh_I_belegt": 233,
-        "Krh_I_frei": 57,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -42,
-        "Krh_I": 290,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 29,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 17.9,
-        "Mutation": 25,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.06.2021",
+        "Fallzahl": 30554,
+        "ObjectId": 461,
+        "Sterbefall": 1097,
+        "Genesungsfall": 29196,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2635,
+        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 38,
+        "BelegteBetten": null,
+        "Inzidenz": 10.5966449944323,
+        "Datum_neu": 1623283200000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "03.06.2021 - 09.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 9.9,
+        "Fallzahl_aktiv": 261,
+        "Krh_I_belegt": 232,
+        "Krh_I_frei": 48,
+        "Fallzahl_aktiv_Zuwachs": -27,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 27,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 15.4,
+        "Mutation": 27,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
