### PR TITLE
New data set: 2021-07-01T135304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-01T100803Z.json
+pjson/2021-07-01T135304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-01T100803Z.json pjson/2021-07-01T135304Z.json```:
```
--- pjson/2021-07-01T100803Z.json	2021-07-01 10:08:04.077446657 +0000
+++ pjson/2021-07-01T135304Z.json	2021-07-01 13:53:04.181956875 +0000
@@ -16092,7 +16092,7 @@
         "ObjectId": 481,
         "Sterbefall": 1104,
         "Genesungsfall": 29482,
-        "Anzeige_Indikator": null,
+        "Anzeige_Indikator": "x",
         "Hospitalisierung": 2642,
         "Zuwachs_Fallzahl": 4,
         "Zuwachs_Sterbefall": 0,
@@ -16101,8 +16101,8 @@
         "BelegteBetten": null,
         "Inzidenz": 7.4,
         "Datum_neu": 1625011200000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": null,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "23.06.2021 - 29.06.2021",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
         "Fallzahl_aktiv": 85,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
