### PR TITLE
New data set: 2021-07-28T104804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-27T100404Z.json
+pjson/2021-07-28T104804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-27T100404Z.json pjson/2021-07-28T104804Z.json```:
```
--- pjson/2021-07-27T100404Z.json	2021-07-27 10:04:04.654257173 +0000
+++ pjson/2021-07-28T104804Z.json	2021-07-28 10:48:04.327653501 +0000
@@ -16295,7 +16295,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -17405,7 +17405,7 @@
         "BelegteBetten": null,
         "Inzidenz": 12.2130823664643,
         "Datum_neu": 1627084800000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 8.1,
@@ -17462,26 +17462,26 @@
         "Datum": "26.07.2021",
         "Fallzahl": 30841,
         "ObjectId": 507,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29619,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2647,
-        "Zuwachs_Fallzahl": 0,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
         "Inzidenz": 11.4946657566723,
         "Datum_neu": 1627257600000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 10.8,
-        "Fallzahl_aktiv": 116,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -17498,7 +17498,7 @@
         "ObjectId": 508,
         "Sterbefall": 1106,
         "Genesungsfall": 29630,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2648,
         "Zuwachs_Fallzahl": 14,
         "Zuwachs_Sterbefall": 0,
@@ -17507,13 +17507,13 @@
         "BelegteBetten": null,
         "Inzidenz": 11.4946657566723,
         "Datum_neu": 1627344000000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "20.07.2021 - 26.07.2021",
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.8,
         "Fallzahl_aktiv": 119,
-        "Krh_N_belegt": 105,
-        "Krh_I_belegt": 22,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 3,
         "Krh_I": null,
@@ -17524,6 +17524,40 @@
         "Mutation": 178,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.07.2021",
+        "Fallzahl": 30869,
+        "ObjectId": 509,
+        "Sterbefall": 1107,
+        "Genesungsfall": 29633,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2649,
+        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 3,
+        "BelegteBetten": null,
+        "Inzidenz": 12.5722906713603,
+        "Datum_neu": 1627430400000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "21.07.2021 - 27.07.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 11,
+        "Fallzahl_aktiv": 129,
+        "Krh_N_belegt": 105,
+        "Krh_I_belegt": 22,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 10,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 5.5,
+        "Mutation": 185,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
