### PR TITLE
New data set: 2021-07-01T140103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-01T100803Z.json
+pjson/2021-07-01T140103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-01T135304Z.json pjson/2021-07-01T140103Z.json```:
```
--- pjson/2021-07-01T135304Z.json	2021-07-01 13:53:04.181956875 +0000
+++ pjson/2021-07-01T140103Z.json	2021-07-01 14:01:03.339629021 +0000
@@ -163,6 +163,14 @@
       "defaultValue": null
     },
     {
+      "name": "Krh_N_belegt",
+      "type": "esriFieldTypeInteger",
+      "alias": "Krh_N_belegt",
+      "sqlType": "sqlTypeOther",
+      "domain": null,
+      "defaultValue": null
+    },
+    {
       "name": "Krh_I_belegt",
       "type": "esriFieldTypeInteger",
       "alias": "Krh_I_belegt",
@@ -266,6 +274,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -299,6 +308,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -332,6 +342,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -365,6 +376,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -398,6 +410,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -431,6 +444,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -464,6 +478,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -497,6 +512,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -530,6 +546,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -563,6 +580,7 @@
         "Hosp_Meldedatum": null,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -596,6 +614,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -629,6 +648,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -662,6 +682,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -695,6 +716,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -728,6 +750,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -761,6 +784,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -794,6 +818,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -827,6 +852,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -860,6 +886,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -893,6 +920,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -926,6 +954,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -959,6 +988,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -992,6 +1022,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1025,6 +1056,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1058,6 +1090,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1091,6 +1124,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1124,6 +1158,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1157,6 +1192,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1190,6 +1226,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1223,6 +1260,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1256,6 +1294,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1289,6 +1328,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1322,6 +1362,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1355,6 +1396,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1388,6 +1430,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1421,6 +1464,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1454,6 +1498,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1487,6 +1532,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1520,6 +1566,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1553,6 +1600,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1586,6 +1634,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1619,6 +1668,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1652,6 +1702,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1685,6 +1736,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1718,6 +1770,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1751,6 +1804,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1784,6 +1838,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1817,6 +1872,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1850,6 +1906,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1883,6 +1940,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1916,6 +1974,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1949,6 +2008,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -1982,6 +2042,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2015,6 +2076,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2048,6 +2110,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2081,6 +2144,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2114,6 +2178,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2147,6 +2212,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2180,6 +2246,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2213,6 +2280,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2246,6 +2314,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2279,6 +2348,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2312,6 +2382,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2345,6 +2416,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2378,6 +2450,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2411,6 +2484,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2444,6 +2518,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2477,6 +2552,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2510,6 +2586,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2543,6 +2620,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2576,6 +2654,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2609,6 +2688,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2642,6 +2722,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2675,6 +2756,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2708,6 +2790,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2741,6 +2824,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2774,6 +2858,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2807,6 +2892,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2840,6 +2926,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2873,6 +2960,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2906,6 +2994,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2939,6 +3028,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -2972,6 +3062,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3005,6 +3096,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3038,6 +3130,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3071,6 +3164,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3104,6 +3198,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3137,6 +3232,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3170,6 +3266,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3203,6 +3300,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3236,6 +3334,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3269,6 +3368,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3302,6 +3402,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3335,6 +3436,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3368,6 +3470,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3401,6 +3504,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3434,6 +3538,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3467,6 +3572,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3500,6 +3606,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3533,6 +3640,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3566,6 +3674,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3599,6 +3708,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3632,6 +3742,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3665,6 +3776,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3698,6 +3810,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3731,6 +3844,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3764,6 +3878,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3797,6 +3912,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3830,6 +3946,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3863,6 +3980,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3896,6 +4014,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3929,6 +4048,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3962,6 +4082,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -3995,6 +4116,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4028,6 +4150,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4061,6 +4184,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4094,6 +4218,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4127,6 +4252,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4160,6 +4286,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4193,6 +4320,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4226,6 +4354,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4259,6 +4388,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4292,6 +4422,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4325,6 +4456,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4358,6 +4490,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4391,6 +4524,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4424,6 +4558,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4457,6 +4592,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4490,6 +4626,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4523,6 +4660,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4556,6 +4694,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4589,6 +4728,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4622,6 +4762,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4655,6 +4796,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4688,6 +4830,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4721,6 +4864,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4754,6 +4898,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4787,6 +4932,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4820,6 +4966,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4853,6 +5000,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4886,6 +5034,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4919,6 +5068,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4952,6 +5102,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -4985,6 +5136,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5018,6 +5170,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5051,6 +5204,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5084,6 +5238,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5117,6 +5272,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5150,6 +5306,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5183,6 +5340,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5216,6 +5374,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5249,6 +5408,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5282,6 +5442,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5315,6 +5476,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5348,6 +5510,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5381,6 +5544,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5414,6 +5578,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5447,6 +5612,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5480,6 +5646,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5513,6 +5680,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5546,6 +5714,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5579,6 +5748,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5612,6 +5782,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5645,6 +5816,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5678,6 +5850,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5711,6 +5884,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5744,6 +5918,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5777,6 +5952,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5810,6 +5986,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5843,6 +6020,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5876,6 +6054,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5909,6 +6088,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5942,6 +6122,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -5975,6 +6156,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6008,6 +6190,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6041,6 +6224,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6074,6 +6258,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6107,6 +6292,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6140,6 +6326,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6173,6 +6360,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6206,6 +6394,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6239,6 +6428,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6272,6 +6462,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6305,6 +6496,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6338,6 +6530,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6371,6 +6564,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6404,6 +6598,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6437,6 +6632,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6470,6 +6666,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6503,6 +6700,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6536,6 +6734,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6569,6 +6768,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6602,6 +6802,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6635,6 +6836,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6668,6 +6870,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6701,6 +6904,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6734,6 +6938,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6767,6 +6972,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6800,6 +7006,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6833,6 +7040,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6866,6 +7074,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6899,6 +7108,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6932,6 +7142,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6965,6 +7176,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -6998,6 +7210,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7031,6 +7244,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7064,6 +7278,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7097,6 +7312,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7130,6 +7346,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7163,6 +7380,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7196,6 +7414,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7229,6 +7448,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7262,6 +7482,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7295,6 +7516,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7328,6 +7550,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7361,6 +7584,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7394,6 +7618,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7427,6 +7652,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7460,6 +7686,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7493,6 +7720,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7526,6 +7754,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7559,6 +7788,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7592,6 +7822,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7625,6 +7856,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7658,6 +7890,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7691,6 +7924,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7724,6 +7958,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7757,6 +7992,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7790,6 +8026,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7823,6 +8060,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7856,6 +8094,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7889,6 +8128,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7922,6 +8162,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7955,6 +8196,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -7988,6 +8230,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8021,6 +8264,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8054,6 +8298,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8087,6 +8332,7 @@
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8120,6 +8366,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8153,6 +8400,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8186,6 +8434,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8219,6 +8468,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8252,6 +8502,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8285,6 +8536,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8318,6 +8570,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8351,6 +8604,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8384,6 +8638,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8417,6 +8672,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8450,6 +8706,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8483,6 +8740,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8516,6 +8774,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8549,6 +8808,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8582,6 +8842,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8615,6 +8876,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8648,6 +8910,7 @@
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8681,6 +8944,7 @@
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8714,6 +8978,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8747,6 +9012,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8780,6 +9046,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8813,6 +9080,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8846,6 +9114,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8879,6 +9148,7 @@
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8912,6 +9182,7 @@
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8945,6 +9216,7 @@
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -8978,6 +9250,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9011,6 +9284,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9044,6 +9318,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9077,6 +9352,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9110,6 +9386,7 @@
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9143,6 +9420,7 @@
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9176,6 +9454,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9209,6 +9488,7 @@
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9242,6 +9522,7 @@
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9275,6 +9556,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9308,6 +9590,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9341,6 +9624,7 @@
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9374,6 +9658,7 @@
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9407,6 +9692,7 @@
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9440,6 +9726,7 @@
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9473,6 +9760,7 @@
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9506,6 +9794,7 @@
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9539,6 +9828,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9572,6 +9862,7 @@
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9605,6 +9896,7 @@
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9638,6 +9930,7 @@
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9671,6 +9964,7 @@
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9704,6 +9998,7 @@
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9737,6 +10032,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9770,6 +10066,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9803,6 +10100,7 @@
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9836,6 +10134,7 @@
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9869,6 +10168,7 @@
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9902,6 +10202,7 @@
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9935,6 +10236,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -9968,6 +10270,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10001,6 +10304,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10034,6 +10338,7 @@
         "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10067,6 +10372,7 @@
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10100,6 +10406,7 @@
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10133,6 +10440,7 @@
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10166,6 +10474,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10199,6 +10508,7 @@
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10232,6 +10542,7 @@
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10265,6 +10576,7 @@
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10298,6 +10610,7 @@
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10331,6 +10644,7 @@
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10364,6 +10678,7 @@
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10397,6 +10712,7 @@
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10430,6 +10746,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10463,6 +10780,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10496,6 +10814,7 @@
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10529,6 +10848,7 @@
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10562,6 +10882,7 @@
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10595,6 +10916,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10628,6 +10950,7 @@
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10661,6 +10984,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10694,6 +11018,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10727,6 +11052,7 @@
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10760,6 +11086,7 @@
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10793,6 +11120,7 @@
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10826,6 +11154,7 @@
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10859,6 +11188,7 @@
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10892,6 +11222,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10925,6 +11256,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10958,6 +11290,7 @@
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -10991,6 +11324,7 @@
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11024,6 +11358,7 @@
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11057,6 +11392,7 @@
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11090,6 +11426,7 @@
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11123,6 +11460,7 @@
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11156,6 +11494,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11189,6 +11528,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11222,6 +11562,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11255,6 +11596,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11288,6 +11630,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11321,6 +11664,7 @@
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11354,6 +11698,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11387,6 +11732,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11420,6 +11766,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11453,6 +11800,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11486,6 +11834,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11519,6 +11868,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11552,6 +11902,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11585,6 +11936,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11618,6 +11970,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11651,6 +12004,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11684,6 +12038,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11717,6 +12072,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11750,6 +12106,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11783,6 +12140,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11816,6 +12174,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11849,6 +12208,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11882,6 +12242,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11915,6 +12276,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11948,6 +12310,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -11981,6 +12344,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12014,6 +12378,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12047,6 +12412,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12080,6 +12446,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12113,6 +12480,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12146,6 +12514,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12179,6 +12548,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12212,6 +12582,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12245,6 +12616,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12278,6 +12650,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12311,6 +12684,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12344,6 +12718,7 @@
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12377,6 +12752,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12410,6 +12786,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12443,6 +12820,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12476,6 +12854,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12509,6 +12888,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12542,6 +12922,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12575,6 +12956,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12608,6 +12990,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12641,6 +13024,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12674,6 +13058,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12707,6 +13092,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12740,6 +13126,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12773,6 +13160,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12806,6 +13194,7 @@
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12839,6 +13228,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12872,6 +13262,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12905,6 +13296,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12938,6 +13330,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -12971,6 +13364,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13004,6 +13398,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13037,6 +13432,7 @@
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13070,6 +13466,7 @@
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13103,6 +13500,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13136,6 +13534,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13169,6 +13568,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13202,6 +13602,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13235,6 +13636,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13268,6 +13670,7 @@
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13301,6 +13704,7 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13334,6 +13738,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13367,6 +13772,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13400,6 +13806,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13433,6 +13840,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13466,6 +13874,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13499,6 +13908,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13532,6 +13942,7 @@
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13565,6 +13976,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13598,6 +14010,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13631,6 +14044,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13664,6 +14078,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13697,6 +14112,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13730,6 +14146,7 @@
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13763,6 +14180,7 @@
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13796,6 +14214,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13829,6 +14248,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13862,6 +14282,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13895,6 +14316,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13928,6 +14350,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13961,6 +14384,7 @@
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -13994,6 +14418,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14027,6 +14452,7 @@
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14060,6 +14486,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14093,6 +14520,7 @@
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14126,6 +14554,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14159,6 +14588,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14192,6 +14622,7 @@
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14225,6 +14656,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14258,6 +14690,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14291,6 +14724,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14324,6 +14758,7 @@
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14357,6 +14792,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14390,6 +14826,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14423,6 +14860,7 @@
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14456,6 +14894,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14489,6 +14928,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14522,6 +14962,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14555,6 +14996,7 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14588,6 +15030,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14621,6 +15064,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14654,6 +15098,7 @@
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14687,6 +15132,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14720,6 +15166,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14753,6 +15200,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14786,6 +15234,7 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14819,6 +15268,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14852,6 +15302,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14885,6 +15336,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14918,6 +15370,7 @@
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14951,6 +15404,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -14984,6 +15438,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15017,6 +15472,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15050,6 +15506,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15083,6 +15540,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15116,6 +15574,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15149,6 +15608,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15182,6 +15642,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15215,6 +15676,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15248,6 +15710,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15281,6 +15744,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15314,6 +15778,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15347,6 +15812,7 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15380,6 +15846,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15413,6 +15880,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15446,6 +15914,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15479,6 +15948,7 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15512,6 +15982,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15545,6 +16016,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15578,6 +16050,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15611,6 +16084,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15644,6 +16118,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15677,6 +16152,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15710,6 +16186,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15743,6 +16220,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15776,6 +16254,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15809,6 +16288,7 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15842,6 +16322,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15875,6 +16356,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.5,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15908,6 +16390,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.1,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15941,6 +16424,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5.6,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -15974,6 +16458,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.3,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -16007,6 +16492,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.4,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -16040,6 +16526,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.2,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -16073,6 +16560,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
         "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -16106,6 +16594,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
         "Fallzahl_aktiv": 85,
+        "Krh_N_belegt": 136,
         "Krh_I_belegt": 234,
         "Krh_I_frei": 55,
         "Fallzahl_aktiv_Zuwachs": -6,
@@ -16139,6 +16628,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7,
         "Fallzahl_aktiv": 61,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": 229,
         "Krh_I_frei": 60,
         "Fallzahl_aktiv_Zuwachs": -24,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
