### PR TITLE
New data set: 2021-06-19T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-18T101103Z.json
+pjson/2021-06-19T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-18T101103Z.json pjson/2021-06-19T100503Z.json```:
```
--- pjson/2021-06-18T101103Z.json	2021-06-18 10:11:03.406640112 +0000
+++ pjson/2021-06-19T100503Z.json	2021-06-19 10:05:03.751672944 +0000
@@ -15439,12 +15439,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 38,
         "BelegteBetten": null,
-        "Inzidenz": 10.6,
+        "Inzidenz": null,
         "Datum_neu": 1623283200000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 9.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15453,7 +15453,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 15.4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15472,12 +15472,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 30,
         "BelegteBetten": null,
-        "Inzidenz": 10.7762491468803,
+        "Inzidenz": null,
         "Datum_neu": 1623369600000,
         "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 10.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15486,7 +15486,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 14.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15639,7 +15639,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.2,
         "Datum_neu": 1623801600000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
@@ -15672,20 +15672,20 @@
         "BelegteBetten": null,
         "Inzidenz": 6.8,
         "Datum_neu": 1623888000000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 6.6,
         "Fallzahl_aktiv": null,
-        "Krh_I_belegt": 249,
-        "Krh_I_frei": 41,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
-        "Krh_I": 290,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 23,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 7.1,
-        "Mutation": 33,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -15694,30 +15694,63 @@
         "Datum": "18.06.2021",
         "Fallzahl": 30596,
         "ObjectId": 469,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 8,
+        "BelegteBetten": null,
+        "Inzidenz": 5.7,
+        "Datum_neu": 1623974400000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 4.5,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.1,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.06.2021",
+        "Fallzahl": 30605,
+        "ObjectId": 470,
         "Sterbefall": 1102,
-        "Genesungsfall": 29367,
+        "Genesungsfall": 29385,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 11,
+        "Zuwachs_Fallzahl": 9,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
-        "Zuwachs_Genesung": 8,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 18,
         "BelegteBetten": null,
-        "Inzidenz": 5.7,
-        "Datum_neu": 1623974400000,
+        "Inzidenz": 6.6,
+        "Datum_neu": 1624060800000,
         "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "11.06.2021 - 17.06.2021",
+        "Zeitraum": "12.06.2021 - 18.06.2021",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 4.5,
-        "Fallzahl_aktiv": 127,
-        "Krh_I_belegt": 253,
-        "Krh_I_frei": 37,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Inzidenz_RKI": 5.6,
+        "Fallzahl_aktiv": 118,
+        "Krh_I_belegt": 255,
+        "Krh_I_frei": 35,
+        "Fallzahl_aktiv_Zuwachs": -9,
         "Krh_I": 290,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 22,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 23,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.1,
+        "Inzi_SN_RKI": 5.2,
         "Mutation": 33,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
