### PR TITLE
New data set: 2021-07-06T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-05T100814Z.json
+pjson/2021-07-06T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-05T100814Z.json pjson/2021-07-06T100403Z.json```:
```
--- pjson/2021-07-05T100814Z.json	2021-07-05 10:08:14.330331965 +0000
+++ pjson/2021-07-06T100403Z.json	2021-07-06 10:04:03.459204553 +0000
@@ -16519,12 +16519,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
-        "Inzidenz": 7.4,
+        "Inzidenz": null,
         "Datum_neu": 1624838400000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 7.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16534,7 +16534,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16714,13 +16714,13 @@
         "Datum": "04.07.2021",
         "Fallzahl": 30678,
         "ObjectId": 485,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29530,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 0,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
         "Inzidenz": 4.7,
@@ -16729,17 +16729,17 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 4.7,
-        "Fallzahl_aktiv": 44,
-        "Krh_N_belegt": 127,
-        "Krh_I_belegt": 48,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -4,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.3,
-        "Mutation": 85,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -16750,7 +16750,7 @@
         "ObjectId": 486,
         "Sterbefall": 1104,
         "Genesungsfall": 29534,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2640,
         "Zuwachs_Fallzahl": 1,
         "Zuwachs_Sterbefall": 0,
@@ -16759,13 +16759,13 @@
         "BelegteBetten": null,
         "Inzidenz": 4.66970796364812,
         "Datum_neu": 1625443200000,
-        "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "28.06.2021 - 04.07.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 4.5,
         "Fallzahl_aktiv": 41,
-        "Krh_N_belegt": 127,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -3,
         "Krh_I": null,
@@ -16773,7 +16773,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.1,
-        "Mutation": 85,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.07.2021",
+        "Fallzahl": 30684,
+        "ObjectId": 487,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29544,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2641,
+        "Zuwachs_Fallzahl": 5,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 10,
+        "BelegteBetten": null,
+        "Inzidenz": 3.05327059161608,
+        "Datum_neu": 1625529600000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "29.06.2021 - 05.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 3.1,
+        "Fallzahl_aktiv": 36,
+        "Krh_N_belegt": 129,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -5,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 1.7,
+        "Mutation": 88,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
