### PR TITLE
New data set: 2021-09-19T101304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-18T111004Z.json
+pjson/2021-09-19T101304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-18T111004Z.json pjson/2021-09-19T101304Z.json```:
```
--- pjson/2021-09-18T111004Z.json	2021-09-18 11:10:04.509340214 +0000
+++ pjson/2021-09-19T101304Z.json	2021-09-19 10:13:04.331145389 +0000
@@ -11183,7 +11183,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -12849,7 +12849,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -13801,7 +13801,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -19069,12 +19069,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 5,
         "BelegteBetten": null,
-        "Inzidenz": 57.8325370882575,
+        "Inzidenz": null,
         "Datum_neu": 1631318400000,
         "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 52.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19084,7 +19084,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 39.5,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19139,7 +19139,7 @@
         "BelegteBetten": null,
         "Inzidenz": 59.9877869176335,
         "Datum_neu": 1631491200000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 59,
@@ -19207,7 +19207,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 53.9,
@@ -19241,7 +19241,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.0852042099213,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 49.3,
@@ -19262,7 +19262,7 @@
     {
       "attributes": {
         "Datum": "17.09.2021",
-        "Fallzahl": 32330,
+        "Fallzahl": 32306,
         "ObjectId": 560,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -19273,9 +19273,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
-        "Inzidenz": 55.6772872588814,
+        "Inzidenz": 56.2160997162254,
         "Datum_neu": 1631836800000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 52.1,
@@ -19298,32 +19298,66 @@
         "Datum": "18.09.2021",
         "Fallzahl": 32346,
         "ObjectId": 561,
-        "Sterbefall": 1116,
-        "Genesungsfall": 30581,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2709,
-        "Zuwachs_Fallzahl": 16,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 41,
         "BelegteBetten": null,
-        "Inzidenz": 56.0364955637774,
+        "Inzidenz": 56.9345163260175,
         "Datum_neu": 1631923200000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "11.09.2021 - 17.09.2021",
+        "F\u00e4lle_Meldedatum": 30,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.4,
-        "Fallzahl_aktiv": 649,
-        "Krh_N_belegt": 94,
-        "Krh_I_belegt": 33,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -25,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 36.6,
-        "Mutation": 970,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.09.2021",
+        "Fallzahl": 32373,
+        "ObjectId": 562,
+        "Sterbefall": 1116,
+        "Genesungsfall": 30596,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2709,
+        "Zuwachs_Fallzahl": 27,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 15,
+        "BelegteBetten": null,
+        "Inzidenz": 52.2648083623693,
+        "Datum_neu": 1632009600000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "12.09.2021 - 18.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 42.2,
+        "Fallzahl_aktiv": 661,
+        "Krh_N_belegt": 91,
+        "Krh_I_belegt": 34,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 31.7,
+        "Mutation": 991,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
