### PR TITLE
New data set: 2021-07-29T102203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-28T104804Z.json
+pjson/2021-07-29T102203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-28T104804Z.json pjson/2021-07-29T102203Z.json```:
```
--- pjson/2021-07-28T104804Z.json	2021-07-28 10:48:04.327653501 +0000
+++ pjson/2021-07-29T102203Z.json	2021-07-29 10:22:03.920027609 +0000
@@ -17267,12 +17267,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 10.4,
+        "Inzidenz": null,
         "Datum_neu": 1626739200000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 10.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17282,7 +17282,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17301,12 +17301,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
-        "Inzidenz": 9.2,
+        "Inzidenz": null,
         "Datum_neu": 1626825600000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 7.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17316,7 +17316,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 2.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17496,32 +17496,32 @@
         "Datum": "27.07.2021",
         "Fallzahl": 30855,
         "ObjectId": 508,
-        "Sterbefall": 1106,
-        "Genesungsfall": 29630,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2648,
-        "Zuwachs_Fallzahl": 14,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 11,
         "BelegteBetten": null,
         "Inzidenz": 11.4946657566723,
         "Datum_neu": 1627344000000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 10.8,
-        "Fallzahl_aktiv": 119,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 4.8,
-        "Mutation": 178,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17532,7 +17532,7 @@
         "ObjectId": 509,
         "Sterbefall": 1107,
         "Genesungsfall": 29633,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2649,
         "Zuwachs_Fallzahl": 14,
         "Zuwachs_Sterbefall": 1,
@@ -17541,13 +17541,13 @@
         "BelegteBetten": null,
         "Inzidenz": 12.5722906713603,
         "Datum_neu": 1627430400000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "21.07.2021 - 27.07.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 11,
         "Fallzahl_aktiv": 129,
-        "Krh_N_belegt": 105,
-        "Krh_I_belegt": 22,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 10,
         "Krh_I": null,
@@ -17555,7 +17555,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 5.5,
-        "Mutation": 185,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.07.2021",
+        "Fallzahl": 30878,
+        "ObjectId": 510,
+        "Sterbefall": 1107,
+        "Genesungsfall": 29637,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2650,
+        "Zuwachs_Fallzahl": 9,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 4,
+        "BelegteBetten": null,
+        "Inzidenz": 12.7518948238083,
+        "Datum_neu": 1627516800000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "22.07.2021 - 28.07.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 12.4,
+        "Fallzahl_aktiv": 134,
+        "Krh_N_belegt": 91,
+        "Krh_I_belegt": 22,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 5,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.5,
+        "Mutation": 193,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
