### PR TITLE
New data set: 2021-06-14T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-13T100104Z.json
+pjson/2021-06-14T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-13T100104Z.json pjson/2021-06-14T100903Z.json```:
```
--- pjson/2021-06-13T100104Z.json	2021-06-13 10:01:04.430667276 +0000
+++ pjson/2021-06-14T100903Z.json	2021-06-14 10:09:03.768736835 +0000
@@ -13529,7 +13529,7 @@
         "Datum_neu": 1618272000000,
         "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15307,12 +15307,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
-        "Inzidenz": 19.4,
+        "Inzidenz": null,
         "Datum_neu": 1622937600000,
         "F\u00e4lle_Meldedatum": 0,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 18.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15321,7 +15321,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 24.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15441,7 +15441,7 @@
         "BelegteBetten": null,
         "Inzidenz": 10.6,
         "Datum_neu": 1623283200000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.9,
@@ -15496,13 +15496,13 @@
         "Datum": "12.06.2021",
         "Fallzahl": 30571,
         "ObjectId": 463,
-        "Sterbefall": 1100,
-        "Genesungsfall": 29250,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2637,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
         "Inzidenz": 10.0578325370883,
@@ -15511,10 +15511,10 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.1,
-        "Fallzahl_aktiv": 221,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -16,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15529,30 +15529,63 @@
         "Datum": "13.06.2021",
         "Fallzahl": 30571,
         "ObjectId": 464,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 13,
+        "BelegteBetten": null,
+        "Inzidenz": 8.1,
+        "Datum_neu": 1623542400000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 8.1,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 12,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.06.2021",
+        "Fallzahl": 30573,
+        "ObjectId": 465,
         "Sterbefall": 1100,
-        "Genesungsfall": 29263,
+        "Genesungsfall": 29287,
         "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2637,
-        "Zuwachs_Fallzahl": 0,
+        "Hospitalisierung": 2638,
+        "Zuwachs_Fallzahl": 2,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 13,
+        "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
-        "Inzidenz": 8.08218686016021,
-        "Datum_neu": 1623542400000,
+        "Inzidenz": 8.4,
+        "Datum_neu": 1623628800000,
         "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "06.06.2021 - 12.06.2021",
+        "Zeitraum": "07.06.2021 - 13.06.2021",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 8.1,
-        "Fallzahl_aktiv": 208,
+        "Fallzahl_aktiv": 186,
         "Krh_I_belegt": 239,
         "Krh_I_frei": 41,
-        "Fallzahl_aktiv_Zuwachs": -13,
+        "Fallzahl_aktiv_Zuwachs": -22,
         "Krh_I": 280,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 25,
+        "Krh_I_covid": 24,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 12,
+        "Inzi_SN_RKI": 11.8,
         "Mutation": 33,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
