### PR TITLE
New data set: 2021-08-10T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-09T103004Z.json
+pjson/2021-08-10T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-09T103004Z.json pjson/2021-08-10T100203Z.json```:
```
--- pjson/2021-08-09T103004Z.json	2021-08-09 10:30:04.539352033 +0000
+++ pjson/2021-08-10T100203Z.json	2021-08-10 10:02:03.891630234 +0000
@@ -17607,12 +17607,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 11,
         "BelegteBetten": null,
-        "Inzidenz": 12.7518948238083,
+        "Inzidenz": null,
         "Datum_neu": 1627603200000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 11.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17622,7 +17622,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17641,12 +17641,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 10.9558532993283,
+        "Inzidenz": null,
         "Datum_neu": 1627689600000,
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 9.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17656,7 +17656,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17675,12 +17675,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 10.9558532993283,
+        "Inzidenz": null,
         "Datum_neu": 1627776000000,
         "F\u00e4lle_Meldedatum": 0,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 10.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17690,7 +17690,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.4,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17709,12 +17709,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 14,
         "BelegteBetten": null,
-        "Inzidenz": 9.87822838464025,
+        "Inzidenz": null,
         "Datum_neu": 1627862400000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 9.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17724,7 +17724,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17745,7 +17745,7 @@
         "BelegteBetten": null,
         "Inzidenz": 10.7762491468803,
         "Datum_neu": 1627948800000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.2,
@@ -17802,13 +17802,13 @@
         "Datum": "05.08.2021",
         "Fallzahl": 30933,
         "ObjectId": 517,
-        "Sterbefall": 1108,
-        "Genesungsfall": 29695,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2654,
-        "Zuwachs_Fallzahl": 10,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 12,
         "BelegteBetten": null,
         "Inzidenz": 7.9025827077122,
@@ -17817,11 +17817,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 7.5,
-        "Fallzahl_aktiv": 130,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -17836,13 +17836,13 @@
         "Datum": "06.08.2021",
         "Fallzahl": 30953,
         "ObjectId": 518,
-        "Sterbefall": 1108,
-        "Genesungsfall": 29716,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2654,
-        "Zuwachs_Fallzahl": 10,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
         "Inzidenz": 10.7762491468803,
@@ -17851,17 +17851,17 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 8.4,
-        "Fallzahl_aktiv": 129,
-        "Krh_N_belegt": 100,
-        "Krh_I_belegt": 21,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 6.7,
-        "Mutation": 226,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -17870,26 +17870,26 @@
         "Datum": "07.08.2021",
         "Fallzahl": 30963,
         "ObjectId": 519,
-        "Sterbefall": 1108,
-        "Genesungsfall": 29722,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2654,
-        "Zuwachs_Fallzahl": 3,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 6,
         "BelegteBetten": null,
         "Inzidenz": 10.7762491468803,
         "Datum_neu": 1628294400000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 8.1,
-        "Fallzahl_aktiv": 133,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -17904,13 +17904,13 @@
         "Datum": "08.08.2021",
         "Fallzahl": 30966,
         "ObjectId": 520,
-        "Sterbefall": 1108,
-        "Genesungsfall": 29724,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2654,
-        "Zuwachs_Fallzahl": 0,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
         "Inzidenz": 11.4946657566723,
@@ -17919,11 +17919,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 9.2,
-        "Fallzahl_aktiv": 134,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -17940,30 +17940,64 @@
         "ObjectId": 521,
         "Sterbefall": 1108,
         "Genesungsfall": 29726,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2656,
         "Zuwachs_Fallzahl": 14,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 2,
-        "Zuwachs_Genesung": 10,
+        "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
         "Inzidenz": 12.0334782140163,
         "Datum_neu": 1628467200000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "02.08.2021 - 08.08.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 9.2,
         "Fallzahl_aktiv": 133,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 7.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.08.2021",
+        "Fallzahl": 30986,
+        "ObjectId": 522,
+        "Sterbefall": 1108,
+        "Genesungsfall": 29745,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2657,
+        "Zuwachs_Fallzahl": 23,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 19,
+        "BelegteBetten": null,
+        "Inzidenz": 12.7518948238083,
+        "Datum_neu": 1628553600000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "03.08.2021 - 09.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 11.1,
+        "Fallzahl_aktiv": 133,
         "Krh_N_belegt": 102,
-        "Krh_I_belegt": 21,
+        "Krh_I_belegt": 23,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 4,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 7.6,
-        "Mutation": 242,
+        "Inzi_SN_RKI": 7.8,
+        "Mutation": 246,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
