### PR TITLE
New data set: 2021-06-26T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-25T100603Z.json
+pjson/2021-06-26T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-25T100603Z.json pjson/2021-06-26T100203Z.json```:
```
--- pjson/2021-06-25T100603Z.json	2021-06-25 10:06:04.022350225 +0000
+++ pjson/2021-06-26T100203Z.json	2021-06-26 10:02:03.480480451 +0000
@@ -15703,7 +15703,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
-        "Inzidenz": 5.7,
+        "Inzidenz": null,
         "Datum_neu": 1623974400000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
@@ -15717,7 +15717,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 6.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15892,31 +15892,31 @@
         "Datum": "24.06.2021",
         "Fallzahl": 30632,
         "ObjectId": 475,
-        "Sterbefall": 1102,
-        "Genesungsfall": 29436,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
         "Inzidenz": 6.1,
         "Datum_neu": 1624492800000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.1,
-        "Fallzahl_aktiv": 94,
-        "Krh_I_belegt": 242,
-        "Krh_I_frei": 48,
-        "Fallzahl_aktiv_Zuwachs": -18,
-        "Krh_I": 290,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 14,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 4,
-        "Mutation": 52,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -15927,7 +15927,7 @@
         "ObjectId": 476,
         "Sterbefall": 1104,
         "Genesungsfall": 29441,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2640,
         "Zuwachs_Fallzahl": 14,
         "Zuwachs_Sterbefall": 2,
@@ -15936,8 +15936,8 @@
         "BelegteBetten": null,
         "Inzidenz": 5.92693703078415,
         "Datum_neu": 1624579200000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "18.06.2021 - 24.06.2021",
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5.6,
         "Fallzahl_aktiv": 101,
@@ -15952,6 +15952,39 @@
         "Mutation": 56,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.06.2021",
+        "Fallzahl": 30654,
+        "ObjectId": 477,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29449,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2640,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 8,
+        "BelegteBetten": null,
+        "Inzidenz": 7.18416609792018,
+        "Datum_neu": 1624665600000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "19.06.2021 - 25.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.3,
+        "Fallzahl_aktiv": 101,
+        "Krh_I_belegt": 251,
+        "Krh_I_frei": 39,
+        "Fallzahl_aktiv_Zuwachs": 0,
+        "Krh_I": 290,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": 13,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 3.4,
+        "Mutation": 60,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
