### PR TITLE
New data set: 2021-08-12T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-11T100504Z.json
+pjson/2021-08-12T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-11T100504Z.json pjson/2021-08-12T100103Z.json```:
```
--- pjson/2021-08-11T100504Z.json	2021-08-11 10:05:04.160445436 +0000
+++ pjson/2021-08-12T100103Z.json	2021-08-12 10:01:03.706541805 +0000
@@ -17609,7 +17609,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627603200000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -17621,7 +17621,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -17743,12 +17743,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 10.7762491468803,
+        "Inzidenz": null,
         "Datum_neu": 1627948800000,
         "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 9.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17758,7 +17758,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17777,12 +17777,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 11,
         "BelegteBetten": null,
-        "Inzidenz": 10.0578325370883,
+        "Inzidenz": null,
         "Datum_neu": 1628035200000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 9.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17792,7 +17792,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 5.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -17949,7 +17949,7 @@
         "BelegteBetten": null,
         "Inzidenz": 12.0334782140163,
         "Datum_neu": 1628467200000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 9.2,
@@ -17972,26 +17972,26 @@
         "Datum": "10.08.2021",
         "Fallzahl": 30986,
         "ObjectId": 522,
-        "Sterbefall": 1108,
-        "Genesungsfall": 29745,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2657,
-        "Zuwachs_Fallzahl": 19,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 19,
         "BelegteBetten": null,
         "Inzidenz": 12.7518948238083,
         "Datum_neu": 1628553600000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 11.1,
-        "Fallzahl_aktiv": 133,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 0,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -18008,7 +18008,7 @@
         "ObjectId": 523,
         "Sterbefall": 1108,
         "Genesungsfall": 29760,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2657,
         "Zuwachs_Fallzahl": 12,
         "Zuwachs_Sterbefall": 0,
@@ -18017,13 +18017,13 @@
         "BelegteBetten": null,
         "Inzidenz": 12.7518948238083,
         "Datum_neu": 1628640000000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "04.08.2021 - 10.08.2021",
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 11.9,
         "Fallzahl_aktiv": 130,
-        "Krh_N_belegt": 102,
-        "Krh_I_belegt": 21,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -3,
         "Krh_I": null,
@@ -18031,7 +18031,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 8,
-        "Mutation": 252,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.08.2021",
+        "Fallzahl": 31022,
+        "ObjectId": 524,
+        "Sterbefall": 1109,
+        "Genesungsfall": 29769,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2657,
+        "Zuwachs_Fallzahl": 24,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 9,
+        "BelegteBetten": null,
+        "Inzidenz": 15.0867488056324,
+        "Datum_neu": 1628726400000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "05.08.2021 - 11.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 12.8,
+        "Fallzahl_aktiv": 144,
+        "Krh_N_belegt": 101,
+        "Krh_I_belegt": 17,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 14,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 9.8,
+        "Mutation": 281,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
