### PR TITLE
New data set: 2021-06-17T101404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-16T101303Z.json
+pjson/2021-06-17T101404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-16T101303Z.json pjson/2021-06-17T101404Z.json```:
```
--- pjson/2021-06-16T101303Z.json	2021-06-16 10:13:03.823374016 +0000
+++ pjson/2021-06-17T101404Z.json	2021-06-17 10:14:04.102323511 +0000
@@ -15221,7 +15221,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15353,7 +15353,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15406,12 +15406,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 48,
         "BelegteBetten": null,
-        "Inzidenz": 11.5,
+        "Inzidenz": null,
         "Datum_neu": 1623196800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 11.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15420,7 +15420,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 17.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15628,30 +15628,63 @@
         "Datum": "16.06.2021",
         "Fallzahl": 30585,
         "ObjectId": 467,
-        "Sterbefall": 1100,
-        "Genesungsfall": 29344,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2638,
-        "Zuwachs_Fallzahl": 3,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
         "Inzidenz": 7.2,
         "Datum_neu": 1623801600000,
         "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "09.06.2021 - 15.06.2021",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
-        "Fallzahl_aktiv": 141,
-        "Krh_I_belegt": 252,
-        "Krh_I_frei": 38,
-        "Fallzahl_aktiv_Zuwachs": -20,
-        "Krh_I": 290,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 26,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 8.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.06.2021",
+        "Fallzahl": 30585,
+        "ObjectId": 468,
+        "Sterbefall": 1102,
+        "Genesungsfall": 29359,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2639,
+        "Zuwachs_Fallzahl": 0,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 15,
+        "BelegteBetten": null,
+        "Inzidenz": 6.8,
+        "Datum_neu": 1623888000000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "10.06.2021 - 16.06.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 6.6,
+        "Fallzahl_aktiv": 124,
+        "Krh_I_belegt": 249,
+        "Krh_I_frei": 41,
+        "Fallzahl_aktiv_Zuwachs": -17,
+        "Krh_I": 290,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 23,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 7.1,
         "Mutation": 33,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
