### PR TITLE
New data set: 2021-08-26T101203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-25T100302Z.json
+pjson/2021-08-26T101203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-25T100302Z.json pjson/2021-08-26T101203Z.json```:
```
--- pjson/2021-08-25T100302Z.json	2021-08-25 10:03:02.926013705 +0000
+++ pjson/2021-08-26T101203Z.json	2021-08-26 10:12:03.647866565 +0000
@@ -18017,7 +18017,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1628640000000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -18051,10 +18051,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1628726400000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 12.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18064,7 +18064,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 9.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18083,12 +18083,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 17.4216027874564,
+        "Inzidenz": null,
         "Datum_neu": 1628812800000,
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 14.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18098,7 +18098,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 10.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18117,12 +18117,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
-        "Inzidenz": 18.7,
+        "Inzidenz": null,
         "Datum_neu": 1628899200000,
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 16.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18132,7 +18132,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 12,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18151,12 +18151,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 21,
+        "Inzidenz": null,
         "Datum_neu": 1628985600000,
         "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 14.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18166,7 +18166,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 10.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18185,14 +18185,14 @@
         "Zuwachs_Krankenhauseinweisung": 4,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
-        "Inzidenz": 20.8,
+        "Inzidenz": null,
         "Datum_neu": 1629072000000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 14.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 184,
-        "Krh_N_belegt": 101,
+        "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 5,
@@ -18200,7 +18200,7 @@
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 10.5,
+        "Inzi_SN_RKI": null,
         "Mutation": 319,
         "Zuwachs_Mutation": null
       }
@@ -18221,7 +18221,7 @@
         "BelegteBetten": null,
         "Inzidenz": 21.3728941413126,
         "Datum_neu": 1629158400000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 16.3,
@@ -18255,7 +18255,7 @@
         "BelegteBetten": null,
         "Inzidenz": 24.6057688853766,
         "Datum_neu": 1629244800000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 22.3,
@@ -18289,7 +18289,7 @@
         "BelegteBetten": null,
         "Inzidenz": 26.7610187147527,
         "Datum_neu": 1629331200000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 24.4,
@@ -18325,7 +18325,7 @@
         "Datum_neu": 1629417600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 23.5,
         "Fallzahl_aktiv": 260,
         "Krh_N_belegt": 79,
@@ -18425,7 +18425,7 @@
         "BelegteBetten": null,
         "Inzidenz": 26.9406228672007,
         "Datum_neu": 1629676800000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 26.6,
@@ -18459,7 +18459,7 @@
         "BelegteBetten": null,
         "Inzidenz": 29.2754768490248,
         "Datum_neu": 1629763200000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 24.4,
@@ -18484,7 +18484,7 @@
         "ObjectId": 537,
         "Sterbefall": 1111,
         "Genesungsfall": 29892,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2671,
         "Zuwachs_Fallzahl": 51,
         "Zuwachs_Sterbefall": 0,
@@ -18493,9 +18493,9 @@
         "BelegteBetten": null,
         "Inzidenz": 33.5859765077769,
         "Datum_neu": 1629849600000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "18.08.2021 - 24.08.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 30.4,
         "Fallzahl_aktiv": 345,
         "Krh_N_belegt": 76,
@@ -18510,6 +18510,40 @@
         "Mutation": 486,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.08.2021",
+        "Fallzahl": 31376,
+        "ObjectId": 538,
+        "Sterbefall": 1111,
+        "Genesungsfall": 29924,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2671,
+        "Zuwachs_Fallzahl": 28,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 32,
+        "BelegteBetten": null,
+        "Inzidenz": 35.9208304896009,
+        "Datum_neu": 1629936000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "19.08.2021 - 25.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 32.9,
+        "Fallzahl_aktiv": 341,
+        "Krh_N_belegt": 90,
+        "Krh_I_belegt": 18,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 17.9,
+        "Mutation": 521,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
