### PR TITLE
New data set: 2021-07-25T094504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-23T100304Z.json
+pjson/2021-07-25T094504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-23T100304Z.json pjson/2021-07-25T094504Z.json```:
```
--- pjson/2021-07-23T100304Z.json	2021-07-23 10:03:04.387689444 +0000
+++ pjson/2021-07-25T094504Z.json	2021-07-25 09:45:04.181258066 +0000
@@ -16861,7 +16861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625702400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -17031,7 +17031,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626134400000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 21,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -17131,12 +17131,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 8.1,
+        "Inzidenz": null,
         "Datum_neu": 1626393600000,
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 7.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17146,7 +17146,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17337,7 +17337,7 @@
         "BelegteBetten": null,
         "Inzidenz": 10.2,
         "Datum_neu": 1626912000000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.7,
@@ -17362,22 +17362,22 @@
         "ObjectId": 504,
         "Sterbefall": 1106,
         "Genesungsfall": 29615,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2647,
         "Zuwachs_Fallzahl": 17,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 10.8,
+        "Inzidenz": 10.7762491468803,
         "Datum_neu": 1626998400000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "16.07.2021 - 22.07.2021",
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.2,
         "Fallzahl_aktiv": 98,
-        "Krh_N_belegt": 105,
-        "Krh_I_belegt": 26,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 16,
         "Krh_I": null,
@@ -17385,7 +17385,75 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 3.8,
-        "Mutation": 151,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.07.2021",
+        "Fallzahl": 30837,
+        "ObjectId": 505,
+        "Sterbefall": 1106,
+        "Genesungsfall": 29618,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 2647,
+        "Zuwachs_Fallzahl": 18,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 3,
+        "BelegteBetten": null,
+        "Inzidenz": 12.2130823664643,
+        "Datum_neu": 1627084800000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 8.1,
+        "Fallzahl_aktiv": 113,
+        "Krh_N_belegt": 104,
+        "Krh_I_belegt": 26,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 15,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 4.1,
+        "Mutation": 172,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.07.2021",
+        "Fallzahl": 30841,
+        "ObjectId": 506,
+        "Sterbefall": 1106,
+        "Genesungsfall": 29618,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2647,
+        "Zuwachs_Fallzahl": 4,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 0,
+        "BelegteBetten": null,
+        "Inzidenz": 11.6742699091203,
+        "Datum_neu": 1627171200000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "18.07.2021 - 24.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 11.1,
+        "Fallzahl_aktiv": 117,
+        "Krh_N_belegt": 104,
+        "Krh_I_belegt": 26,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 4.8,
+        "Mutation": 172,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
