### PR TITLE
New data set: 2021-07-08T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-07T101203Z.json
+pjson/2021-07-08T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-07T101203Z.json pjson/2021-07-08T100203Z.json```:
```
--- pjson/2021-07-07T101203Z.json	2021-07-07 10:12:03.939904292 +0000
+++ pjson/2021-07-08T100203Z.json	2021-07-08 10:02:03.802005756 +0000
@@ -16587,12 +16587,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 7.4,
+        "Inzidenz": null,
         "Datum_neu": 1625011200000,
         "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 6.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16602,7 +16602,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16623,7 +16623,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.5,
         "Datum_neu": 1625097600000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7,
@@ -16782,26 +16782,26 @@
         "Datum": "06.07.2021",
         "Fallzahl": 30684,
         "ObjectId": 487,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29544,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2641,
-        "Zuwachs_Fallzahl": 5,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
         "Inzidenz": 3.05327059161608,
         "Datum_neu": 1625529600000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.1,
-        "Fallzahl_aktiv": 36,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -5,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -16818,22 +16818,22 @@
         "ObjectId": 488,
         "Sterbefall": 1104,
         "Genesungsfall": 29549,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2641,
         "Zuwachs_Fallzahl": 8,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
-        "Inzidenz": 3.05327059161608,
+        "Inzidenz": 3.1,
         "Datum_neu": 1625616000000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "30.06.2021 - 06.07.2021",
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 2.7,
         "Fallzahl_aktiv": 39,
-        "Krh_N_belegt": 130,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 3,
         "Krh_I": null,
@@ -16841,6 +16841,40 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 1.5,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.07.2021",
+        "Fallzahl": 30698,
+        "ObjectId": 489,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29558,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2641,
+        "Zuwachs_Fallzahl": 6,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 9,
+        "BelegteBetten": null,
+        "Inzidenz": 4.13089550630411,
+        "Datum_neu": 1625702400000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "01.07.2021 - 07.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 3.4,
+        "Fallzahl_aktiv": 36,
+        "Krh_N_belegt": 119,
+        "Krh_I_belegt": 39,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 1.8,
         "Mutation": 87,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
