### PR TITLE
New data set: 2021-07-18T101104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-17T100504Z.json
+pjson/2021-07-18T101104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-17T100504Z.json pjson/2021-07-18T101104Z.json```:
```
--- pjson/2021-07-17T100504Z.json	2021-07-17 10:05:04.933348278 +0000
+++ pjson/2021-07-18T101104Z.json	2021-07-18 10:11:04.242336202 +0000
@@ -16927,12 +16927,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 4,
+        "Inzidenz": null,
         "Datum_neu": 1625875200000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 3.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -16942,7 +16942,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 1.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17099,7 +17099,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.54337440281619,
         "Datum_neu": 1626307200000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 7.2,
@@ -17133,7 +17133,7 @@
         "BelegteBetten": null,
         "Inzidenz": 8.1,
         "Datum_neu": 1626393600000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.7,
@@ -17156,32 +17156,66 @@
         "Datum": "17.07.2021",
         "Fallzahl": 30764,
         "ObjectId": 498,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 10.1,
+        "Datum_neu": 1626480000000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 8.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 3.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.07.2021",
+        "Fallzahl": 30773,
+        "ObjectId": 499,
         "Sterbefall": 1106,
         "Genesungsfall": 29604,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2643,
-        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Fallzahl": 9,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 1,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": 10.1,
-        "Datum_neu": 1626480000000,
-        "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "10.07.2021 - 16.07.2021",
+        "Datum_neu": 1626566400000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "11.07.2021 - 17.07.2021",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 8.8,
-        "Fallzahl_aktiv": 54,
+        "Inzidenz_RKI": 8.1,
+        "Fallzahl_aktiv": 63,
         "Krh_N_belegt": 121,
         "Krh_I_belegt": 30,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 7,
+        "Fallzahl_aktiv_Zuwachs": 9,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.3,
-        "Mutation": 126,
+        "Inzi_SN_RKI": 3.5,
+        "Mutation": 128,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
