### PR TITLE
New data set: 2021-06-30T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-06-29T102503Z.json
+pjson/2021-06-30T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-06-29T102503Z.json pjson/2021-06-30T100303Z.json```:
```
--- pjson/2021-06-29T102503Z.json	2021-06-29 10:25:03.486987496 +0000
+++ pjson/2021-06-30T100303Z.json	2021-06-30 10:03:03.538338099 +0000
@@ -15835,12 +15835,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
-        "Inzidenz": 6.6,
+        "Inzidenz": null,
         "Datum_neu": 1624320000000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
@@ -15849,7 +15849,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16035,7 +16035,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.4,
         "Datum_neu": 1624838400000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.2,
@@ -16057,31 +16057,64 @@
         "Datum": "29.06.2021",
         "Fallzahl": 30667,
         "ObjectId": 480,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 7,
+        "BelegteBetten": null,
+        "Inzidenz": 8.4,
+        "Datum_neu": 1624924800000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.8,
+        "Fallzahl_aktiv": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.06.2021",
+        "Fallzahl": 30671,
+        "ObjectId": 481,
         "Sterbefall": 1104,
-        "Genesungsfall": 29472,
+        "Genesungsfall": 29482,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2642,
-        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Fallzahl": 4,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 7,
+        "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 8.4,
-        "Datum_neu": 1624924800000,
+        "Inzidenz": 7.4,
+        "Datum_neu": 1625011200000,
         "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "22.06.2021 - 28.06.2021",
+        "Zeitraum": "23.06.2021 - 29.06.2021",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
-        "Fallzahl_aktiv": 91,
-        "Krh_I_belegt": 243,
-        "Krh_I_frei": 45,
-        "Fallzahl_aktiv_Zuwachs": 5,
-        "Krh_I": 288,
-        "Vorz_akt_Faelle": "+",
+        "Fallzahl_aktiv": 85,
+        "Krh_I_belegt": 234,
+        "Krh_I_frei": 55,
+        "Fallzahl_aktiv_Zuwachs": -6,
+        "Krh_I": 289,
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": 14,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3,
-        "Mutation": 68,
+        "Inzi_SN_RKI": 2.9,
+        "Mutation": 81,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
