### PR TITLE
New data set: 2021-09-14T100702Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-13T102003Z.json
+pjson/2021-09-14T100702Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-13T102003Z.json pjson/2021-09-14T100702Z.json```:
```
--- pjson/2021-09-13T102003Z.json	2021-09-13 10:20:04.072226678 +0000
+++ pjson/2021-09-14T100702Z.json	2021-09-14 10:07:02.400451773 +0000
@@ -18530,7 +18530,7 @@
         "F\u00e4lle_Meldedatum": 35,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 32.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18540,7 +18540,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 17.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18564,7 +18564,7 @@
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 34.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18574,7 +18574,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 18.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18598,7 +18598,7 @@
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 33.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18608,7 +18608,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 18.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18632,7 +18632,7 @@
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 34.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18642,7 +18642,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 19.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18666,7 +18666,7 @@
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 35.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18676,7 +18676,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 20.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18700,7 +18700,7 @@
         "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 33.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18710,7 +18710,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 19.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18734,7 +18734,7 @@
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 32,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18744,7 +18744,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 19.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18768,7 +18768,7 @@
         "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 31.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18778,7 +18778,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 22.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18802,7 +18802,7 @@
         "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 34,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18812,7 +18812,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 25.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18833,7 +18833,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630713600000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 33.6,
@@ -18969,7 +18969,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.8568914113294,
         "Datum_neu": 1631059200000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 48.7,
@@ -19003,7 +19003,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1631145600000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 50.7,
@@ -19037,7 +19037,7 @@
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 29,
+        "F\u00e4lle_Meldedatum": 35,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 48.7,
@@ -19071,7 +19071,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 52.3,
@@ -19105,7 +19105,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1631404800000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 52.3,
@@ -19130,7 +19130,7 @@
         "ObjectId": 556,
         "Sterbefall": 1111,
         "Genesungsfall": 30374,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2704,
         "Zuwachs_Fallzahl": 94,
         "Zuwachs_Sterbefall": 0,
@@ -19139,13 +19139,13 @@
         "BelegteBetten": null,
         "Inzidenz": 59.9877869176335,
         "Datum_neu": 1631491200000,
-        "F\u00e4lle_Meldedatum": 0,
-        "Zeitraum": "06.09.2021 - 12.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 44,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 59,
         "Fallzahl_aktiv": 577,
-        "Krh_N_belegt": 79,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 33,
         "Krh_I": null,
@@ -19153,7 +19153,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 43.6,
-        "Mutation": 856,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.09.2021",
+        "Fallzahl": 32152,
+        "ObjectId": 557,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30412,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2706,
+        "Zuwachs_Fallzahl": 90,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 38,
+        "BelegteBetten": null,
+        "Inzidenz": 60.5265993749776,
+        "Datum_neu": 1631577600000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "07.09.2021 - 13.09.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 50.5,
+        "Fallzahl_aktiv": 629,
+        "Krh_N_belegt": 84,
+        "Krh_I_belegt": 35,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 52,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 40.1,
+        "Mutation": 864,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
