### PR TITLE
New data set: 2021-06-28T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-26T100203Z.json
+pjson/2021-06-28T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-26T100203Z.json pjson/2021-06-28T101103Z.json```:
```
--- pjson/2021-06-26T100203Z.json	2021-06-26 10:02:03.480480451 +0000
+++ pjson/2021-06-28T101103Z.json	2021-06-28 10:11:03.991923846 +0000
@@ -15708,7 +15708,7 @@
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 4.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15736,12 +15736,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 18,
         "BelegteBetten": null,
-        "Inzidenz": 6.6,
+        "Inzidenz": null,
         "Datum_neu": 1624060800000,
         "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 5.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15750,7 +15750,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 5.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15769,12 +15769,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
-        "Inzidenz": 6.5,
+        "Inzidenz": null,
         "Datum_neu": 1624147200000,
         "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15783,7 +15783,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 5.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -15806,7 +15806,7 @@
         "Datum_neu": 1624233600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 6.3,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
@@ -15925,13 +15925,13 @@
         "Datum": "25.06.2021",
         "Fallzahl": 30646,
         "ObjectId": 476,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29441,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 14,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
         "Inzidenz": 5.92693703078415,
@@ -15940,16 +15940,16 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5.6,
-        "Fallzahl_aktiv": 101,
-        "Krh_I_belegt": 254,
-        "Krh_I_frei": 37,
-        "Fallzahl_aktiv_Zuwachs": 7,
-        "Krh_I": 291,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": 13,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 3.6,
-        "Mutation": 56,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -15958,31 +15958,97 @@
         "Datum": "26.06.2021",
         "Fallzahl": 30654,
         "ObjectId": 477,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29449,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
         "Inzidenz": 7.18416609792018,
         "Datum_neu": 1624665600000,
         "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "19.06.2021 - 25.06.2021",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.3,
-        "Fallzahl_aktiv": 101,
-        "Krh_I_belegt": 251,
-        "Krh_I_frei": 39,
-        "Fallzahl_aktiv_Zuwachs": 0,
-        "Krh_I": 290,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 3.4,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.06.2021",
+        "Fallzahl": 30654,
+        "ObjectId": 478,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 7,
+        "BelegteBetten": null,
+        "Inzidenz": 7.4,
+        "Datum_neu": 1624752000000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 7.4,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 3.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.06.2021",
+        "Fallzahl": 30655,
+        "ObjectId": 479,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29465,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2642,
+        "Zuwachs_Fallzahl": 1,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 9,
+        "BelegteBetten": null,
+        "Inzidenz": 7.4,
+        "Datum_neu": 1624838400000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "21.06.2021 - 27.06.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 7.2,
+        "Fallzahl_aktiv": 86,
+        "Krh_I_belegt": 236,
+        "Krh_I_frei": 52,
+        "Fallzahl_aktiv_Zuwachs": -8,
+        "Krh_I": 288,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 13,
+        "Krh_I_covid": 14,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 3.4,
-        "Mutation": 60,
+        "Mutation": 64,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
