### PR TITLE
New data set: 2021-08-09T103004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-06T100504Z.json
+pjson/2021-08-09T103004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-06T100504Z.json pjson/2021-08-09T103004Z.json```:
```
--- pjson/2021-08-06T100504Z.json	2021-08-06 10:05:04.237348749 +0000
+++ pjson/2021-08-09T103004Z.json	2021-08-09 10:30:04.539352033 +0000
@@ -17133,7 +17133,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626393600000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -17303,7 +17303,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626825600000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -17507,7 +17507,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627344000000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -17541,7 +17541,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627430400000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -17609,7 +17609,7 @@
         "BelegteBetten": null,
         "Inzidenz": 12.7518948238083,
         "Datum_neu": 1627603200000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 11.1,
@@ -17641,7 +17641,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 11.4946657566723,
+        "Inzidenz": 10.9558532993283,
         "Datum_neu": 1627689600000,
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
@@ -17675,7 +17675,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 11.4946657566723,
+        "Inzidenz": 10.9558532993283,
         "Datum_neu": 1627776000000,
         "F\u00e4lle_Meldedatum": 0,
         "Zeitraum": null,
@@ -17711,7 +17711,7 @@
         "BelegteBetten": null,
         "Inzidenz": 9.87822838464025,
         "Datum_neu": 1627862400000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 9.9,
@@ -17813,7 +17813,7 @@
         "BelegteBetten": null,
         "Inzidenz": 7.9025827077122,
         "Datum_neu": 1628121600000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.5,
@@ -17834,24 +17834,24 @@
     {
       "attributes": {
         "Datum": "06.08.2021",
-        "Fallzahl": 30946,
+        "Fallzahl": 30953,
         "ObjectId": 518,
         "Sterbefall": 1108,
-        "Genesungsfall": 29719,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 29716,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2654,
-        "Zuwachs_Fallzahl": 13,
+        "Zuwachs_Fallzahl": 10,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 24,
+        "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
-        "Inzidenz": 9.87822838464025,
+        "Inzidenz": 10.7762491468803,
         "Datum_neu": 1628208000000,
-        "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "30.07.2021 - 05.08.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 8.4,
-        "Fallzahl_aktiv": 119,
+        "Fallzahl_aktiv": 129,
         "Krh_N_belegt": 100,
         "Krh_I_belegt": 21,
         "Krh_I_frei": null,
@@ -17864,6 +17864,108 @@
         "Mutation": 226,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.08.2021",
+        "Fallzahl": 30963,
+        "ObjectId": 519,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29722,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 2654,
+        "Zuwachs_Fallzahl": 3,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 6,
+        "BelegteBetten": null,
+        "Inzidenz": 10.7762491468803,
+        "Datum_neu": 1628294400000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 8.1,
+        "Fallzahl_aktiv": 133,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 6.7,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.08.2021",
+        "Fallzahl": 30966,
+        "ObjectId": 520,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29724,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 2654,
+        "Zuwachs_Fallzahl": 0,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 2,
+        "BelegteBetten": null,
+        "Inzidenz": 11.4946657566723,
+        "Datum_neu": 1628380800000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 9.2,
+        "Fallzahl_aktiv": 134,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 7.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.08.2021",
+        "Fallzahl": 30967,
+        "ObjectId": 521,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29726,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2656,
+        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 10,
+        "BelegteBetten": null,
+        "Inzidenz": 12.0334782140163,
+        "Datum_neu": 1628467200000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "02.08.2021 - 08.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 9.2,
+        "Fallzahl_aktiv": 133,
+        "Krh_N_belegt": 102,
+        "Krh_I_belegt": 21,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 7.6,
+        "Mutation": 242,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
