### PR TITLE
New data set: 2021-09-06T101402Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-03T100603Z.json
+pjson/2021-09-06T101402Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-03T100603Z.json pjson/2021-09-06T101402Z.json```:
```
--- pjson/2021-09-03T100603Z.json	2021-09-03 10:06:03.390685131 +0000
+++ pjson/2021-09-06T101402Z.json	2021-09-06 10:14:03.026974255 +0000
@@ -18631,7 +18631,7 @@
         "Datum_neu": 1630195200000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 34.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18663,9 +18663,9 @@
         "BelegteBetten": null,
         "Inzidenz": 35.6,
         "Datum_neu": 1630281600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 35.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18697,7 +18697,7 @@
         "BelegteBetten": null,
         "Inzidenz": 40.051725995905,
         "Datum_neu": 1630368000000,
-        "F\u00e4lle_Meldedatum": 35,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 33.8,
@@ -18720,26 +18720,26 @@
         "Datum": "01.09.2021",
         "Fallzahl": 31532,
         "ObjectId": 544,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30045,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2686,
+        "Zuwachs_Fallzahl": 31,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
         "Inzidenz": 34.6636014224649,
         "Datum_neu": 1630454400000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 32,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 376,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -18754,32 +18754,32 @@
         "Datum": "02.09.2021",
         "Fallzahl": 31606,
         "ObjectId": 545,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30074,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2686,
+        "Zuwachs_Fallzahl": 74,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
         "Inzidenz": 35.0228097273609,
         "Datum_neu": 1630540800000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 31.3,
-        "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Fallzahl_aktiv": 421,
+        "Krh_N_belegt": 83,
+        "Krh_I_belegt": 24,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 45,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 22.7,
-        "Mutation": null,
+        "Mutation": 635,
         "Zuwachs_Mutation": null
       }
     },
@@ -18790,7 +18790,7 @@
         "ObjectId": 546,
         "Sterbefall": 1111,
         "Genesungsfall": 30097,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2686,
         "Zuwachs_Fallzahl": 24,
         "Zuwachs_Sterbefall": 0,
@@ -18799,9 +18799,9 @@
         "BelegteBetten": null,
         "Inzidenz": 37.896476166529,
         "Datum_neu": 1630627200000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "27.08.2021 - 02.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 34,
         "Fallzahl_aktiv": 422,
         "Krh_N_belegt": 95,
@@ -18816,6 +18816,108 @@
         "Mutation": 656,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.09.2021",
+        "Fallzahl": 31697,
+        "ObjectId": 547,
+        "Sterbefall": null,
+        "Genesungsfall": 30114,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1630713600000,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 33.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 26.6,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.09.2021",
+        "Fallzahl": 31697,
+        "ObjectId": 548,
+        "Sterbefall": null,
+        "Genesungsfall": 30128,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1630800000000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 40.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 29,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.09.2021",
+        "Fallzahl": 31713,
+        "ObjectId": 549,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30148,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2689,
+        "Zuwachs_Fallzahl": 83,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 51,
+        "BelegteBetten": null,
+        "Inzidenz": 46.1582671791372,
+        "Datum_neu": 1630886400000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "30.08.2021 - 05.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 43.5,
+        "Fallzahl_aktiv": 454,
+        "Krh_N_belegt": 87,
+        "Krh_I_belegt": 26,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 32,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 30.3,
+        "Mutation": 690,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
