### PR TITLE
New data set: 2021-07-01T150803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-01T100803Z.json
+pjson/2021-07-01T150803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-01T141903Z.json pjson/2021-07-01T150803Z.json```:
```
--- pjson/2021-07-01T141903Z.json	2021-07-01 14:19:03.944503687 +0000
+++ pjson/2021-07-01T150803Z.json	2021-07-01 15:08:03.737540449 +0000
@@ -16629,7 +16629,7 @@
         "Inzidenz_RKI": 7,
         "Fallzahl_aktiv": 61,
         "Krh_N_belegt": 136,
-        "Krh_I_belegt": 229,
+        "Krh_I_belegt": 51,
         "Krh_I_frei": 60,
         "Fallzahl_aktiv_Zuwachs": -24,
         "Krh_I": 289,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
