### PR TITLE
New data set: 2021-06-22T102203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-21T095203Z.json
+pjson/2021-06-22T102203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-21T095203Z.json pjson/2021-06-22T102203Z.json```:
```
--- pjson/2021-06-21T095203Z.json	2021-06-21 09:52:03.680583144 +0000
+++ pjson/2021-06-22T102203Z.json	2021-06-22 10:22:03.532895280 +0000
@@ -15342,7 +15342,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1623024000000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -15474,7 +15474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1623369600000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -15573,10 +15573,10 @@
         "BelegteBetten": null,
         "Inzidenz": 8.4,
         "Datum_neu": 1623628800000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 8.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15585,7 +15585,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 11.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15672,7 +15672,7 @@
         "BelegteBetten": null,
         "Inzidenz": 6.8,
         "Datum_neu": 1623888000000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 6.6,
@@ -15705,7 +15705,7 @@
         "BelegteBetten": null,
         "Inzidenz": 5.7,
         "Datum_neu": 1623974400000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 4.5,
@@ -15760,13 +15760,13 @@
         "Datum": "20.06.2021",
         "Fallzahl": 30606,
         "ObjectId": 471,
-        "Sterbefall": 1102,
-        "Genesungsfall": 29393,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 1,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
         "Inzidenz": 6.5,
@@ -15775,16 +15775,16 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.5,
-        "Fallzahl_aktiv": 111,
-        "Krh_I_belegt": 253,
-        "Krh_I_frei": 37,
-        "Fallzahl_aktiv_Zuwachs": -7,
-        "Krh_I": 290,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 18,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 5.2,
-        "Mutation": 37,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -15795,7 +15795,7 @@
         "ObjectId": 472,
         "Sterbefall": 1102,
         "Genesungsfall": 29400,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2640,
         "Zuwachs_Fallzahl": 2,
         "Zuwachs_Sterbefall": 0,
@@ -15804,20 +15804,53 @@
         "BelegteBetten": null,
         "Inzidenz": 6.64535364057617,
         "Datum_neu": 1624233600000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "14.06.2021 - 20.06.2021",
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.3,
         "Fallzahl_aktiv": 106,
-        "Krh_I_belegt": 249,
-        "Krh_I_frei": 41,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -5,
-        "Krh_I": 290,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 18,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 5.2,
-        "Mutation": 38,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.06.2021",
+        "Fallzahl": 30622,
+        "ObjectId": 473,
+        "Sterbefall": 1102,
+        "Genesungsfall": 29409,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2640,
+        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 9,
+        "BelegteBetten": null,
+        "Inzidenz": 6.64535364057617,
+        "Datum_neu": 1624320000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "15.06.2021 - 21.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.1,
+        "Fallzahl_aktiv": 111,
+        "Krh_I_belegt": 244,
+        "Krh_I_frei": 46,
+        "Fallzahl_aktiv_Zuwachs": 5,
+        "Krh_I": 290,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 17,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 4.7,
+        "Mutation": 44,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
