### PR TITLE
New data set: 2021-08-27T101203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-26T101203Z.json
+pjson/2021-08-27T101203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-27T100504Z.json pjson/2021-08-27T101203Z.json```:
```
--- pjson/2021-08-27T100504Z.json	2021-08-27 10:05:04.414349801 +0000
+++ pjson/2021-08-27T101203Z.json	2021-08-27 10:12:03.433939047 +0000
@@ -18336,7 +18336,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
+        "Inzi_SN_RKI": 14,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18370,7 +18370,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
+        "Inzi_SN_RKI": 15.1,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18404,7 +18404,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
+        "Inzi_SN_RKI": 15.1,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18438,7 +18438,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
+        "Inzi_SN_RKI": 15.8,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18472,7 +18472,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
+        "Inzi_SN_RKI": 14.7,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18506,7 +18506,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
+        "Inzi_SN_RKI": 16.2,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18540,7 +18540,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
+        "Inzi_SN_RKI": 17.9,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18551,13 +18551,13 @@
         "Fallzahl": 31412,
         "ObjectId": 539,
         "Sterbefall": 1111,
-        "Genesungsfall": 29925,
+        "Genesungsfall": 29937,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 2676,
         "Zuwachs_Fallzahl": 36,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 5,
-        "Zuwachs_Genesung": 1,
+        "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
         "Inzidenz": 37.178059556737,
         "Datum_neu": 1630022400000,
@@ -18565,11 +18565,11 @@
         "Zeitraum": "20.08.2021 - 26.08.2021",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 34.5,
-        "Fallzahl_aktiv": 376,
+        "Fallzahl_aktiv": 364,
         "Krh_N_belegt": 96,
         "Krh_I_belegt": 21,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 35,
+        "Fallzahl_aktiv_Zuwachs": 23,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
