### PR TITLE
New data set: 2021-07-10T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-09T100203Z.json
+pjson/2021-07-10T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-09T100203Z.json pjson/2021-07-10T100103Z.json```:
```
--- pjson/2021-07-09T100203Z.json	2021-07-09 10:02:03.812249460 +0000
+++ pjson/2021-07-10T100103Z.json	2021-07-10 10:01:03.381983546 +0000
@@ -16351,7 +16351,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624406400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -16655,12 +16655,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 11,
         "BelegteBetten": null,
-        "Inzidenz": 6.8,
+        "Inzidenz": null,
         "Datum_neu": 1625184000000,
         "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 6.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16670,7 +16670,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16793,7 +16793,7 @@
         "BelegteBetten": null,
         "Inzidenz": 3.05327059161608,
         "Datum_neu": 1625529600000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.1,
@@ -16850,13 +16850,13 @@
         "Datum": "08.07.2021",
         "Fallzahl": 30698,
         "ObjectId": 489,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29558,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2641,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": 4.13089550630411,
@@ -16865,11 +16865,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.4,
-        "Fallzahl_aktiv": 36,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -16886,7 +16886,7 @@
         "ObjectId": 490,
         "Sterbefall": 1104,
         "Genesungsfall": 29571,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2641,
         "Zuwachs_Fallzahl": 1,
         "Zuwachs_Sterbefall": 0,
@@ -16895,13 +16895,13 @@
         "BelegteBetten": null,
         "Inzidenz": 3.41247889651209,
         "Datum_neu": 1625788800000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "02.07.2021 - 08.07.2021",
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.1,
         "Fallzahl_aktiv": 24,
-        "Krh_N_belegt": 122,
-        "Krh_I_belegt": 36,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -12,
         "Krh_I": null,
@@ -16909,7 +16909,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 1.8,
-        "Mutation": 94,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.07.2021",
+        "Fallzahl": 30710,
+        "ObjectId": 491,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29575,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2641,
+        "Zuwachs_Fallzahl": 11,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 4,
+        "BelegteBetten": null,
+        "Inzidenz": 3.9512913538561,
+        "Datum_neu": 1625875200000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "03.07.2021 - 09.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 3.6,
+        "Fallzahl_aktiv": 31,
+        "Krh_N_belegt": 125,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 7,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 1.9,
+        "Mutation": 97,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
