### PR TITLE
New data set: 2021-09-02T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-01T101003Z.json
+pjson/2021-09-02T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-01T101003Z.json pjson/2021-09-02T100203Z.json```:
```
--- pjson/2021-09-01T101003Z.json	2021-09-01 10:10:03.974687735 +0000
+++ pjson/2021-09-02T100203Z.json	2021-09-02 10:02:03.606574379 +0000
@@ -18323,7 +18323,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629417600000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -18425,7 +18425,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629676800000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -18491,12 +18491,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 22,
         "BelegteBetten": null,
-        "Inzidenz": 33.5859765077769,
+        "Inzidenz": null,
         "Datum_neu": 1629849600000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 30.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18506,7 +18506,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 16.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18697,13 +18697,13 @@
         "BelegteBetten": null,
         "Inzidenz": 40.051725995905,
         "Datum_neu": 1630368000000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 35,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 33.8,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 88,
-        "Krh_I_belegt": 25,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -18720,32 +18720,66 @@
         "Datum": "01.09.2021",
         "Fallzahl": 31532,
         "ObjectId": 544,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30045,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2686,
-        "Zuwachs_Fallzahl": 31,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
         "Inzidenz": 34.6636014224649,
         "Datum_neu": 1630454400000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "25.08.2021 - 31.08.2021",
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 32,
-        "Fallzahl_aktiv": 376,
-        "Krh_N_belegt": 84,
-        "Krh_I_belegt": 24,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 19.5,
-        "Mutation": 595,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.09.2021",
+        "Fallzahl": 31606,
+        "ObjectId": 545,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30074,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2686,
+        "Zuwachs_Fallzahl": 74,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 29,
+        "BelegteBetten": null,
+        "Inzidenz": 35.0228097273609,
+        "Datum_neu": 1630540800000,
+        "F\u00e4lle_Meldedatum": 30,
+        "Zeitraum": "26.08.2021 - 01.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 31.3,
+        "Fallzahl_aktiv": 421,
+        "Krh_N_belegt": 83,
+        "Krh_I_belegt": 24,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 45,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 22.7,
+        "Mutation": 635,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
