### PR TITLE
New data set: 2021-09-17T103004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-16T100104Z.json
+pjson/2021-09-17T103004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-16T100104Z.json pjson/2021-09-17T103004Z.json```:
```
--- pjson/2021-09-16T100104Z.json	2021-09-16 10:01:04.292721001 +0000
+++ pjson/2021-09-17T103004Z.json	2021-09-17 10:30:04.574927158 +0000
@@ -9857,7 +9857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 430,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9959,7 +9959,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 514,
+        "F\u00e4lle_Meldedatum": 513,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -9993,7 +9993,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -10061,7 +10061,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -10163,7 +10163,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 446,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -10401,7 +10401,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 449,
+        "F\u00e4lle_Meldedatum": 452,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -10809,7 +10809,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -12815,7 +12815,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -12883,7 +12883,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615593600000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -13801,7 +13801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 187,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -18323,7 +18323,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629417600000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -18335,7 +18335,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -18539,7 +18539,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -18663,7 +18663,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630281600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -18697,7 +18697,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630368000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -18743,7 +18743,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -18765,7 +18765,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630540800000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -18799,7 +18799,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630627200000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -18845,7 +18845,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -18935,7 +18935,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630972800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -18981,7 +18981,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 32.5,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -19039,7 +19039,7 @@
         "Datum_neu": 1631232000000,
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 48.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19139,7 +19139,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.9877869176335,
         "Datum_neu": 1631491200000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 59,
@@ -19173,7 +19173,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 50.5,
@@ -19196,26 +19196,26 @@
         "Datum": "15.09.2021",
         "Fallzahl": 32183,
         "ObjectId": 558,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30451,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2706,
-        "Zuwachs_Fallzahl": 31,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 39,
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 53.9,
-        "Fallzahl_aktiv": 621,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -8,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -19230,32 +19230,66 @@
         "Datum": "16.09.2021",
         "Fallzahl": 32260,
         "ObjectId": 559,
-        "Sterbefall": 1111,
-        "Genesungsfall": 30520,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2709,
-        "Zuwachs_Fallzahl": 77,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 69,
         "BelegteBetten": null,
         "Inzidenz": 52.0852042099213,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 38,
-        "Zeitraum": "09.09.2021 - 15.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 56,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 49.3,
-        "Fallzahl_aktiv": 629,
-        "Krh_N_belegt": 93,
-        "Krh_I_belegt": 36,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 38,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.09.2021",
+        "Fallzahl": 32306,
+        "ObjectId": 560,
+        "Sterbefall": 1116,
+        "Genesungsfall": 30540,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2709,
+        "Zuwachs_Fallzahl": 46,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 20,
+        "BelegteBetten": null,
+        "Inzidenz": 55.1384748015374,
+        "Datum_neu": 1631836800000,
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": "10.09.2021 - 16.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 52.1,
+        "Fallzahl_aktiv": 650,
+        "Krh_N_belegt": 92,
+        "Krh_I_belegt": 35,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 8,
+        "Fallzahl_aktiv_Zuwachs": 21,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 38,
-        "Mutation": 920,
+        "Inzi_SN_RKI": 37.9,
+        "Mutation": 946,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
