### PR TITLE
New data set: 2021-06-24T100803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-23T101803Z.json
+pjson/2021-06-24T100803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-23T101803Z.json pjson/2021-06-24T100803Z.json```:
```
--- pjson/2021-06-23T101803Z.json	2021-06-23 10:18:03.745910914 +0000
+++ pjson/2021-06-24T100803Z.json	2021-06-24 10:08:04.002429270 +0000
@@ -8775,7 +8775,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605830400000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -8874,7 +8874,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606089600000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -8907,7 +8907,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 276,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -8940,7 +8940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 271,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -9105,7 +9105,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -9171,7 +9171,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -9336,7 +9336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 377,
+        "F\u00e4lle_Meldedatum": 378,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -9402,7 +9402,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 397,
+        "F\u00e4lle_Meldedatum": 396,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -9468,7 +9468,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 338,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -9501,7 +9501,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607731200000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 338,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -9534,7 +9534,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -9567,7 +9567,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 430,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9600,7 +9600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 416,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -9666,7 +9666,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 516,
+        "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9699,7 +9699,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 457,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -9765,7 +9765,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -9798,7 +9798,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 435,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -9831,7 +9831,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 484,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -9864,7 +9864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 445,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -9963,7 +9963,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -9996,7 +9996,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609027200000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -10029,7 +10029,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609113600000,
-        "F\u00e4lle_Meldedatum": 365,
+        "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
         "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": null,
@@ -10062,7 +10062,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 552,
+        "F\u00e4lle_Meldedatum": 574,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -10194,7 +10194,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -10293,7 +10293,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 389,
+        "F\u00e4lle_Meldedatum": 390,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -10326,7 +10326,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 347,
+        "F\u00e4lle_Meldedatum": 346,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -10359,7 +10359,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 268,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -10392,7 +10392,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 212,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -10491,7 +10491,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -10524,7 +10524,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 270,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -10590,7 +10590,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -10623,7 +10623,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10656,7 +10656,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610755200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -11151,7 +11151,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612051200000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -15637,12 +15637,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
-        "Inzidenz": 7.2,
+        "Inzidenz": null,
         "Datum_neu": 1623801600000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15651,7 +15651,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 8.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15837,7 +15837,7 @@
         "BelegteBetten": null,
         "Inzidenz": 6.6,
         "Datum_neu": 1624320000000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.1,
@@ -15859,31 +15859,64 @@
         "Datum": "23.06.2021",
         "Fallzahl": 30626,
         "ObjectId": 474,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 3,
+        "BelegteBetten": null,
+        "Inzidenz": 7.2,
+        "Datum_neu": 1624406400000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.5,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 4.1,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.06.2021",
+        "Fallzahl": 30632,
+        "ObjectId": 475,
         "Sterbefall": 1102,
-        "Genesungsfall": 29412,
+        "Genesungsfall": 29436,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 4,
+        "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 3,
+        "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
-        "Inzidenz": 7.1,
-        "Datum_neu": 1624406400000,
-        "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "16.06.2021 - 22.06.2021",
+        "Inzidenz": 6.1,
+        "Datum_neu": 1624492800000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": "17.06.2021 - 23.06.2021",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.5,
-        "Fallzahl_aktiv": 112,
+        "Inzidenz_RKI": 6.1,
+        "Fallzahl_aktiv": 94,
         "Krh_I_belegt": 242,
         "Krh_I_frei": 48,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": -18,
         "Krh_I": 290,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 15,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 14,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.1,
-        "Mutation": 45,
+        "Inzi_SN_RKI": 4,
+        "Mutation": 52,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
