### PR TITLE
New data set: 2021-07-17T100504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-16T100903Z.json
+pjson/2021-07-17T100504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-16T100903Z.json pjson/2021-07-17T100504Z.json```:
```
--- pjson/2021-07-16T100903Z.json	2021-07-16 10:09:03.924247553 +0000
+++ pjson/2021-07-17T100504Z.json	2021-07-17 10:05:04.933348278 +0000
@@ -16861,7 +16861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625702400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -16893,12 +16893,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
-        "Inzidenz": 3.4,
+        "Inzidenz": null,
         "Datum_neu": 1625788800000,
         "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 3.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16908,7 +16908,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 1.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17088,26 +17088,26 @@
         "Datum": "15.07.2021",
         "Fallzahl": 30744,
         "ObjectId": 496,
-        "Sterbefall": 1105,
-        "Genesungsfall": 29603,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2643,
-        "Zuwachs_Fallzahl": 5,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
         "Inzidenz": 7.54337440281619,
         "Datum_neu": 1626307200000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 7.2,
-        "Fallzahl_aktiv": 36,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 0,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -17122,32 +17122,66 @@
         "Datum": "16.07.2021",
         "Fallzahl": 30756,
         "ObjectId": 497,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
+        "BelegteBetten": null,
+        "Inzidenz": 8.1,
+        "Datum_neu": 1626393600000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 7.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.9,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.07.2021",
+        "Fallzahl": 30764,
+        "ObjectId": 498,
         "Sterbefall": 1106,
-        "Genesungsfall": 29603,
+        "Genesungsfall": 29604,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2643,
-        "Zuwachs_Fallzahl": 12,
-        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 0,
+        "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 8.08218686016021,
-        "Datum_neu": 1626393600000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "09.07.2021 - 15.07.2021",
+        "Inzidenz": 10.1,
+        "Datum_neu": 1626480000000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "10.07.2021 - 16.07.2021",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 7.7,
-        "Fallzahl_aktiv": 47,
+        "Inzidenz_RKI": 8.8,
+        "Fallzahl_aktiv": 54,
         "Krh_N_belegt": 121,
-        "Krh_I_belegt": 32,
+        "Krh_I_belegt": 30,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 11,
+        "Fallzahl_aktiv_Zuwachs": 7,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.9,
-        "Mutation": 114,
+        "Inzi_SN_RKI": 3.3,
+        "Mutation": 126,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
