### PR TITLE
New data set: 2021-06-13T100104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-11T102504Z.json
+pjson/2021-06-13T100104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-12T102405Z.json pjson/2021-06-13T100104Z.json```:
```
--- pjson/2021-06-12T102405Z.json	2021-06-12 10:24:05.182632377 +0000
+++ pjson/2021-06-13T100104Z.json	2021-06-13 10:01:04.430667276 +0000
@@ -15274,12 +15274,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 21.1932899888645,
+        "Inzidenz": null,
         "Datum_neu": 1622851200000,
         "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 20.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15288,7 +15288,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 25.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15463,13 +15463,13 @@
         "Datum": "11.06.2021",
         "Fallzahl": 30563,
         "ObjectId": 462,
-        "Sterbefall": 1100,
-        "Genesungsfall": 29226,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2637,
-        "Zuwachs_Fallzahl": 9,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 30,
         "BelegteBetten": null,
         "Inzidenz": 10.7762491468803,
@@ -15478,10 +15478,10 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 10.1,
-        "Fallzahl_aktiv": 237,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -24,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15498,7 +15498,7 @@
         "ObjectId": 463,
         "Sterbefall": 1100,
         "Genesungsfall": 29250,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2637,
         "Zuwachs_Fallzahl": 8,
         "Zuwachs_Sterbefall": 0,
@@ -15508,19 +15508,52 @@
         "Inzidenz": 10.0578325370883,
         "Datum_neu": 1623456000000,
         "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "05.06.2021 - 11.06.2021",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.1,
         "Fallzahl_aktiv": 221,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -16,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 13.8,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.06.2021",
+        "Fallzahl": 30571,
+        "ObjectId": 464,
+        "Sterbefall": 1100,
+        "Genesungsfall": 29263,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2637,
+        "Zuwachs_Fallzahl": 0,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 13,
+        "BelegteBetten": null,
+        "Inzidenz": 8.08218686016021,
+        "Datum_neu": 1623542400000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "06.06.2021 - 12.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 8.1,
+        "Fallzahl_aktiv": 208,
         "Krh_I_belegt": 239,
         "Krh_I_frei": 41,
-        "Fallzahl_aktiv_Zuwachs": -16,
+        "Fallzahl_aktiv_Zuwachs": -13,
         "Krh_I": 280,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 25,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 13.8,
-        "Mutation": 31,
+        "Inzi_SN_RKI": 12,
+        "Mutation": 33,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
