### PR TITLE
New data set: 2021-07-23T100304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-22T100304Z.json
+pjson/2021-07-23T100304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-22T100304Z.json pjson/2021-07-23T100304Z.json```:
```
--- pjson/2021-07-22T100304Z.json	2021-07-22 10:03:04.229732349 +0000
+++ pjson/2021-07-23T100304Z.json	2021-07-23 10:03:04.387689444 +0000
@@ -17097,12 +17097,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
-        "Inzidenz": 7.5,
+        "Inzidenz": null,
         "Datum_neu": 1626307200000,
         "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 7.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17112,7 +17112,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17235,7 +17235,7 @@
         "BelegteBetten": null,
         "Inzidenz": 10.8,
         "Datum_neu": 1626652800000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 10.2,
@@ -17269,7 +17269,7 @@
         "BelegteBetten": null,
         "Inzidenz": 10.4,
         "Datum_neu": 1626739200000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.2,
@@ -17326,32 +17326,66 @@
         "Datum": "22.07.2021",
         "Fallzahl": 30802,
         "ObjectId": 503,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 2,
+        "BelegteBetten": null,
+        "Inzidenz": 10.2,
+        "Datum_neu": 1626912000000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 9.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 3.4,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.07.2021",
+        "Fallzahl": 30819,
+        "ObjectId": 504,
         "Sterbefall": 1106,
-        "Genesungsfall": 29614,
+        "Genesungsfall": 29615,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2647,
-        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Fallzahl": 17,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 2,
+        "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 10.2,
-        "Datum_neu": 1626912000000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "15.07.2021 - 21.07.2021",
+        "Inzidenz": 10.8,
+        "Datum_neu": 1626998400000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "16.07.2021 - 22.07.2021",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 9.7,
-        "Fallzahl_aktiv": 82,
-        "Krh_N_belegt": 125,
-        "Krh_I_belegt": 30,
+        "Inzidenz_RKI": 10.2,
+        "Fallzahl_aktiv": 98,
+        "Krh_N_belegt": 105,
+        "Krh_I_belegt": 26,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 6,
+        "Fallzahl_aktiv_Zuwachs": 16,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.4,
-        "Mutation": 148,
+        "Inzi_SN_RKI": 3.8,
+        "Mutation": 151,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
