### PR TITLE
New data set: 2021-07-07T101203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-06T100403Z.json
+pjson/2021-07-07T101203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-06T100403Z.json pjson/2021-07-07T101203Z.json```:
```
--- pjson/2021-07-06T100403Z.json	2021-07-06 10:04:03.459204553 +0000
+++ pjson/2021-07-07T101203Z.json	2021-07-07 10:12:03.939904292 +0000
@@ -16283,7 +16283,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624233600000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -16553,12 +16553,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
-        "Inzidenz": 8.4,
+        "Inzidenz": null,
         "Datum_neu": 1624924800000,
         "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16568,7 +16568,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16691,7 +16691,7 @@
         "BelegteBetten": null,
         "Inzidenz": 5.4,
         "Datum_neu": 1625270400000,
-        "F\u00e4lle_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5,
@@ -16748,13 +16748,13 @@
         "Datum": "05.07.2021",
         "Fallzahl": 30679,
         "ObjectId": 486,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29534,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2640,
-        "Zuwachs_Fallzahl": 1,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
         "Inzidenz": 4.66970796364812,
@@ -16763,11 +16763,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 4.5,
-        "Fallzahl_aktiv": 41,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -16784,7 +16784,7 @@
         "ObjectId": 487,
         "Sterbefall": 1104,
         "Genesungsfall": 29544,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2641,
         "Zuwachs_Fallzahl": 5,
         "Zuwachs_Sterbefall": 0,
@@ -16793,13 +16793,13 @@
         "BelegteBetten": null,
         "Inzidenz": 3.05327059161608,
         "Datum_neu": 1625529600000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "29.06.2021 - 05.07.2021",
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.1,
         "Fallzahl_aktiv": 36,
-        "Krh_N_belegt": 129,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -5,
         "Krh_I": null,
@@ -16807,7 +16807,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 1.7,
-        "Mutation": 88,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.07.2021",
+        "Fallzahl": 30692,
+        "ObjectId": 488,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29549,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2641,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 5,
+        "BelegteBetten": null,
+        "Inzidenz": 3.05327059161608,
+        "Datum_neu": 1625616000000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "30.06.2021 - 06.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 2.7,
+        "Fallzahl_aktiv": 39,
+        "Krh_N_belegt": 130,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 1.5,
+        "Mutation": 87,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
