### PR TITLE
New data set: 2021-09-15T103004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-14T100702Z.json
+pjson/2021-09-15T103004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-14T100702Z.json pjson/2021-09-15T103004Z.json```:
```
--- pjson/2021-09-14T100702Z.json	2021-09-14 10:07:02.400451773 +0000
+++ pjson/2021-09-15T103004Z.json	2021-09-15 10:30:04.328399745 +0000
@@ -18523,7 +18523,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 32,
+        "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629936000000,
@@ -18795,7 +18795,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 23,
+        "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630627200000,
@@ -18836,7 +18836,7 @@
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 33.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18846,7 +18846,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 26.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18870,7 +18870,7 @@
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 40.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18880,7 +18880,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 29,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18897,14 +18897,14 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 51,
+        "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
-        "Inzidenz": 46.1582671791372,
+        "Inzidenz": null,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 43.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18914,7 +18914,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 30.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -18933,12 +18933,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
-        "Inzidenz": 44.1826215022091,
+        "Inzidenz": null,
         "Datum_neu": 1630972800000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 38.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -18948,7 +18948,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 29.3,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19003,7 +19003,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1631145600000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 50.7,
@@ -19037,7 +19037,7 @@
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 35,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 48.7,
@@ -19067,11 +19067,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 7,
+        "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 52.3,
@@ -19128,28 +19128,28 @@
         "Datum": "13.09.2021",
         "Fallzahl": 32062,
         "ObjectId": 556,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30374,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2704,
-        "Zuwachs_Fallzahl": 94,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
-        "Zuwachs_Genesung": 61,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 44,
         "BelegteBetten": null,
         "Inzidenz": 59.9877869176335,
         "Datum_neu": 1631491200000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 59,
-        "Fallzahl_aktiv": 577,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 33,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 43.6,
@@ -19164,7 +19164,7 @@
         "ObjectId": 557,
         "Sterbefall": 1111,
         "Genesungsfall": 30412,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2706,
         "Zuwachs_Fallzahl": 90,
         "Zuwachs_Sterbefall": 0,
@@ -19173,13 +19173,13 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "07.09.2021 - 13.09.2021",
+        "F\u00e4lle_Meldedatum": 43,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 50.5,
         "Fallzahl_aktiv": 629,
-        "Krh_N_belegt": 84,
-        "Krh_I_belegt": 35,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 52,
         "Krh_I": null,
@@ -19187,7 +19187,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 40.1,
-        "Mutation": 864,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.09.2021",
+        "Fallzahl": 32183,
+        "ObjectId": 558,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30451,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2706,
+        "Zuwachs_Fallzahl": 31,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 39,
+        "BelegteBetten": null,
+        "Inzidenz": 55.6772872588814,
+        "Datum_neu": 1631664000000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "08.09.2021 - 14.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 53.9,
+        "Fallzahl_aktiv": 621,
+        "Krh_N_belegt": 93,
+        "Krh_I_belegt": 39,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -8,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 36.8,
+        "Mutation": 881,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
