### PR TITLE
New data set: 2021-09-09T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-08T103704Z.json
+pjson/2021-09-09T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-08T103704Z.json pjson/2021-09-09T100303Z.json```:
```
--- pjson/2021-09-08T103704Z.json	2021-09-08 10:37:04.418175661 +0000
+++ pjson/2021-09-09T100303Z.json	2021-09-09 10:03:03.804441771 +0000
@@ -15127,7 +15127,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1621296000000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -18754,28 +18754,28 @@
         "Datum": "02.09.2021",
         "Fallzahl": 31606,
         "ObjectId": 545,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30074,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2686,
+        "Zuwachs_Fallzahl": 74,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
         "Inzidenz": 35.0228097273609,
         "Datum_neu": 1630540800000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 31.3,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 421,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 45,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 22.7,
@@ -18788,28 +18788,28 @@
         "Datum": "03.09.2021",
         "Fallzahl": 31630,
         "ObjectId": 546,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30097,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2686,
+        "Zuwachs_Fallzahl": 24,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
         "Inzidenz": 37.896476166529,
         "Datum_neu": 1630627200000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 34,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 422,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 1,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 25.1,
@@ -18823,7 +18823,7 @@
         "Fallzahl": 31697,
         "ObjectId": 547,
         "Sterbefall": null,
-        "Genesungsfall": null,
+        "Genesungsfall": 30114,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18857,7 +18857,7 @@
         "Fallzahl": 31697,
         "ObjectId": 548,
         "Sterbefall": null,
-        "Genesungsfall": null,
+        "Genesungsfall": 30128,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18867,7 +18867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630800000000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 40.3,
@@ -18890,28 +18890,28 @@
         "Datum": "06.09.2021",
         "Fallzahl": 31713,
         "ObjectId": 549,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30148,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2689,
+        "Zuwachs_Fallzahl": 83,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": 46.1582671791372,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 43.5,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 454,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 32,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 30.3,
@@ -18924,28 +18924,28 @@
         "Datum": "07.09.2021",
         "Fallzahl": 31785,
         "ObjectId": 550,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30207,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2695,
+        "Zuwachs_Fallzahl": 72,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
         "Inzidenz": 44.1826215022091,
         "Datum_neu": 1630972800000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 38.7,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 467,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 13,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 29.3,
@@ -18960,7 +18960,7 @@
         "ObjectId": 551,
         "Sterbefall": 1111,
         "Genesungsfall": 30254,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2696,
         "Zuwachs_Fallzahl": 72,
         "Zuwachs_Sterbefall": 0,
@@ -18969,9 +18969,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.8568914113294,
         "Datum_neu": 1631059200000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "01.09.2021 - 07.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 48.7,
         "Fallzahl_aktiv": 492,
         "Krh_N_belegt": 98,
@@ -18986,6 +18986,40 @@
         "Mutation": 751,
         "Zuwachs_Mutation": null
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.09.2021",
+        "Fallzahl": 31910,
+        "ObjectId": 552,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30287,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2699,
+        "Zuwachs_Fallzahl": 53,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 33,
+        "BelegteBetten": null,
+        "Inzidenz": 57.8325370882575,
+        "Datum_neu": 1631145600000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "02.09.2021 - 08.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 50.7,
+        "Fallzahl_aktiv": 512,
+        "Krh_N_belegt": 90,
+        "Krh_I_belegt": 22,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 20,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 35.8,
+        "Mutation": 790,
+        "Zuwachs_Mutation": null
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
