### PR TITLE
New data set: 2021-08-14T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-13T100203Z.json
+pjson/2021-08-14T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-13T100203Z.json pjson/2021-08-14T100103Z.json```:
```
--- pjson/2021-08-13T100203Z.json	2021-08-13 10:02:03.219963388 +0000
+++ pjson/2021-08-14T100103Z.json	2021-08-14 10:01:04.012678753 +0000
@@ -17845,12 +17845,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
-        "Inzidenz": 10.7762491468803,
+        "Inzidenz": null,
         "Datum_neu": 1628208000000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 8.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -17860,7 +17860,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 6.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18017,7 +18017,7 @@
         "BelegteBetten": null,
         "Inzidenz": 12.7518948238083,
         "Datum_neu": 1628640000000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 11.9,
@@ -18040,28 +18040,28 @@
         "Datum": "12.08.2021",
         "Fallzahl": 31022,
         "ObjectId": 524,
-        "Sterbefall": 1109,
-        "Genesungsfall": 29769,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2657,
-        "Zuwachs_Fallzahl": 24,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": 15.0867488056324,
         "Datum_neu": 1628726400000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 12.8,
-        "Fallzahl_aktiv": 144,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 14,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 9.8,
@@ -18076,7 +18076,7 @@
         "ObjectId": 525,
         "Sterbefall": 1111,
         "Genesungsfall": 29770,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2658,
         "Zuwachs_Fallzahl": 26,
         "Zuwachs_Sterbefall": 2,
@@ -18085,13 +18085,13 @@
         "BelegteBetten": null,
         "Inzidenz": 17.4216027874564,
         "Datum_neu": 1628812800000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "06.08.2021 - 12.08.2021",
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 14.2,
         "Fallzahl_aktiv": 167,
-        "Krh_N_belegt": 102,
-        "Krh_I_belegt": 17,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 23,
         "Krh_I": null,
@@ -18099,7 +18099,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 10.3,
-        "Mutation": 289,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.08.2021",
+        "Fallzahl": 31067,
+        "ObjectId": 526,
+        "Sterbefall": 1111,
+        "Genesungsfall": 29777,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2658,
+        "Zuwachs_Fallzahl": 19,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 7,
+        "BelegteBetten": null,
+        "Inzidenz": 18.6788318545925,
+        "Datum_neu": 1628899200000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "07.08.2021 - 13.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 16.9,
+        "Fallzahl_aktiv": 179,
+        "Krh_N_belegt": 101,
+        "Krh_I_belegt": 17,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 12,
+        "Mutation": 311,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
