### PR TITLE
New data set: 2021-08-06T100504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-05T100503Z.json
+pjson/2021-08-06T100504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-05T100503Z.json pjson/2021-08-06T100504Z.json```:
```
--- pjson/2021-08-05T100503Z.json	2021-08-05 10:05:04.094891022 +0000
+++ pjson/2021-08-06T100504Z.json	2021-08-06 10:05:04.237348749 +0000
@@ -17476,7 +17476,7 @@
         "F\u00e4lle_Meldedatum": 3,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 10.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17486,7 +17486,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17510,7 +17510,7 @@
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 10.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17520,7 +17520,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 4.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17544,7 +17544,7 @@
         "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 11,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17554,7 +17554,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 5.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17573,12 +17573,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 12.7518948238083,
+        "Inzidenz": null,
         "Datum_neu": 1627516800000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 12.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17588,7 +17588,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17641,7 +17641,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 11.3150616042243,
+        "Inzidenz": 11.4946657566723,
         "Datum_neu": 1627689600000,
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
@@ -17675,7 +17675,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 11.3150616042243,
+        "Inzidenz": 11.4946657566723,
         "Datum_neu": 1627776000000,
         "F\u00e4lle_Meldedatum": 0,
         "Zeitraum": null,
@@ -17711,7 +17711,7 @@
         "BelegteBetten": null,
         "Inzidenz": 9.87822838464025,
         "Datum_neu": 1627862400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 9.9,
@@ -17725,7 +17725,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6.3,
-        "Mutation": 209,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17750,8 +17750,8 @@
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.2,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 98,
-        "Krh_I_belegt": 19,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -17759,7 +17759,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6.1,
-        "Mutation": 214,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17768,32 +17768,32 @@
         "Datum": "04.08.2021",
         "Fallzahl": 30923,
         "ObjectId": 516,
-        "Sterbefall": 1108,
-        "Genesungsfall": 29683,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2654,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 11,
         "BelegteBetten": null,
         "Inzidenz": 10.0578325370883,
         "Datum_neu": 1628035200000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.7,
-        "Fallzahl_aktiv": 132,
-        "Krh_N_belegt": 96,
-        "Krh_I_belegt": 17,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 5.9,
-        "Mutation": 220,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17804,7 +17804,7 @@
         "ObjectId": 517,
         "Sterbefall": 1108,
         "Genesungsfall": 29695,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2654,
         "Zuwachs_Fallzahl": 10,
         "Zuwachs_Sterbefall": 0,
@@ -17813,13 +17813,13 @@
         "BelegteBetten": null,
         "Inzidenz": 7.9025827077122,
         "Datum_neu": 1628121600000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "29.07.2021 - 04.08.2021",
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.5,
         "Fallzahl_aktiv": 130,
-        "Krh_N_belegt": 98,
-        "Krh_I_belegt": 21,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -2,
         "Krh_I": null,
@@ -17827,7 +17827,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6,
-        "Mutation": 225,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.08.2021",
+        "Fallzahl": 30946,
+        "ObjectId": 518,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29719,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2654,
+        "Zuwachs_Fallzahl": 13,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 24,
+        "BelegteBetten": null,
+        "Inzidenz": 9.87822838464025,
+        "Datum_neu": 1628208000000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "30.07.2021 - 05.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 8.4,
+        "Fallzahl_aktiv": 119,
+        "Krh_N_belegt": 100,
+        "Krh_I_belegt": 21,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.7,
+        "Mutation": 226,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
