### PR TITLE
New data set: 2021-08-31T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-30T101103Z.json
+pjson/2021-08-31T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-30T101103Z.json pjson/2021-08-31T101103Z.json```:
```
--- pjson/2021-08-30T101103Z.json	2021-08-30 10:11:03.707802938 +0000
+++ pjson/2021-08-31T101103Z.json	2021-08-31 10:11:03.578470602 +0000
@@ -18459,7 +18459,7 @@
         "BelegteBetten": null,
         "Inzidenz": 29.2754768490248,
         "Datum_neu": 1629763200000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 24.4,
@@ -18527,7 +18527,7 @@
         "BelegteBetten": null,
         "Inzidenz": 35.9208304896009,
         "Datum_neu": 1629936000000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 35,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 32.9,
@@ -18550,32 +18550,32 @@
         "Datum": "27.08.2021",
         "Fallzahl": 31412,
         "ObjectId": 539,
-        "Sterbefall": 1111,
-        "Genesungsfall": 29937,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2676,
-        "Zuwachs_Fallzahl": 36,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
         "Inzidenz": 37.178059556737,
         "Datum_neu": 1630022400000,
-        "F\u00e4lle_Meldedatum": 29,
+        "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 34.5,
-        "Fallzahl_aktiv": 364,
-        "Krh_N_belegt": 96,
-        "Krh_I_belegt": 21,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 23,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 18.5,
-        "Mutation": 553,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -18585,7 +18585,7 @@
         "Fallzahl": 31443,
         "ObjectId": 540,
         "Sterbefall": null,
-        "Genesungsfall": 29964,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18593,9 +18593,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 38.974101081217,
+        "Inzidenz": 39,
         "Datum_neu": 1630108800000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 33.8,
@@ -18619,7 +18619,7 @@
         "Fallzahl": 31449,
         "ObjectId": 541,
         "Sterbefall": null,
-        "Genesungsfall": 29965,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18627,9 +18627,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 36.6392470993929,
+        "Inzidenz": 36.6,
         "Datum_neu": 1630195200000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 34.5,
@@ -18654,22 +18654,22 @@
         "ObjectId": 542,
         "Sterbefall": 1111,
         "Genesungsfall": 29981,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2679,
         "Zuwachs_Fallzahl": 42,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 3,
         "Zuwachs_Genesung": 44,
         "BelegteBetten": null,
-        "Inzidenz": 35.5616221847049,
+        "Inzidenz": 35.6,
         "Datum_neu": 1630281600000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "23.08.2021 - 29.08.2021",
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 35.4,
         "Fallzahl_aktiv": 362,
-        "Krh_N_belegt": 78,
-        "Krh_I_belegt": 23,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -2,
         "Krh_I": null,
@@ -18677,7 +18677,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 20.3,
-        "Mutation": 566,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.08.2022",
+        "Fallzahl": 31501,
+        "ObjectId": 543,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30012,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2679,
+        "Zuwachs_Fallzahl": 47,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 31,
+        "BelegteBetten": null,
+        "Inzidenz": 40.051725995905,
+        "Datum_neu": 1661904000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "24.08.2021 - 30.08.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 33.8,
+        "Fallzahl_aktiv": 378,
+        "Krh_N_belegt": 88,
+        "Krh_I_belegt": 25,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 16,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 19.3,
+        "Mutation": 580,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
