### PR TITLE
New data set: 2021-07-16T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-15T100503Z.json
+pjson/2021-07-16T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-15T100503Z.json pjson/2021-07-16T100903Z.json```:
```
--- pjson/2021-07-15T100503Z.json	2021-07-15 10:05:03.395841462 +0000
+++ pjson/2021-07-16T100903Z.json	2021-07-16 10:09:03.924247553 +0000
@@ -16771,7 +16771,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -16859,12 +16859,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
-        "Inzidenz": 4.1,
+        "Inzidenz": null,
         "Datum_neu": 1625702400000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 3.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16874,7 +16874,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 1.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17054,28 +17054,28 @@
         "Datum": "14.07.2021",
         "Fallzahl": 30739,
         "ObjectId": 495,
-        "Sterbefall": 1105,
-        "Genesungsfall": 29598,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2641,
-        "Zuwachs_Fallzahl": 12,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
         "Inzidenz": 7.9,
         "Datum_neu": 1626220800000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 5.9,
-        "Fallzahl_aktiv": 36,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 9,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.7,
@@ -17090,7 +17090,7 @@
         "ObjectId": 496,
         "Sterbefall": 1105,
         "Genesungsfall": 29603,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2643,
         "Zuwachs_Fallzahl": 5,
         "Zuwachs_Sterbefall": 0,
@@ -17099,13 +17099,13 @@
         "BelegteBetten": null,
         "Inzidenz": 7.54337440281619,
         "Datum_neu": 1626307200000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "08.07.2021 - 14.07.2021",
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 7.2,
         "Fallzahl_aktiv": 36,
-        "Krh_N_belegt": 127,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 0,
         "Krh_I": null,
@@ -17113,7 +17113,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 2.9,
-        "Mutation": 108,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.07.2021",
+        "Fallzahl": 30756,
+        "ObjectId": 497,
+        "Sterbefall": 1106,
+        "Genesungsfall": 29603,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2643,
+        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 0,
+        "BelegteBetten": null,
+        "Inzidenz": 8.08218686016021,
+        "Datum_neu": 1626393600000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "09.07.2021 - 15.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 7.7,
+        "Fallzahl_aktiv": 47,
+        "Krh_N_belegt": 121,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.9,
+        "Mutation": 114,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
