### PR TITLE
New data set: 2021-07-22T100304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-21T100104Z.json
+pjson/2021-07-22T100304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-21T100104Z.json pjson/2021-07-22T100304Z.json```:
```
--- pjson/2021-07-21T100104Z.json	2021-07-21 10:01:04.799707262 +0000
+++ pjson/2021-07-22T100304Z.json	2021-07-22 10:03:04.229732349 +0000
@@ -17000,7 +17000,7 @@
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17010,7 +17010,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17029,12 +17029,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
-        "Inzidenz": 6.1,
+        "Inzidenz": null,
         "Datum_neu": 1626134400000,
         "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 5.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17044,7 +17044,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17063,12 +17063,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
-        "Inzidenz": 7.9,
+        "Inzidenz": null,
         "Datum_neu": 1626220800000,
         "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 5.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17078,7 +17078,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17097,7 +17097,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
-        "Inzidenz": 7.54337440281619,
+        "Inzidenz": 7.5,
         "Datum_neu": 1626307200000,
         "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
@@ -17190,28 +17190,28 @@
         "Datum": "18.07.2021",
         "Fallzahl": 30773,
         "ObjectId": 499,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29604,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2643,
-        "Zuwachs_Fallzahl": 9,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 10.0578325370883,
+        "Inzidenz": 10.1,
         "Datum_neu": 1626566400000,
         "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 8.1,
-        "Fallzahl_aktiv": 63,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 9,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 3.5,
@@ -17224,32 +17224,32 @@
         "Datum": "19.07.2021",
         "Fallzahl": 30779,
         "ObjectId": 500,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29607,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2646,
-        "Zuwachs_Fallzahl": 6,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 10.7762491468803,
+        "Inzidenz": 10.8,
         "Datum_neu": 1626652800000,
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 10.2,
-        "Fallzahl_aktiv": 66,
-        "Krh_N_belegt": 121,
-        "Krh_I_belegt": 30,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 3.9,
-        "Mutation": 129,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17258,32 +17258,32 @@
         "Datum": "20.07.2021",
         "Fallzahl": 30782,
         "ObjectId": 501,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29610,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2646,
-        "Zuwachs_Fallzahl": 3,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 10.4170408419843,
+        "Inzidenz": 10.4,
         "Datum_neu": 1626739200000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.2,
-        "Fallzahl_aktiv": 66,
-        "Krh_N_belegt": 127,
-        "Krh_I_belegt": 30,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 0,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 3.5,
-        "Mutation": 134,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17292,32 +17292,66 @@
         "Datum": "21.07.2021",
         "Fallzahl": 30794,
         "ObjectId": 502,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 2,
+        "BelegteBetten": null,
+        "Inzidenz": 9.2,
+        "Datum_neu": 1626825600000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 7.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 2.9,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.07.2021",
+        "Fallzahl": 30802,
+        "ObjectId": 503,
         "Sterbefall": 1106,
-        "Genesungsfall": 29612,
+        "Genesungsfall": 29614,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2647,
-        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Fallzahl": 8,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
-        "Inzidenz": 9.15981177484824,
-        "Datum_neu": 1626825600000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "14.07.2021 - 20.07.2021",
-        "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 7.2,
-        "Fallzahl_aktiv": 76,
+        "Inzidenz": 10.2,
+        "Datum_neu": 1626912000000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "15.07.2021 - 21.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 9.7,
+        "Fallzahl_aktiv": 82,
         "Krh_N_belegt": 125,
         "Krh_I_belegt": 30,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 10,
+        "Fallzahl_aktiv_Zuwachs": 6,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.9,
-        "Mutation": 139,
+        "Inzi_SN_RKI": 3.4,
+        "Mutation": 148,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
