### PR TITLE
New data set: 2021-06-11T102504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-10T101103Z.json
+pjson/2021-06-11T102504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-10T101103Z.json pjson/2021-06-11T102504Z.json```:
```
--- pjson/2021-06-10T101103Z.json	2021-06-10 10:11:03.378899138 +0000
+++ pjson/2021-06-11T102504Z.json	2021-06-11 10:25:04.208122049 +0000
@@ -7719,7 +7719,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603065600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -9173,7 +9173,7 @@
         "Datum_neu": 1606867200000,
         "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9899,7 +9899,7 @@
         "Datum_neu": 1608768000000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9932,7 +9932,7 @@
         "Datum_neu": 1608854400000,
         "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9965,7 +9965,7 @@
         "Datum_neu": 1608940800000,
         "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9998,7 +9998,7 @@
         "Datum_neu": 1609027200000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10031,7 +10031,7 @@
         "Datum_neu": 1609113600000,
         "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 41,
+        "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10064,7 +10064,7 @@
         "Datum_neu": 1609200000000,
         "F\u00e4lle_Meldedatum": 552,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 38,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10097,7 +10097,7 @@
         "Datum_neu": 1609286400000,
         "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10130,7 +10130,7 @@
         "Datum_neu": 1609372800000,
         "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10163,7 +10163,7 @@
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10196,7 +10196,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10295,7 +10295,7 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10328,7 +10328,7 @@
         "Datum_neu": 1609891200000,
         "F\u00e4lle_Meldedatum": 347,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10361,7 +10361,7 @@
         "Datum_neu": 1609977600000,
         "F\u00e4lle_Meldedatum": 268,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10394,7 +10394,7 @@
         "Datum_neu": 1610064000000,
         "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10493,7 +10493,7 @@
         "Datum_neu": 1610323200000,
         "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 44,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10524,9 +10524,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 271,
+        "F\u00e4lle_Meldedatum": 270,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10559,7 +10559,7 @@
         "Datum_neu": 1610496000000,
         "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10625,7 +10625,7 @@
         "Datum_neu": 1610668800000,
         "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10724,7 +10724,7 @@
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10790,7 +10790,7 @@
         "Datum_neu": 1611100800000,
         "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10821,9 +10821,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611187200000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10856,7 +10856,7 @@
         "Datum_neu": 1611273600000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10955,7 +10955,7 @@
         "Datum_neu": 1611532800000,
         "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10988,7 +10988,7 @@
         "Datum_neu": 1611619200000,
         "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11021,7 +11021,7 @@
         "Datum_neu": 1611705600000,
         "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11087,7 +11087,7 @@
         "Datum_neu": 1611878400000,
         "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11120,7 +11120,7 @@
         "Datum_neu": 1611964800000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11219,7 +11219,7 @@
         "Datum_neu": 1612224000000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11252,7 +11252,7 @@
         "Datum_neu": 1612310400000,
         "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11285,7 +11285,7 @@
         "Datum_neu": 1612396800000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11384,7 +11384,7 @@
         "Datum_neu": 1612656000000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11417,7 +11417,7 @@
         "Datum_neu": 1612742400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11450,7 +11450,7 @@
         "Datum_neu": 1612828800000,
         "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11483,7 +11483,7 @@
         "Datum_neu": 1612915200000,
         "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11549,7 +11549,7 @@
         "Datum_neu": 1613088000000,
         "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11615,7 +11615,7 @@
         "Datum_neu": 1613260800000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11714,7 +11714,7 @@
         "Datum_neu": 1613520000000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11747,7 +11747,7 @@
         "Datum_neu": 1613606400000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11879,7 +11879,7 @@
         "Datum_neu": 1613952000000,
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11912,7 +11912,7 @@
         "Datum_neu": 1614038400000,
         "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -11945,7 +11945,7 @@
         "Datum_neu": 1614124800000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12110,7 +12110,7 @@
         "Datum_neu": 1614556800000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12143,7 +12143,7 @@
         "Datum_neu": 1614643200000,
         "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12176,7 +12176,7 @@
         "Datum_neu": 1614729600000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12209,7 +12209,7 @@
         "Datum_neu": 1614816000000,
         "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12242,7 +12242,7 @@
         "Datum_neu": 1614902400000,
         "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12275,7 +12275,7 @@
         "Datum_neu": 1614988800000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12341,7 +12341,7 @@
         "Datum_neu": 1615161600000,
         "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12407,7 +12407,7 @@
         "Datum_neu": 1615334400000,
         "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12473,7 +12473,7 @@
         "Datum_neu": 1615507200000,
         "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12539,7 +12539,7 @@
         "Datum_neu": 1615680000000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12572,7 +12572,7 @@
         "Datum_neu": 1615766400000,
         "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12671,7 +12671,7 @@
         "Datum_neu": 1616025600000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12704,7 +12704,7 @@
         "Datum_neu": 1616112000000,
         "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12737,7 +12737,7 @@
         "Datum_neu": 1616198400000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12770,7 +12770,7 @@
         "Datum_neu": 1616284800000,
         "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12902,7 +12902,7 @@
         "Datum_neu": 1616630400000,
         "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12935,7 +12935,7 @@
         "Datum_neu": 1616716800000,
         "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -12968,7 +12968,7 @@
         "Datum_neu": 1616803200000,
         "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13034,7 +13034,7 @@
         "Datum_neu": 1616976000000,
         "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13067,7 +13067,7 @@
         "Datum_neu": 1617062400000,
         "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13100,7 +13100,7 @@
         "Datum_neu": 1617148800000,
         "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13133,7 +13133,7 @@
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13166,7 +13166,7 @@
         "Datum_neu": 1617321600000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13199,7 +13199,7 @@
         "Datum_neu": 1617408000000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13265,7 +13265,7 @@
         "Datum_neu": 1617580800000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13298,7 +13298,7 @@
         "Datum_neu": 1617667200000,
         "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13331,7 +13331,7 @@
         "Datum_neu": 1617753600000,
         "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13397,7 +13397,7 @@
         "Datum_neu": 1617926400000,
         "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13430,7 +13430,7 @@
         "Datum_neu": 1618012800000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13496,7 +13496,7 @@
         "Datum_neu": 1618185600000,
         "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13562,7 +13562,7 @@
         "Datum_neu": 1618358400000,
         "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13760,7 +13760,7 @@
         "Datum_neu": 1618876800000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13793,7 +13793,7 @@
         "Datum_neu": 1618963200000,
         "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13826,7 +13826,7 @@
         "Datum_neu": 1619049600000,
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13859,7 +13859,7 @@
         "Datum_neu": 1619136000000,
         "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13956,9 +13956,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619395200000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -13991,7 +13991,7 @@
         "Datum_neu": 1619481600000,
         "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14090,7 +14090,7 @@
         "Datum_neu": 1619740800000,
         "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14255,7 +14255,7 @@
         "Datum_neu": 1620172800000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14321,7 +14321,7 @@
         "Datum_neu": 1620345600000,
         "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14420,7 +14420,7 @@
         "Datum_neu": 1620604800000,
         "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14453,7 +14453,7 @@
         "Datum_neu": 1620691200000,
         "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15208,12 +15208,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
