### PR TITLE
New data set: 2021-06-16T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-15T100303Z.json
+pjson/2021-06-16T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-15T100303Z.json pjson/2021-06-16T101303Z.json```:
```
--- pjson/2021-06-15T100303Z.json	2021-06-15 10:03:03.820513177 +0000
+++ pjson/2021-06-16T101303Z.json	2021-06-16 10:13:03.823374016 +0000
@@ -13824,7 +13824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619049600000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -15243,7 +15243,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1622764800000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -15373,12 +15373,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 39,
         "BelegteBetten": null,
-        "Inzidenz": 15.8051654154244,
+        "Inzidenz": null,
         "Datum_neu": 1623110400000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 14.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15387,7 +15387,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 21.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15408,7 +15408,7 @@
         "BelegteBetten": null,
         "Inzidenz": 11.5,
         "Datum_neu": 1623196800000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 11.1,
@@ -15474,7 +15474,7 @@
         "BelegteBetten": null,
         "Inzidenz": 10.7762491468803,
         "Datum_neu": 1623369600000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 10.1,
@@ -15573,7 +15573,7 @@
         "BelegteBetten": null,
         "Inzidenz": 8.4,
         "Datum_neu": 1623628800000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 8.1,
@@ -15595,30 +15595,63 @@
         "Datum": "15.06.2021",
         "Fallzahl": 30582,
         "ObjectId": 466,
-        "Sterbefall": 1100,
-        "Genesungsfall": 29321,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2638,
-        "Zuwachs_Fallzahl": 9,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 34,
         "BelegteBetten": null,
         "Inzidenz": 7.5,
         "Datum_neu": 1623715200000,
-        "F\u00e4lle_Meldedatum": 6,
-        "Zeitraum": "08.06.2021 - 14.06.2021",
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.4,
-        "Fallzahl_aktiv": 161,
-        "Krh_I_belegt": 248,
-        "Krh_I_frei": 40,
-        "Fallzahl_aktiv_Zuwachs": -25,
-        "Krh_I": 288,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 24,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 11,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.06.2021",
+        "Fallzahl": 30585,
+        "ObjectId": 467,
+        "Sterbefall": 1100,
+        "Genesungsfall": 29344,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2638,
+        "Zuwachs_Fallzahl": 3,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 23,
+        "BelegteBetten": null,
+        "Inzidenz": 7.2,
+        "Datum_neu": 1623801600000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "09.06.2021 - 15.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.8,
+        "Fallzahl_aktiv": 141,
+        "Krh_I_belegt": 252,
+        "Krh_I_frei": 38,
+        "Fallzahl_aktiv_Zuwachs": -20,
+        "Krh_I": 290,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 26,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 8.3,
         "Mutation": 33,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
