### PR TITLE
New data set: 2021-07-03T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-02T101104Z.json
+pjson/2021-07-03T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-02T101104Z.json pjson/2021-07-03T100103Z.json```:
```
--- pjson/2021-07-02T101104Z.json	2021-07-02 10:11:04.147265699 +0000
+++ pjson/2021-07-03T100103Z.json	2021-07-03 10:01:03.973638233 +0000
@@ -16417,12 +16417,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
-        "Inzidenz": 5.92693703078415,
+        "Inzidenz": null,
         "Datum_neu": 1624579200000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 5.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16432,7 +16432,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16451,7 +16451,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
-        "Inzidenz": 7.18416609792018,
+        "Inzidenz": 7.2,
         "Datum_neu": 1624665600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
@@ -16555,7 +16555,7 @@
         "BelegteBetten": null,
         "Inzidenz": 8.4,
         "Datum_neu": 1624924800000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
@@ -16589,7 +16589,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.4,
         "Datum_neu": 1625011200000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 6.8,
@@ -16623,7 +16623,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.5,
         "Datum_neu": 1625097600000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7,
@@ -16646,32 +16646,66 @@
         "Datum": "02.07.2021",
         "Fallzahl": 30676,
         "ObjectId": 483,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 11,
+        "BelegteBetten": null,
+        "Inzidenz": 6.8,
+        "Datum_neu": 1625184000000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 6.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.7,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.07.2021",
+        "Fallzahl": 30678,
+        "ObjectId": 484,
         "Sterbefall": 1104,
-        "Genesungsfall": 29522,
+        "Genesungsfall": 29526,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 0,
+        "Zuwachs_Fallzahl": 2,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 11,
+        "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 6.8,
-        "Datum_neu": 1625184000000,
+        "Inzidenz": 5.4,
+        "Datum_neu": 1625270400000,
         "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "25.06.2021 - 01.07.2021",
+        "Zeitraum": "26.06.2021 - 02.07.2021",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.6,
-        "Fallzahl_aktiv": 50,
-        "Krh_N_belegt": 129,
-        "Krh_I_belegt": 49,
+        "Inzidenz_RKI": 5,
+        "Fallzahl_aktiv": 48,
+        "Krh_N_belegt": 127,
+        "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -11,
+        "Fallzahl_aktiv_Zuwachs": -2,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.7,
-        "Mutation": 83,
+        "Inzi_SN_RKI": 2.4,
+        "Mutation": 85,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
