### PR TITLE
New data set: 2021-09-16T100104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-15T103004Z.json
+pjson/2021-09-16T100104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-15T103004Z.json pjson/2021-09-16T100104Z.json```:
```
--- pjson/2021-09-15T103004Z.json	2021-09-15 10:30:04.328399745 +0000
+++ pjson/2021-09-16T100104Z.json	2021-09-16 10:01:04.292721001 +0000
@@ -18697,7 +18697,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630368000000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -18901,7 +18901,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -18967,12 +18967,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 47,
         "BelegteBetten": null,
-        "Inzidenz": 55.8568914113294,
+        "Inzidenz": null,
         "Datum_neu": 1631059200000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 48.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19037,7 +19037,7 @@
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 48.7,
@@ -19139,7 +19139,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.9877869176335,
         "Datum_neu": 1631491200000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 59,
@@ -19162,28 +19162,28 @@
         "Datum": "14.09.2021",
         "Fallzahl": 32152,
         "ObjectId": 557,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30412,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2706,
-        "Zuwachs_Fallzahl": 90,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 38,
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 50.5,
-        "Fallzahl_aktiv": 629,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 52,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 40.1,
@@ -19198,7 +19198,7 @@
         "ObjectId": 558,
         "Sterbefall": 1111,
         "Genesungsfall": 30451,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2706,
         "Zuwachs_Fallzahl": 31,
         "Zuwachs_Sterbefall": 0,
@@ -19207,13 +19207,13 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 6,
-        "Zeitraum": "08.09.2021 - 14.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 53.9,
         "Fallzahl_aktiv": 621,
-        "Krh_N_belegt": 93,
-        "Krh_I_belegt": 39,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -8,
         "Krh_I": null,
@@ -19221,7 +19221,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 36.8,
-        "Mutation": 881,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.09.2021",
+        "Fallzahl": 32260,
+        "ObjectId": 559,
+        "Sterbefall": 1111,
+        "Genesungsfall": 30520,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2709,
+        "Zuwachs_Fallzahl": 77,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 69,
+        "BelegteBetten": null,
+        "Inzidenz": 52.0852042099213,
+        "Datum_neu": 1631750400000,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": "09.09.2021 - 15.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 49.3,
+        "Fallzahl_aktiv": 629,
+        "Krh_N_belegt": 93,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 8,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 38,
+        "Mutation": 920,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
