### PR TITLE
New data set: 2021-07-01T151303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-01T100803Z.json
+pjson/2021-07-01T151303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-01T150803Z.json pjson/2021-07-01T151303Z.json```:
```
--- pjson/2021-07-01T150803Z.json	2021-07-01 15:08:03.737540449 +0000
+++ pjson/2021-07-01T151303Z.json	2021-07-01 15:13:03.716626564 +0000
@@ -16595,7 +16595,7 @@
         "Inzidenz_RKI": 6.8,
         "Fallzahl_aktiv": 85,
         "Krh_N_belegt": null,
-        "Krh_I_belegt": 234,
+        "Krh_I_belegt": null,
         "Krh_I_frei": 55,
         "Fallzahl_aktiv_Zuwachs": -6,
         "Krh_I": 289,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
