### PR TITLE
New data set: 2021-07-01T141903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-01T100803Z.json
+pjson/2021-07-01T141903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-01T141203Z.json pjson/2021-07-01T141903Z.json```:
```
--- pjson/2021-07-01T141203Z.json	2021-07-01 14:12:03.684221117 +0000
+++ pjson/2021-07-01T141903Z.json	2021-07-01 14:19:03.944503687 +0000
@@ -16594,7 +16594,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
         "Fallzahl_aktiv": 85,
-        "Krh_N_belegt": 136,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": 234,
         "Krh_I_frei": 55,
         "Fallzahl_aktiv_Zuwachs": -6,
@@ -16628,7 +16628,7 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7,
         "Fallzahl_aktiv": 61,
-        "Krh_N_belegt": null,
+        "Krh_N_belegt": 136,
         "Krh_I_belegt": 229,
         "Krh_I_frei": 60,
         "Fallzahl_aktiv_Zuwachs": -24,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
