### PR TITLE
New data set: 2021-07-15T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-14T101603Z.json
+pjson/2021-07-15T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-14T101603Z.json pjson/2021-07-15T100503Z.json```:
```
--- pjson/2021-07-14T101603Z.json	2021-07-14 10:16:03.561421686 +0000
+++ pjson/2021-07-15T100503Z.json	2021-07-15 10:05:03.395841462 +0000
@@ -16791,12 +16791,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 3.1,
+        "Inzidenz": null,
         "Datum_neu": 1625529600000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 3.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16806,7 +16806,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 1.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -16825,12 +16825,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
-        "Inzidenz": 3.1,
+        "Inzidenz": null,
         "Datum_neu": 1625616000000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 2.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16840,7 +16840,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 1.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17031,7 +17031,7 @@
         "BelegteBetten": null,
         "Inzidenz": 6.1,
         "Datum_neu": 1626134400000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5.2,
@@ -17056,7 +17056,7 @@
         "ObjectId": 495,
         "Sterbefall": 1105,
         "Genesungsfall": 29598,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2641,
         "Zuwachs_Fallzahl": 12,
         "Zuwachs_Sterbefall": 1,
@@ -17065,13 +17065,13 @@
         "BelegteBetten": null,
         "Inzidenz": 7.9,
         "Datum_neu": 1626220800000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "07.07.2021 - 13.07.2021",
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5.9,
         "Fallzahl_aktiv": 36,
-        "Krh_N_belegt": 122,
-        "Krh_I_belegt": 34,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 9,
         "Krh_I": null,
@@ -17079,7 +17079,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.7,
-        "Mutation": 104,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.07.2021",
+        "Fallzahl": 30744,
+        "ObjectId": 496,
+        "Sterbefall": 1105,
+        "Genesungsfall": 29603,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2643,
+        "Zuwachs_Fallzahl": 5,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 5,
+        "BelegteBetten": null,
+        "Inzidenz": 7.54337440281619,
+        "Datum_neu": 1626307200000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "08.07.2021 - 14.07.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 7.2,
+        "Fallzahl_aktiv": 36,
+        "Krh_N_belegt": 127,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 0,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.9,
+        "Mutation": 108,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
