### PR TITLE
New data set: 2021-07-30T102603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-29T102203Z.json
+pjson/2021-07-30T102603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-29T102203Z.json pjson/2021-07-30T102603Z.json```:
```
--- pjson/2021-07-29T102203Z.json	2021-07-29 10:22:03.920027609 +0000
+++ pjson/2021-07-30T102603Z.json	2021-07-30 10:26:03.605341135 +0000
@@ -4587,7 +4587,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1594512000000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 0,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -8021,7 +8021,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603238400000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -8191,7 +8191,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603670400000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -9721,7 +9721,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 464,
+        "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -9993,7 +9993,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 456,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -10401,7 +10401,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -10707,7 +10707,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -10843,7 +10843,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610409600000,
-        "F\u00e4lle_Meldedatum": 272,
+        "F\u00e4lle_Meldedatum": 269,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -11183,7 +11183,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -11319,7 +11319,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611619200000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -12237,7 +12237,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -16091,7 +16091,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -16827,7 +16827,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625616000000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 7,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -16861,7 +16861,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625702400000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -17031,7 +17031,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626134400000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -17133,7 +17133,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626393600000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -17335,12 +17335,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
-        "Inzidenz": 10.2,
+        "Inzidenz": null,
         "Datum_neu": 1626912000000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 9.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17350,7 +17350,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17509,7 +17509,7 @@
         "Datum_neu": 1627344000000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 10.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -17530,28 +17530,28 @@
         "Datum": "28.07.2021",
         "Fallzahl": 30869,
         "ObjectId": 509,
-        "Sterbefall": 1107,
-        "Genesungsfall": 29633,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2649,
-        "Zuwachs_Fallzahl": 14,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
         "Inzidenz": 12.5722906713603,
         "Datum_neu": 1627430400000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 11,
-        "Fallzahl_aktiv": 129,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 10,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 5.5,
@@ -17566,7 +17566,7 @@
         "ObjectId": 510,
         "Sterbefall": 1107,
         "Genesungsfall": 29637,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2650,
         "Zuwachs_Fallzahl": 9,
         "Zuwachs_Sterbefall": 0,
@@ -17575,13 +17575,13 @@
         "BelegteBetten": null,
         "Inzidenz": 12.7518948238083,
         "Datum_neu": 1627516800000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "22.07.2021 - 28.07.2021",
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 12.4,
         "Fallzahl_aktiv": 134,
-        "Krh_N_belegt": 91,
-        "Krh_I_belegt": 22,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 5,
         "Krh_I": null,
@@ -17589,7 +17589,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6.5,
-        "Mutation": 193,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.07.2021",
+        "Fallzahl": 30886,
+        "ObjectId": 511,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29648,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2652,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 11,
+        "BelegteBetten": null,
+        "Inzidenz": 12.7518948238083,
+        "Datum_neu": 1627603200000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "23.07.2021 - 29.07.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 11.1,
+        "Fallzahl_aktiv": 130,
+        "Krh_N_belegt": 92,
+        "Krh_I_belegt": 20,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.7,
+        "Mutation": 194,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
