### PR TITLE
New data set: 2021-09-01T101003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-08-31T121903Z.json
+pjson/2021-09-01T101003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-08-31T121903Z.json pjson/2021-09-01T101003Z.json```:
```
--- pjson/2021-08-31T121903Z.json	2021-08-31 12:19:03.519205590 +0000
+++ pjson/2021-09-01T101003Z.json	2021-09-01 10:10:03.974687735 +0000
@@ -18389,12 +18389,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
-        "Inzidenz": 26.5814145623047,
+        "Inzidenz": null,
         "Datum_neu": 1629590400000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 23.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18404,7 +18404,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 15.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18423,12 +18423,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
-        "Inzidenz": 26.9406228672007,
+        "Inzidenz": null,
         "Datum_neu": 1629676800000,
         "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 26.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18438,7 +18438,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 15.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18457,12 +18457,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 19,
         "BelegteBetten": null,
-        "Inzidenz": 29.2754768490248,
+        "Inzidenz": null,
         "Datum_neu": 1629763200000,
         "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 24.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18472,7 +18472,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 14.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18631,7 +18631,7 @@
         "Datum_neu": 1630195200000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 34.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18652,26 +18652,26 @@
         "Datum": "30.08.2021",
         "Fallzahl": 31454,
         "ObjectId": 542,
-        "Sterbefall": 1111,
-        "Genesungsfall": 29981,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2679,
-        "Zuwachs_Fallzahl": 42,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 44,
         "BelegteBetten": null,
         "Inzidenz": 35.6,
         "Datum_neu": 1630281600000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 35.4,
-        "Fallzahl_aktiv": 362,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -18686,32 +18686,66 @@
         "Datum": "31.08.2021",
         "Fallzahl": 31501,
         "ObjectId": 543,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30012,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2679,
-        "Zuwachs_Fallzahl": 47,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 31,
         "BelegteBetten": null,
         "Inzidenz": 40.051725995905,
         "Datum_neu": 1630368000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "24.08.2021 - 30.08.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 33.8,
-        "Fallzahl_aktiv": 378,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 88,
         "Krh_I_belegt": 25,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 16,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 19.3,
-        "Mutation": 580,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.09.2021",
+        "Fallzahl": 31532,
+        "ObjectId": 544,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30045,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2686,
+        "Zuwachs_Fallzahl": 31,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 33,
+        "BelegteBetten": null,
+        "Inzidenz": 34.6636014224649,
+        "Datum_neu": 1630454400000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "25.08.2021 - 31.08.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 32,
+        "Fallzahl_aktiv": 376,
+        "Krh_N_belegt": 84,
+        "Krh_I_belegt": 24,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 19.5,
+        "Mutation": 595,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
