### PR TITLE
New data set: 2021-09-18T111004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-17T103004Z.json
+pjson/2021-09-18T111004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-17T103004Z.json pjson/2021-09-18T111004Z.json```:
```
--- pjson/2021-09-17T103004Z.json	2021-09-17 10:30:04.574927158 +0000
+++ pjson/2021-09-18T111004Z.json	2021-09-18 11:10:04.509340214 +0000
@@ -9857,7 +9857,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 430,
+        "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -12883,7 +12883,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615593600000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -18765,7 +18765,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630540800000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -18935,7 +18935,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630972800000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -18982,7 +18982,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 32.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19001,12 +19001,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
-        "Inzidenz": 57.8325370882575,
+        "Inzidenz": null,
         "Datum_neu": 1631145600000,
         "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 50.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19016,7 +19016,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 35.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19035,12 +19035,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
-        "Inzidenz": 54.2404540392974,
+        "Inzidenz": null,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 48.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19050,7 +19050,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 37.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19207,7 +19207,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 53.9,
@@ -19241,7 +19241,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.0852042099213,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 49.3,
@@ -19262,34 +19262,68 @@
     {
       "attributes": {
         "Datum": "17.09.2021",
-        "Fallzahl": 32306,
+        "Fallzahl": 32330,
         "ObjectId": 560,
-        "Sterbefall": 1116,
-        "Genesungsfall": 30540,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2709,
-        "Zuwachs_Fallzahl": 46,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
-        "Inzidenz": 55.1384748015374,
+        "Inzidenz": 55.6772872588814,
         "Datum_neu": 1631836800000,
-        "F\u00e4lle_Meldedatum": 19,
-        "Zeitraum": "10.09.2021 - 16.09.2021",
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 52.1,
-        "Fallzahl_aktiv": 650,
-        "Krh_N_belegt": 92,
-        "Krh_I_belegt": 35,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 21,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 37.9,
-        "Mutation": 946,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.09.2021",
+        "Fallzahl": 32346,
+        "ObjectId": 561,
+        "Sterbefall": 1116,
+        "Genesungsfall": 30581,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2709,
+        "Zuwachs_Fallzahl": 16,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 41,
+        "BelegteBetten": null,
+        "Inzidenz": 56.0364955637774,
+        "Datum_neu": 1631923200000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "11.09.2021 - 17.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 51.4,
+        "Fallzahl_aktiv": 649,
+        "Krh_N_belegt": 94,
+        "Krh_I_belegt": 33,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -25,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 36.6,
+        "Mutation": 970,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
