### PR TITLE
New data set: 2021-07-14T101603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-13T095703Z.json
+pjson/2021-07-14T101603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-13T095703Z.json pjson/2021-07-14T101603Z.json```:
```
--- pjson/2021-07-13T095703Z.json	2021-07-13 09:57:03.315544025 +0000
+++ pjson/2021-07-14T101603Z.json	2021-07-14 10:16:03.561421686 +0000
@@ -15921,7 +15921,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -16555,7 +16555,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624924800000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -16623,7 +16623,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625097600000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -16738,7 +16738,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16757,12 +16757,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 4.66970796364812,
+        "Inzidenz": null,
         "Datum_neu": 1625443200000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 4.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16772,7 +16772,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16791,9 +16791,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 3.05327059161608,
+        "Inzidenz": 3.1,
         "Datum_neu": 1625529600000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.1,
@@ -16859,9 +16859,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
-        "Inzidenz": 4.13089550630411,
+        "Inzidenz": 4.1,
         "Datum_neu": 1625702400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 3.4,
@@ -16893,7 +16893,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
-        "Inzidenz": 3.41247889651209,
+        "Inzidenz": 3.4,
         "Datum_neu": 1625788800000,
         "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
@@ -16927,7 +16927,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 3.9512913538561,
+        "Inzidenz": 4,
         "Datum_neu": 1625875200000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
@@ -16977,7 +16977,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.1,
-        "Mutation": 97,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -16986,32 +16986,32 @@
         "Datum": "12.07.2021",
         "Fallzahl": 30713,
         "ObjectId": 493,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29566,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2641,
-        "Zuwachs_Fallzahl": 2,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 5.02891626854413,
+        "Inzidenz": 5,
         "Datum_neu": 1626048000000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5,
-        "Fallzahl_aktiv": 43,
-        "Krh_N_belegt": 125,
-        "Krh_I_belegt": 36,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -5,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.2,
-        "Mutation": 97,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17020,32 +17020,66 @@
         "Datum": "13.07.2021",
         "Fallzahl": 30727,
         "ObjectId": 494,
-        "Sterbefall": 1104,
-        "Genesungsfall": 29573,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2641,
-        "Zuwachs_Fallzahl": 14,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
-        "Inzidenz": 6.10654118323216,
+        "Inzidenz": 6.1,
         "Datum_neu": 1626134400000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "06.07.2021 - 12.07.2021",
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5.2,
-        "Fallzahl_aktiv": 50,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.2,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.07.2021",
+        "Fallzahl": 30739,
+        "ObjectId": 495,
+        "Sterbefall": 1105,
+        "Genesungsfall": 29598,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2641,
+        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 2,
+        "BelegteBetten": null,
+        "Inzidenz": 7.9,
+        "Datum_neu": 1626220800000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "07.07.2021 - 13.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 5.9,
+        "Fallzahl_aktiv": 36,
         "Krh_N_belegt": 122,
-        "Krh_I_belegt": 35,
+        "Krh_I_belegt": 34,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 7,
+        "Fallzahl_aktiv_Zuwachs": 9,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.2,
-        "Mutation": 102,
+        "Inzi_SN_RKI": 2.7,
+        "Mutation": 104,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
