### PR TITLE
New data set: 2021-07-09T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-08T100203Z.json
+pjson/2021-07-09T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-08T100203Z.json pjson/2021-07-09T100203Z.json```:
```
--- pjson/2021-07-08T100203Z.json	2021-07-08 10:02:03.802005756 +0000
+++ pjson/2021-07-09T100203Z.json	2021-07-09 10:02:03.812249460 +0000
@@ -16621,12 +16621,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 7.5,
+        "Inzidenz": null,
         "Datum_neu": 1625097600000,
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16636,7 +16636,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16816,13 +16816,13 @@
         "Datum": "07.07.2021",
         "Fallzahl": 30692,
         "ObjectId": 488,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29549,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2641,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
         "Inzidenz": 3.1,
@@ -16831,13 +16831,13 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 2.7,
-        "Fallzahl_aktiv": 39,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 1.5,
@@ -16852,7 +16852,7 @@
         "ObjectId": 489,
         "Sterbefall": 1104,
         "Genesungsfall": 29558,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2641,
         "Zuwachs_Fallzahl": 6,
         "Zuwachs_Sterbefall": 0,
@@ -16862,12 +16862,12 @@
         "Inzidenz": 4.13089550630411,
         "Datum_neu": 1625702400000,
         "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "01.07.2021 - 07.07.2021",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.4,
         "Fallzahl_aktiv": 36,
-        "Krh_N_belegt": 119,
-        "Krh_I_belegt": 39,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -3,
         "Krh_I": null,
@@ -16875,7 +16875,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 1.8,
-        "Mutation": 87,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.07.2021",
+        "Fallzahl": 30699,
+        "ObjectId": 490,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29571,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2641,
+        "Zuwachs_Fallzahl": 1,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 13,
+        "BelegteBetten": null,
+        "Inzidenz": 3.41247889651209,
+        "Datum_neu": 1625788800000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "02.07.2021 - 08.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 3.1,
+        "Fallzahl_aktiv": 24,
+        "Krh_N_belegt": 122,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 1.8,
+        "Mutation": 94,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
