### PR TITLE
New data set: 2021-08-16T112203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-16T101004Z.json
+pjson/2021-08-16T112203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-16T101004Z.json pjson/2021-08-16T112203Z.json```:
```
--- pjson/2021-08-16T101004Z.json	2021-08-16 10:10:04.419641265 +0000
+++ pjson/2021-08-16T112203Z.json	2021-08-16 11:22:03.267789089 +0000
@@ -18180,10 +18180,10 @@
         "Genesungsfall": 29786,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2662,
-        "Zuwachs_Fallzahl": 33,
+        "Zuwachs_Fallzahl": 14,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 4,
-        "Zuwachs_Genesung": 16,
+        "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": 20.8340816839685,
         "Datum_neu": 1629072000000,
@@ -18195,7 +18195,7 @@
         "Krh_N_belegt": 101,
         "Krh_I_belegt": 17,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 17,
+        "Fallzahl_aktiv_Zuwachs": 5,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
