### PR TITLE
New data set: 2021-08-02T120803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-02T100203Z.json
+pjson/2021-08-02T120803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-02T100203Z.json pjson/2021-08-02T120803Z.json```:
```
--- pjson/2021-08-02T100203Z.json	2021-08-02 10:02:03.665588568 +0000
+++ pjson/2021-08-02T120803Z.json	2021-08-02 12:08:03.354782866 +0000
@@ -17646,7 +17646,7 @@
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 10.4,
+        "Inzidenz_RKI": 9.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17656,7 +17656,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.6,
+        "Inzi_SN_RKI": 6.3,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
