### PR TITLE
New data set: 2021-09-08T103704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-07T100204Z.json
+pjson/2021-09-08T103704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-07T100204Z.json pjson/2021-09-08T103704Z.json```:
```
--- pjson/2021-09-07T100204Z.json	2021-09-07 10:02:04.104176012 +0000
+++ pjson/2021-09-08T103704Z.json	2021-09-08 10:37:04.418175661 +0000
@@ -14515,7 +14515,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -16285,7 +16285,7 @@
         "Datum_neu": 1624233600000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18291,7 +18291,7 @@
         "Datum_neu": 1629331200000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18551,7 +18551,7 @@
         "Fallzahl": 31412,
         "ObjectId": 539,
         "Sterbefall": null,
-        "Genesungsfall": 29937,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18585,7 +18585,7 @@
         "Fallzahl": 31443,
         "ObjectId": 540,
         "Sterbefall": null,
-        "Genesungsfall": 29964,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18619,7 +18619,7 @@
         "Fallzahl": 31449,
         "ObjectId": 541,
         "Sterbefall": null,
-        "Genesungsfall": 29965,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18720,13 +18720,13 @@
         "Datum": "01.09.2021",
         "Fallzahl": 31532,
         "ObjectId": 544,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30045,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2686,
-        "Zuwachs_Fallzahl": 31,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
         "Inzidenz": 34.6636014224649,
@@ -18735,11 +18735,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 32,
-        "Fallzahl_aktiv": 376,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -18754,13 +18754,13 @@
         "Datum": "02.09.2021",
         "Fallzahl": 31606,
         "ObjectId": 545,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30074,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2686,
-        "Zuwachs_Fallzahl": 74,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
         "Inzidenz": 35.0228097273609,
@@ -18769,17 +18769,17 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 31.3,
-        "Fallzahl_aktiv": 421,
-        "Krh_N_belegt": 83,
-        "Krh_I_belegt": 24,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 45,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 22.7,
-        "Mutation": 635,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -18788,32 +18788,32 @@
         "Datum": "03.09.2021",
         "Fallzahl": 31630,
         "ObjectId": 546,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30097,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2686,
-        "Zuwachs_Fallzahl": 24,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
         "Inzidenz": 37.896476166529,
         "Datum_neu": 1630627200000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 34,
-        "Fallzahl_aktiv": 422,
-        "Krh_N_belegt": 95,
-        "Krh_I_belegt": 26,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 25.1,
-        "Mutation": 656,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -18823,7 +18823,7 @@
         "Fallzahl": 31697,
         "ObjectId": 547,
         "Sterbefall": null,
-        "Genesungsfall": 30114,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18833,7 +18833,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630713600000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 33.6,
@@ -18857,7 +18857,7 @@
         "Fallzahl": 31697,
         "ObjectId": 548,
         "Sterbefall": null,
-        "Genesungsfall": 30128,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18867,7 +18867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630800000000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 40.3,
@@ -18890,32 +18890,32 @@
         "Datum": "06.09.2021",
         "Fallzahl": 31713,
         "ObjectId": 549,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30148,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2689,
-        "Zuwachs_Fallzahl": 83,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": 46.1582671791372,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 43.5,
-        "Fallzahl_aktiv": 454,
-        "Krh_N_belegt": 87,
-        "Krh_I_belegt": 26,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 32,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 30.3,
-        "Mutation": 690,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -18924,32 +18924,66 @@
         "Datum": "07.09.2021",
         "Fallzahl": 31785,
         "ObjectId": 550,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30207,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2695,
-        "Zuwachs_Fallzahl": 72,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
         "Inzidenz": 44.1826215022091,
         "Datum_neu": 1630972800000,
-        "F\u00e4lle_Meldedatum": 34,
-        "Zeitraum": "31.08.2021 - 06.09.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 76,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 38.7,
-        "Fallzahl_aktiv": 467,
-        "Krh_N_belegt": 100,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 29.3,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.09.2021",
+        "Fallzahl": 31857,
+        "ObjectId": 551,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30254,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2696,
+        "Zuwachs_Fallzahl": 72,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 47,
+        "BelegteBetten": null,
+        "Inzidenz": 55.8568914113294,
+        "Datum_neu": 1631059200000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "01.09.2021 - 07.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 48.7,
+        "Fallzahl_aktiv": 492,
+        "Krh_N_belegt": 98,
         "Krh_I_belegt": 24,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 13,
+        "Fallzahl_aktiv_Zuwachs": 25,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 29.3,
-        "Mutation": 714,
+        "Inzi_SN_RKI": 32.5,
+        "Mutation": 751,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
