### PR TITLE
New data set: 2021-07-02T101104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-01T100803Z.json
+pjson/2021-07-02T101104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-01T151303Z.json pjson/2021-07-02T101104Z.json```:
```
--- pjson/2021-07-01T151303Z.json	2021-07-01 15:13:03.716626564 +0000
+++ pjson/2021-07-02T101104Z.json	2021-07-02 10:11:04.147265699 +0000
@@ -10199,7 +10199,7 @@
         "Datum_neu": 1608768000000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10743,7 +10743,7 @@
         "Datum_neu": 1610150400000,
         "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11083,7 +11083,7 @@
         "Datum_neu": 1611014400000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11151,7 +11151,7 @@
         "Datum_neu": 1611187200000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12781,7 +12781,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615334400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -14177,7 +14177,7 @@
         "Datum_neu": 1618876800000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14211,7 +14211,7 @@
         "Datum_neu": 1618963200000,
         "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14279,7 +14279,7 @@
         "Datum_neu": 1619136000000,
         "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14381,7 +14381,7 @@
         "Datum_neu": 1619395200000,
         "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14415,7 +14415,7 @@
         "Datum_neu": 1619481600000,
         "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14687,7 +14687,7 @@
         "Datum_neu": 1620172800000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14755,7 +14755,7 @@
         "Datum_neu": 1620345600000,
         "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14857,7 +14857,7 @@
         "Datum_neu": 1620604800000,
         "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14891,7 +14891,7 @@
         "Datum_neu": 1620691200000,
         "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14993,7 +14993,7 @@
         "Datum_neu": 1620950400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15095,7 +15095,7 @@
         "Datum_neu": 1621209600000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15129,7 +15129,7 @@
         "Datum_neu": 1621296000000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15163,7 +15163,7 @@
         "Datum_neu": 1621382400000,
         "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15197,7 +15197,7 @@
         "Datum_neu": 1621468800000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15367,7 +15367,7 @@
         "Datum_neu": 1621900800000,
         "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15809,7 +15809,7 @@
         "Datum_neu": 1623024000000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15877,7 +15877,7 @@
         "Datum_neu": 1623196800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15945,7 +15945,7 @@
         "Datum_neu": 1623369600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16285,7 +16285,7 @@
         "Datum_neu": 1624233600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16349,12 +16349,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 7.2,
+        "Inzidenz": null,
         "Datum_neu": 1624406400000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16364,7 +16364,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16383,12 +16383,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
-        "Inzidenz": 6.1,
+        "Inzidenz": null,
         "Datum_neu": 1624492800000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16398,7 +16398,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16578,32 +16578,32 @@
         "Datum": "30.06.2021",
         "Fallzahl": 30671,
         "ObjectId": 481,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29482,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2642,
-        "Zuwachs_Fallzahl": 4,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
         "Inzidenz": 7.4,
         "Datum_neu": 1625011200000,
-        "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "23.06.2021 - 29.06.2021",
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
-        "Fallzahl_aktiv": 85,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
-        "Krh_I_frei": 55,
-        "Fallzahl_aktiv_Zuwachs": -6,
-        "Krh_I": 289,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 14,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.9,
-        "Mutation": 81,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -16612,32 +16612,66 @@
         "Datum": "01.07.2021",
         "Fallzahl": 30676,
         "ObjectId": 482,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29511,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2642,
-        "Zuwachs_Fallzahl": 5,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 7.54337440281619,
+        "Inzidenz": 7.5,
         "Datum_neu": 1625097600000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "24.06.2021 - 30.06.2021",
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7,
-        "Fallzahl_aktiv": 61,
-        "Krh_N_belegt": 136,
-        "Krh_I_belegt": 51,
-        "Krh_I_frei": 60,
-        "Fallzahl_aktiv_Zuwachs": -24,
-        "Krh_I": 289,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
         "Vorz_akt_Faelle": null,
-        "Krh_I_covid": 14,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.8,
-        "Mutation": 82,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.07.2021",
+        "Fallzahl": 30676,
+        "ObjectId": 483,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29522,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2640,
+        "Zuwachs_Fallzahl": 0,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 11,
+        "BelegteBetten": null,
+        "Inzidenz": 6.8,
+        "Datum_neu": 1625184000000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "25.06.2021 - 01.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.6,
+        "Fallzahl_aktiv": 50,
+        "Krh_N_belegt": 129,
+        "Krh_I_belegt": 49,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.7,
+        "Mutation": 83,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
