### PR TITLE
New data set: 2021-07-01T141203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-01T100803Z.json
+pjson/2021-07-01T141203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-01T140103Z.json pjson/2021-07-01T141203Z.json```:
```
--- pjson/2021-07-01T140103Z.json	2021-07-01 14:01:03.339629021 +0000
+++ pjson/2021-07-01T141203Z.json	2021-07-01 14:12:03.684221117 +0000
@@ -16580,7 +16580,7 @@
         "ObjectId": 481,
         "Sterbefall": 1104,
         "Genesungsfall": 29482,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2642,
         "Zuwachs_Fallzahl": 4,
         "Zuwachs_Sterbefall": 0,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
