### PR TITLE
New data set: 2021-07-12T100003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-11T100203Z.json
+pjson/2021-07-12T100003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-11T100203Z.json pjson/2021-07-12T100003Z.json```:
```
--- pjson/2021-07-11T100203Z.json	2021-07-11 10:02:03.682002246 +0000
+++ pjson/2021-07-12T100003Z.json	2021-07-12 10:00:03.763497358 +0000
@@ -15095,7 +15095,7 @@
         "Datum_neu": 1621209600000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15129,7 +15129,7 @@
         "Datum_neu": 1621296000000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15163,7 +15163,7 @@
         "Datum_neu": 1621382400000,
         "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15197,7 +15197,7 @@
         "Datum_neu": 1621468800000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15265,7 +15265,7 @@
         "Datum_neu": 1621641600000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15367,7 +15367,7 @@
         "Datum_neu": 1621900800000,
         "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15809,7 +15809,7 @@
         "Datum_neu": 1623024000000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15877,7 +15877,7 @@
         "Datum_neu": 1623196800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15945,7 +15945,7 @@
         "Datum_neu": 1623369600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16285,7 +16285,7 @@
         "Datum_neu": 1624233600000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16723,12 +16723,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 4.7,
+        "Inzidenz": null,
         "Datum_neu": 1625356800000,
         "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 4.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16793,7 +16793,7 @@
         "BelegteBetten": null,
         "Inzidenz": 3.05327059161608,
         "Datum_neu": 1625529600000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.1,
@@ -16918,28 +16918,28 @@
         "Datum": "10.07.2021",
         "Fallzahl": 30710,
         "ObjectId": 491,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29575,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2641,
-        "Zuwachs_Fallzahl": 11,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
         "Inzidenz": 3.9512913538561,
         "Datum_neu": 1625875200000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.6,
-        "Fallzahl_aktiv": 31,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 7,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 1.9,
@@ -16953,21 +16953,21 @@
         "Fallzahl": 30711,
         "ObjectId": 492,
         "Sterbefall": 1104,
-        "Genesungsfall": 29579,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 29559,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2641,
         "Zuwachs_Fallzahl": 1,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 5.20852042099213,
+        "Inzidenz": 5.2,
         "Datum_neu": 1625961600000,
         "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "04.07.2021 - 10.07.2021",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5,
-        "Fallzahl_aktiv": 28,
+        "Fallzahl_aktiv": 48,
         "Krh_N_belegt": 125,
         "Krh_I_belegt": 36,
         "Krh_I_frei": null,
@@ -16980,6 +16980,40 @@
         "Mutation": 97,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.07.2021",
+        "Fallzahl": 30713,
+        "ObjectId": 493,
+        "Sterbefall": 1104,
+        "Genesungsfall": 29566,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2641,
+        "Zuwachs_Fallzahl": 2,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 7,
+        "BelegteBetten": null,
+        "Inzidenz": 5.02891626854413,
+        "Datum_neu": 1626048000000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "05.07.2021 - 11.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 5,
+        "Fallzahl_aktiv": 43,
+        "Krh_N_belegt": 125,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -5,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.2,
+        "Mutation": 97,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
