### PR TITLE
New data set: 2021-08-10T102004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-09T103004Z.json
+pjson/2021-08-10T102004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-10T100203Z.json pjson/2021-08-10T102004Z.json```:
```
--- pjson/2021-08-10T100203Z.json	2021-08-10 10:02:03.891630234 +0000
+++ pjson/2021-08-10T102004Z.json	2021-08-10 10:20:04.399601987 +0000
@@ -17976,7 +17976,7 @@
         "Genesungsfall": 29745,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2657,
-        "Zuwachs_Fallzahl": 23,
+        "Zuwachs_Fallzahl": 19,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 1,
         "Zuwachs_Genesung": 19,
@@ -17991,9 +17991,9 @@
         "Krh_N_belegt": 102,
         "Krh_I_belegt": 23,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 4,
+        "Fallzahl_aktiv_Zuwachs": 0,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 7.8,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
