### PR TITLE
New data set: 2021-09-13T102003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-10T100804Z.json
+pjson/2021-09-13T102003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-10T100804Z.json pjson/2021-09-13T102003Z.json```:
```
--- pjson/2021-09-10T100804Z.json	2021-09-10 10:08:04.178634227 +0000
+++ pjson/2021-09-13T102003Z.json	2021-09-13 10:20:04.072226678 +0000
@@ -10809,7 +10809,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -18525,7 +18525,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 35.9208304896009,
+        "Inzidenz": null,
         "Datum_neu": 1629936000000,
         "F\u00e4lle_Meldedatum": 35,
         "Zeitraum": null,
@@ -18559,7 +18559,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
-        "Inzidenz": 37.178059556737,
+        "Inzidenz": null,
         "Datum_neu": 1630022400000,
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
@@ -18593,7 +18593,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 27,
         "BelegteBetten": null,
-        "Inzidenz": 39,
+        "Inzidenz": null,
         "Datum_neu": 1630108800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
@@ -18627,7 +18627,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
-        "Inzidenz": 36.6,
+        "Inzidenz": null,
         "Datum_neu": 1630195200000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
@@ -18661,7 +18661,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 16,
         "BelegteBetten": null,
-        "Inzidenz": 35.6,
+        "Inzidenz": null,
         "Datum_neu": 1630281600000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
@@ -18695,7 +18695,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 31,
         "BelegteBetten": null,
-        "Inzidenz": 40.051725995905,
+        "Inzidenz": null,
         "Datum_neu": 1630368000000,
         "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
@@ -18729,7 +18729,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
-        "Inzidenz": 34.6636014224649,
+        "Inzidenz": null,
         "Datum_neu": 1630454400000,
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
@@ -18754,28 +18754,28 @@
         "Datum": "02.09.2021",
         "Fallzahl": 31606,
         "ObjectId": 545,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30074,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2686,
-        "Zuwachs_Fallzahl": 74,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 35.0228097273609,
+        "Inzidenz": null,
         "Datum_neu": 1630540800000,
         "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 31.3,
-        "Fallzahl_aktiv": 421,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 45,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 22.7,
@@ -18788,28 +18788,28 @@
         "Datum": "03.09.2021",
         "Fallzahl": 31630,
         "ObjectId": 546,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30097,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2686,
-        "Zuwachs_Fallzahl": 24,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
-        "Inzidenz": 37.896476166529,
+        "Inzidenz": null,
         "Datum_neu": 1630627200000,
         "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 34,
-        "Fallzahl_aktiv": 422,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 25.1,
@@ -18823,7 +18823,7 @@
         "Fallzahl": 31697,
         "ObjectId": 547,
         "Sterbefall": null,
-        "Genesungsfall": 30114,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18857,7 +18857,7 @@
         "Fallzahl": 31697,
         "ObjectId": 548,
         "Sterbefall": null,
-        "Genesungsfall": 30128,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -18890,13 +18890,13 @@
         "Datum": "06.09.2021",
         "Fallzahl": 31713,
         "ObjectId": 549,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30148,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2689,
-        "Zuwachs_Fallzahl": 83,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": 46.1582671791372,
@@ -18905,13 +18905,13 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 43.5,
-        "Fallzahl_aktiv": 454,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 32,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 30.3,
@@ -18924,28 +18924,28 @@
         "Datum": "07.09.2021",
         "Fallzahl": 31785,
         "ObjectId": 550,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30207,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2695,
-        "Zuwachs_Fallzahl": 72,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
         "Inzidenz": 44.1826215022091,
         "Datum_neu": 1630972800000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 38.7,
-        "Fallzahl_aktiv": 467,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 13,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 29.3,
@@ -18958,32 +18958,32 @@
         "Datum": "08.09.2021",
         "Fallzahl": 31857,
         "ObjectId": 551,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30254,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2696,
-        "Zuwachs_Fallzahl": 72,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 47,
         "BelegteBetten": null,
         "Inzidenz": 55.8568914113294,
         "Datum_neu": 1631059200000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 48.7,
-        "Fallzahl_aktiv": 492,
-        "Krh_N_belegt": 98,
-        "Krh_I_belegt": 24,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 25,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 32.5,
-        "Mutation": 751,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -18992,32 +18992,32 @@
         "Datum": "09.09.2021",
         "Fallzahl": 31910,
         "ObjectId": 552,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30287,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2699,
-        "Zuwachs_Fallzahl": 53,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1631145600000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 50.7,
-        "Fallzahl_aktiv": 512,
-        "Krh_N_belegt": 90,
-        "Krh_I_belegt": 22,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 20,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 35.8,
-        "Mutation": 790,
+        "Mutation": null,
         "Zuwachs_Mutation": null
       }
     },
@@ -19026,32 +19026,134 @@
         "Datum": "10.09.2021",
         "Fallzahl": 31968,
         "ObjectId": 553,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30313,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2700,
-        "Zuwachs_Fallzahl": 58,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "03.09.2021 - 09.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 29,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 48.7,
-        "Fallzahl_aktiv": 544,
-        "Krh_N_belegt": 88,
-        "Krh_I_belegt": 28,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 32,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 37.8,
-        "Mutation": 805,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.09.2021",
+        "Fallzahl": 32048,
+        "ObjectId": 554,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 7,
+        "BelegteBetten": null,
+        "Inzidenz": 57.8325370882575,
+        "Datum_neu": 1631318400000,
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 52.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 39.5,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.09.2021",
+        "Fallzahl": 32054,
+        "ObjectId": 555,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 10,
+        "BelegteBetten": null,
+        "Inzidenz": 60.5265993749776,
+        "Datum_neu": 1631404800000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 52.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 41.2,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.09.2021",
+        "Fallzahl": 32062,
+        "ObjectId": 556,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30374,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2704,
+        "Zuwachs_Fallzahl": 94,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 61,
+        "BelegteBetten": null,
+        "Inzidenz": 59.9877869176335,
+        "Datum_neu": 1631491200000,
+        "F\u00e4lle_Meldedatum": 0,
+        "Zeitraum": "06.09.2021 - 12.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 59,
+        "Fallzahl_aktiv": 577,
+        "Krh_N_belegt": 79,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 33,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 43.6,
+        "Mutation": 856,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
