### PR TITLE
New data set: 2021-06-23T101803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-22T102203Z.json
+pjson/2021-06-23T101803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-22T102203Z.json pjson/2021-06-23T101803Z.json```:
```
--- pjson/2021-06-22T102203Z.json	2021-06-22 10:22:03.532895280 +0000
+++ pjson/2021-06-23T101803Z.json	2021-06-23 10:18:03.745910914 +0000
@@ -15571,7 +15571,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
-        "Inzidenz": 8.4,
+        "Inzidenz": null,
         "Datum_neu": 1623628800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
@@ -15604,12 +15604,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 34,
         "BelegteBetten": null,
-        "Inzidenz": 7.5,
+        "Inzidenz": null,
         "Datum_neu": 1623715200000,
         "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 7.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15618,7 +15618,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 11,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15672,7 +15672,7 @@
         "BelegteBetten": null,
         "Inzidenz": 6.8,
         "Datum_neu": 1623888000000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 6.6,
@@ -15793,25 +15793,25 @@
         "Datum": "21.06.2021",
         "Fallzahl": 30608,
         "ObjectId": 472,
-        "Sterbefall": 1102,
-        "Genesungsfall": 29400,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 2,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
-        "Inzidenz": 6.64535364057617,
+        "Inzidenz": 6.6,
         "Datum_neu": 1624233600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.3,
-        "Fallzahl_aktiv": 106,
+        "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -5,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -15826,31 +15826,64 @@
         "Datum": "22.06.2021",
         "Fallzahl": 30622,
         "ObjectId": 473,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 9,
+        "BelegteBetten": null,
+        "Inzidenz": 6.6,
+        "Datum_neu": 1624320000000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.1,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 4.7,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.06.2021",
+        "Fallzahl": 30626,
+        "ObjectId": 474,
         "Sterbefall": 1102,
-        "Genesungsfall": 29409,
+        "Genesungsfall": 29412,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Fallzahl": 4,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 9,
+        "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 6.64535364057617,
-        "Datum_neu": 1624320000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "15.06.2021 - 21.06.2021",
+        "Inzidenz": 7.1,
+        "Datum_neu": 1624406400000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "16.06.2021 - 22.06.2021",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.1,
-        "Fallzahl_aktiv": 111,
-        "Krh_I_belegt": 244,
-        "Krh_I_frei": 46,
-        "Fallzahl_aktiv_Zuwachs": 5,
+        "Inzidenz_RKI": 6.5,
+        "Fallzahl_aktiv": 112,
+        "Krh_I_belegt": 242,
+        "Krh_I_frei": 48,
+        "Fallzahl_aktiv_Zuwachs": 1,
         "Krh_I": 290,
         "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 17,
+        "Krh_I_covid": 15,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.7,
-        "Mutation": 44,
+        "Inzi_SN_RKI": 4.1,
+        "Mutation": 45,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
