### PR TITLE
New data set: 2021-08-05T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-04T102003Z.json
+pjson/2021-08-05T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-04T102003Z.json pjson/2021-08-05T100503Z.json```:
```
--- pjson/2021-08-04T102003Z.json	2021-08-04 10:20:03.322535835 +0000
+++ pjson/2021-08-05T100503Z.json	2021-08-05 10:05:04.094891022 +0000
@@ -17471,7 +17471,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 11.4946657566723,
+        "Inzidenz": null,
         "Datum_neu": 1627257600000,
         "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
@@ -17505,7 +17505,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 11,
         "BelegteBetten": null,
-        "Inzidenz": 11.4946657566723,
+        "Inzidenz": null,
         "Datum_neu": 1627344000000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
@@ -17539,7 +17539,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3,
         "BelegteBetten": null,
-        "Inzidenz": 12.5722906713603,
+        "Inzidenz": null,
         "Datum_neu": 1627430400000,
         "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
@@ -17734,28 +17734,28 @@
         "Datum": "03.08.2021",
         "Fallzahl": 30915,
         "ObjectId": 515,
-        "Sterbefall": 1108,
-        "Genesungsfall": 29672,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2652,
-        "Zuwachs_Fallzahl": 19,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
         "Inzidenz": 10.7762491468803,
         "Datum_neu": 1627948800000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.2,
-        "Fallzahl_aktiv": 135,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 98,
         "Krh_I_belegt": 19,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 9,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6.1,
@@ -17770,7 +17770,7 @@
         "ObjectId": 516,
         "Sterbefall": 1108,
         "Genesungsfall": 29683,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2654,
         "Zuwachs_Fallzahl": 8,
         "Zuwachs_Sterbefall": 0,
@@ -17779,8 +17779,8 @@
         "BelegteBetten": null,
         "Inzidenz": 10.0578325370883,
         "Datum_neu": 1628035200000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "28.07.2021 - 03.08.2021",
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.7,
         "Fallzahl_aktiv": 132,
@@ -17796,6 +17796,40 @@
         "Mutation": 220,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.08.2021",
+        "Fallzahl": 30933,
+        "ObjectId": 517,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29695,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2654,
+        "Zuwachs_Fallzahl": 10,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 12,
+        "BelegteBetten": null,
+        "Inzidenz": 7.9025827077122,
+        "Datum_neu": 1628121600000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "29.07.2021 - 04.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 7.5,
+        "Fallzahl_aktiv": 130,
+        "Krh_N_belegt": 98,
+        "Krh_I_belegt": 21,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6,
+        "Mutation": 225,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
