### PR TITLE
New data set: 2021-06-18T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-17T101404Z.json
+pjson/2021-06-18T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-17T101404Z.json pjson/2021-06-18T101103Z.json```:
```
--- pjson/2021-06-17T101404Z.json	2021-06-17 10:14:04.102323511 +0000
+++ pjson/2021-06-18T101103Z.json	2021-06-18 10:11:03.406640112 +0000
@@ -9767,7 +9767,7 @@
         "Datum_neu": 1608422400000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9833,7 +9833,7 @@
         "Datum_neu": 1608595200000,
         "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -9866,7 +9866,7 @@
         "Datum_neu": 1608681600000,
         "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -10623,7 +10623,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10755,7 +10755,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10953,7 +10953,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -11151,7 +11151,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612051200000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -12044,7 +12044,7 @@
         "Datum_neu": 1614384000000,
         "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -14154,7 +14154,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619913600000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -15606,7 +15606,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.5,
         "Datum_neu": 1623715200000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.4,
@@ -15639,7 +15639,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.2,
         "Datum_neu": 1623801600000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
@@ -15661,25 +15661,25 @@
         "Datum": "17.06.2021",
         "Fallzahl": 30585,
         "ObjectId": 468,
-        "Sterbefall": 1102,
-        "Genesungsfall": 29359,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2639,
-        "Zuwachs_Fallzahl": 0,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
         "Inzidenz": 6.8,
         "Datum_neu": 1623888000000,
-        "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "10.06.2021 - 16.06.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 6.6,
-        "Fallzahl_aktiv": 124,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": 249,
         "Krh_I_frei": 41,
-        "Fallzahl_aktiv_Zuwachs": -17,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": 290,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": 23,
@@ -15688,6 +15688,39 @@
         "Mutation": 33,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.06.2021",
+        "Fallzahl": 30596,
+        "ObjectId": 469,
+        "Sterbefall": 1102,
+        "Genesungsfall": 29367,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2640,
+        "Zuwachs_Fallzahl": 11,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 8,
+        "BelegteBetten": null,
+        "Inzidenz": 5.7,
+        "Datum_neu": 1623974400000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "11.06.2021 - 17.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 4.5,
+        "Fallzahl_aktiv": 127,
+        "Krh_I_belegt": 253,
+        "Krh_I_frei": 37,
+        "Fallzahl_aktiv_Zuwachs": 3,
+        "Krh_I": 290,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 22,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.1,
+        "Mutation": 33,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
