### PR TITLE
New data set: 2021-08-30T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-27T101203Z.json
+pjson/2021-08-30T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-27T101203Z.json pjson/2021-08-30T101103Z.json```:
```
--- pjson/2021-08-27T101203Z.json	2021-08-27 10:12:03.433939047 +0000
+++ pjson/2021-08-30T101103Z.json	2021-08-30 10:11:03.707802938 +0000
@@ -18189,7 +18189,7 @@
         "Datum_neu": 1629072000000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18321,12 +18321,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
-        "Inzidenz": 26.5814145623047,
+        "Inzidenz": null,
         "Datum_neu": 1629417600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 23.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18336,7 +18336,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 14,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18355,12 +18355,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
-        "Inzidenz": 29.4550810014728,
+        "Inzidenz": null,
         "Datum_neu": 1629504000000,
         "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 27.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18370,7 +18370,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 15.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18459,7 +18459,7 @@
         "BelegteBetten": null,
         "Inzidenz": 29.2754768490248,
         "Datum_neu": 1629763200000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 24.4,
@@ -18493,9 +18493,9 @@
         "BelegteBetten": null,
         "Inzidenz": 33.5859765077769,
         "Datum_neu": 1629849600000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 30.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18527,7 +18527,7 @@
         "BelegteBetten": null,
         "Inzidenz": 35.9208304896009,
         "Datum_neu": 1629936000000,
-        "F\u00e4lle_Meldedatum": 29,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 32.9,
@@ -18552,7 +18552,7 @@
         "ObjectId": 539,
         "Sterbefall": 1111,
         "Genesungsfall": 29937,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2676,
         "Zuwachs_Fallzahl": 36,
         "Zuwachs_Sterbefall": 0,
@@ -18561,9 +18561,9 @@
         "BelegteBetten": null,
         "Inzidenz": 37.178059556737,
         "Datum_neu": 1630022400000,
-        "F\u00e4lle_Meldedatum": 6,
-        "Zeitraum": "20.08.2021 - 26.08.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 29,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 34.5,
         "Fallzahl_aktiv": 364,
         "Krh_N_belegt": 96,
@@ -18578,6 +18578,108 @@
         "Mutation": 553,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.08.2021",
+        "Fallzahl": 31443,
+        "ObjectId": 540,
+        "Sterbefall": null,
+        "Genesungsfall": 29964,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 38.974101081217,
+        "Datum_neu": 1630108800000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 33.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 18.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.08.2021",
+        "Fallzahl": 31449,
+        "ObjectId": 541,
+        "Sterbefall": null,
+        "Genesungsfall": 29965,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 36.6392470993929,
+        "Datum_neu": 1630195200000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 34.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 19.7,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.08.2021",
+        "Fallzahl": 31454,
+        "ObjectId": 542,
+        "Sterbefall": 1111,
+        "Genesungsfall": 29981,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2679,
+        "Zuwachs_Fallzahl": 42,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 44,
+        "BelegteBetten": null,
+        "Inzidenz": 35.5616221847049,
+        "Datum_neu": 1630281600000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "23.08.2021 - 29.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 35.4,
+        "Fallzahl_aktiv": 362,
+        "Krh_N_belegt": 78,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 20.3,
+        "Mutation": 566,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
