### PR TITLE
New data set: 2021-08-02T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-07-30T102603Z.json
+pjson/2021-08-02T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-07-30T102603Z.json pjson/2021-08-02T100203Z.json```:
```
--- pjson/2021-07-30T102603Z.json	2021-07-30 10:26:03.605341135 +0000
+++ pjson/2021-08-02T100203Z.json	2021-08-02 10:02:03.665588568 +0000
@@ -17369,12 +17369,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 10.7762491468803,
+        "Inzidenz": null,
         "Datum_neu": 1626998400000,
         "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 10.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17384,7 +17384,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 3.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17403,12 +17403,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 12.2130823664643,
+        "Inzidenz": null,
         "Datum_neu": 1627084800000,
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 8.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17418,7 +17418,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17437,12 +17437,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 11.6742699091203,
+        "Inzidenz": null,
         "Datum_neu": 1627171200000,
         "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 11.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17452,7 +17452,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17473,7 +17473,7 @@
         "BelegteBetten": null,
         "Inzidenz": 11.4946657566723,
         "Datum_neu": 1627257600000,
-        "F\u00e4lle_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 10.8,
@@ -17564,13 +17564,13 @@
         "Datum": "29.07.2021",
         "Fallzahl": 30878,
         "ObjectId": 510,
-        "Sterbefall": 1107,
-        "Genesungsfall": 29637,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2650,
-        "Zuwachs_Fallzahl": 9,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
         "Inzidenz": 12.7518948238083,
@@ -17579,13 +17579,13 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 12.4,
-        "Fallzahl_aktiv": 134,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 5,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6.5,
@@ -17600,7 +17600,7 @@
         "ObjectId": 511,
         "Sterbefall": 1108,
         "Genesungsfall": 29648,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2652,
         "Zuwachs_Fallzahl": 8,
         "Zuwachs_Sterbefall": 1,
@@ -17609,13 +17609,13 @@
         "BelegteBetten": null,
         "Inzidenz": 12.7518948238083,
         "Datum_neu": 1627603200000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "23.07.2021 - 29.07.2021",
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 11.1,
         "Fallzahl_aktiv": 130,
-        "Krh_N_belegt": 92,
-        "Krh_I_belegt": 20,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -4,
         "Krh_I": null,
@@ -17623,7 +17623,109 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6.7,
-        "Mutation": 194,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.07.2021",
+        "Fallzahl": 30896,
+        "ObjectId": 512,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
+        "BelegteBetten": null,
+        "Inzidenz": 10.4170408419843,
+        "Datum_neu": 1627689600000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 10.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.08.2021",
+        "Fallzahl": 30896,
+        "ObjectId": 513,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
+        "BelegteBetten": null,
+        "Inzidenz": 10.2374366895363,
+        "Datum_neu": 1627776000000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 10.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.4,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.08.2021",
+        "Fallzahl": 30896,
+        "ObjectId": 514,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29662,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2652,
+        "Zuwachs_Fallzahl": 10,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 14,
+        "BelegteBetten": null,
+        "Inzidenz": 9.87822838464025,
+        "Datum_neu": 1627862400000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "26.07.2021 - 01.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 9.9,
+        "Fallzahl_aktiv": 126,
+        "Krh_N_belegt": 96,
+        "Krh_I_belegt": 21,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.3,
+        "Mutation": 209,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