-        "Inzidenz": 28.1978519343367,
+        "Inzidenz": null,
         "Datum_neu": 1622678400000,
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 27.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15221,8 +15221,8 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 35.2,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15254,7 +15254,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 29.4,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15287,7 +15287,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 25.6,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15397,25 +15397,25 @@
         "Datum": "09.06.2021",
         "Fallzahl": 30542,
         "ObjectId": 460,
-        "Sterbefall": 1096,
-        "Genesungsfall": 29158,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2635,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 48,
         "BelegteBetten": null,
         "Inzidenz": 11.5,
         "Datum_neu": 1623196800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 11.1,
-        "Fallzahl_aktiv": 288,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -42,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15432,29 +15432,62 @@
         "ObjectId": 461,
         "Sterbefall": 1097,
         "Genesungsfall": 29196,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2635,
         "Zuwachs_Fallzahl": 12,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 38,
         "BelegteBetten": null,
-        "Inzidenz": 10.5966449944323,
+        "Inzidenz": 10.6,
         "Datum_neu": 1623283200000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "03.06.2021 - 09.06.2021",
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.9,
         "Fallzahl_aktiv": 261,
-        "Krh_I_belegt": 232,
-        "Krh_I_frei": 48,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -27,
-        "Krh_I": 280,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 27,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 15.4,
-        "Mutation": 27,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.06.2021",
+        "Fallzahl": 30563,
+        "ObjectId": 462,
+        "Sterbefall": 1100,
+        "Genesungsfall": 29226,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2637,
+        "Zuwachs_Fallzahl": 9,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 30,
+        "BelegteBetten": null,
+        "Inzidenz": 10.7762491468803,
+        "Datum_neu": 1623369600000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "04.06.2021 - 10.06.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 10.1,
+        "Fallzahl_aktiv": 237,
+        "Krh_I_belegt": 240,
+        "Krh_I_frei": 40,
+        "Fallzahl_aktiv_Zuwachs": -24,
+        "Krh_I": 280,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 29,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 14.7,
+        "Mutation": 28,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
