### PR TITLE
New data set: 2021-06-25T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-24T100803Z.json
+pjson/2021-06-25T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-24T100803Z.json pjson/2021-06-25T100603Z.json```:
```
--- pjson/2021-06-24T100803Z.json	2021-06-24 10:08:04.002429270 +0000
+++ pjson/2021-06-25T100603Z.json	2021-06-25 10:06:04.022350225 +0000
@@ -4452,7 +4452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1594512000000,
-        "F\u00e4lle_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -9831,7 +9831,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 480,
+        "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -9864,7 +9864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -15377,7 +15377,7 @@
         "Datum_neu": 1623110400000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15518,7 +15518,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15670,12 +15670,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
-        "Inzidenz": 6.8,
+        "Inzidenz": null,
         "Datum_neu": 1623888000000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 6.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15684,7 +15684,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 7.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15716,7 +15716,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 6.1,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -15806,7 +15806,7 @@
         "Datum_neu": 1624233600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 6.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15870,7 +15870,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.2,
         "Datum_neu": 1624406400000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.5,
@@ -15894,7 +15894,7 @@
         "ObjectId": 475,
         "Sterbefall": 1102,
         "Genesungsfall": 29436,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2640,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
@@ -15903,8 +15903,8 @@
         "BelegteBetten": null,
         "Inzidenz": 6.1,
         "Datum_neu": 1624492800000,
-        "F\u00e4lle_Meldedatum": 5,
-        "Zeitraum": "17.06.2021 - 23.06.2021",
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.1,
         "Fallzahl_aktiv": 94,
@@ -15919,6 +15919,39 @@
         "Mutation": 52,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.06.2021",
+        "Fallzahl": 30646,
+        "ObjectId": 476,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29441,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2640,
+        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 5,
+        "BelegteBetten": null,
+        "Inzidenz": 5.92693703078415,
+        "Datum_neu": 1624579200000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "18.06.2021 - 24.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 5.6,
+        "Fallzahl_aktiv": 101,
+        "Krh_I_belegt": 254,
+        "Krh_I_frei": 37,
+        "Fallzahl_aktiv_Zuwachs": 7,
+        "Krh_I": 291,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": 13,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 3.6,
+        "Mutation": 56,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
