### PR TITLE
New data set: 2021-07-27T100404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-26T110703Z.json
+pjson/2021-07-27T100404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-26T110703Z.json pjson/2021-07-27T100404Z.json```:
```
--- pjson/2021-07-26T110703Z.json	2021-07-26 11:07:03.354396078 +0000
+++ pjson/2021-07-27T100404Z.json	2021-07-27 10:04:04.654257173 +0000
@@ -17165,12 +17165,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 10.1,
+        "Inzidenz": null,
         "Datum_neu": 1626480000000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 8.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17180,7 +17180,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17199,12 +17199,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 10.1,
+        "Inzidenz": null,
         "Datum_neu": 1626566400000,
         "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 8.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17214,7 +17214,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17233,12 +17233,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 10.8,
+        "Inzidenz": null,
         "Datum_neu": 1626652800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 10.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17248,7 +17248,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17303,7 +17303,7 @@
         "BelegteBetten": null,
         "Inzidenz": 9.2,
         "Datum_neu": 1626825600000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 7.2,
@@ -17360,28 +17360,28 @@
         "Datum": "23.07.2021",
         "Fallzahl": 30819,
         "ObjectId": 504,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29615,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2647,
-        "Zuwachs_Fallzahl": 17,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
         "Inzidenz": 10.7762491468803,
         "Datum_neu": 1626998400000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.2,
-        "Fallzahl_aktiv": 98,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 16,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 3.8,
@@ -17394,32 +17394,32 @@
         "Datum": "24.07.2021",
         "Fallzahl": 30837,
         "ObjectId": 505,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29618,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2647,
-        "Zuwachs_Fallzahl": 18,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
         "Inzidenz": 12.2130823664643,
         "Datum_neu": 1627084800000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 8.1,
-        "Fallzahl_aktiv": 113,
-        "Krh_N_belegt": 104,
-        "Krh_I_belegt": 26,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 15,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 4.1,
-        "Mutation": 172,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17428,32 +17428,32 @@
         "Datum": "25.07.2021",
         "Fallzahl": 30841,
         "ObjectId": 506,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29618,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2647,
-        "Zuwachs_Fallzahl": 4,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": 11.6742699091203,
         "Datum_neu": 1627171200000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 11.1,
-        "Fallzahl_aktiv": 117,
-        "Krh_N_belegt": 104,
-        "Krh_I_belegt": 26,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 4,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 4.8,
-        "Mutation": 172,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17464,7 +17464,7 @@
         "ObjectId": 507,
         "Sterbefall": 1106,
         "Genesungsfall": 29619,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2647,
         "Zuwachs_Fallzahl": 0,
         "Zuwachs_Sterbefall": 0,
@@ -17473,13 +17473,13 @@
         "BelegteBetten": null,
         "Inzidenz": 11.4946657566723,
         "Datum_neu": 1627257600000,
-        "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "19.07.2021 - 25.07.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 10.8,
         "Fallzahl_aktiv": 116,
-        "Krh_N_belegt": 104,
-        "Krh_I_belegt": 26,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -1,
         "Krh_I": null,
@@ -17487,7 +17487,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 4.7,
-        "Mutation": 177,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.07.2021",
+        "Fallzahl": 30855,
+        "ObjectId": 508,
+        "Sterbefall": 1106,
+        "Genesungsfall": 29630,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2648,
+        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 11,
+        "BelegteBetten": null,
+        "Inzidenz": 11.4946657566723,
+        "Datum_neu": 1627344000000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "20.07.2021 - 26.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 10.8,
+        "Fallzahl_aktiv": 119,
+        "Krh_N_belegt": 105,
+        "Krh_I_belegt": 22,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 4.8,
+        "Mutation": 178,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
