### PR TITLE
New data set: 2021-08-23T101503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-20T102503Z.json
+pjson/2021-08-23T101503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-23T101403Z.json pjson/2021-08-23T101503Z.json```:
```
--- pjson/2021-08-23T101403Z.json	2021-08-23 10:14:03.280329230 +0000
+++ pjson/2021-08-23T101503Z.json	2021-08-23 10:15:03.646554812 +0000
@@ -18017,7 +18017,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1628640000000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -18187,7 +18187,7 @@
         "BelegteBetten": null,
         "Inzidenz": 20.8,
         "Datum_neu": 1629072000000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 14.7,
@@ -18255,7 +18255,7 @@
         "BelegteBetten": null,
         "Inzidenz": 24.6057688853766,
         "Datum_neu": 1629244800000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 22.3,
@@ -18289,9 +18289,9 @@
         "BelegteBetten": null,
         "Inzidenz": 26.7610187147527,
         "Datum_neu": 1629331200000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 24.4,
         "Fallzahl_aktiv": 235,
         "Krh_N_belegt": 102,
@@ -18314,7 +18314,7 @@
         "ObjectId": 532,
         "Sterbefall": 1111,
         "Genesungsfall": 29832,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2667,
         "Zuwachs_Fallzahl": 33,
         "Zuwachs_Sterbefall": 0,
@@ -18323,9 +18323,9 @@
         "BelegteBetten": null,
         "Inzidenz": 26.5814145623047,
         "Datum_neu": 1629417600000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "13.08.2021 - 19.08.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 23.5,
         "Fallzahl_aktiv": 260,
         "Krh_N_belegt": 79,
@@ -18340,6 +18340,108 @@
         "Mutation": 401,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.08.2021",
+        "Fallzahl": null,
+        "ObjectId": 533,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1629504000000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 27.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 15.1,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.08.2021",
+        "Fallzahl": null,
+        "ObjectId": 534,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1629590400000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 23.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 15.1,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.08.2021",
+        "Fallzahl": 31235,
+        "ObjectId": 535,
+        "Sterbefall": 1111,
+        "Genesungsfall": 29851,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2671,
+        "Zuwachs_Fallzahl": 32,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 19,
+        "BelegteBetten": null,
+        "Inzidenz": 26.9,
+        "Datum_neu": 1629676800000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "16.08.2021 - 22.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 26.6,
+        "Fallzahl_aktiv": 273,
+        "Krh_N_belegt": 77,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 13,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 15.8,
+        "Mutation": 434,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
