### PR TITLE
New data set: 2021-09-20T101704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-19T101304Z.json
+pjson/2021-09-20T101704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-19T101304Z.json pjson/2021-09-20T101704Z.json```:
```
--- pjson/2021-09-19T101304Z.json	2021-09-19 10:13:04.331145389 +0000
+++ pjson/2021-09-20T101704Z.json	2021-09-20 10:17:04.164084401 +0000
@@ -18935,7 +18935,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630972800000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -19003,7 +19003,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631145600000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -19103,12 +19103,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 60.5265993749776,
+        "Inzidenz": null,
         "Datum_neu": 1631404800000,
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 52.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19118,7 +19118,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 41.2,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19334,7 +19334,7 @@
         "ObjectId": 562,
         "Sterbefall": 1116,
         "Genesungsfall": 30596,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2709,
         "Zuwachs_Fallzahl": 27,
         "Zuwachs_Sterbefall": 0,
@@ -19343,13 +19343,13 @@
         "BelegteBetten": null,
         "Inzidenz": 52.2648083623693,
         "Datum_neu": 1632009600000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "12.09.2021 - 18.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 42.2,
         "Fallzahl_aktiv": 661,
-        "Krh_N_belegt": 91,
-        "Krh_I_belegt": 34,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 12,
         "Krh_I": null,
@@ -19357,7 +19357,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 31.7,
-        "Mutation": 991,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.09.2021",
+        "Fallzahl": 32381,
+        "ObjectId": 563,
+        "Sterbefall": 1116,
+        "Genesungsfall": 30648,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2713,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 52,
+        "BelegteBetten": null,
+        "Inzidenz": 52.0852042099213,
+        "Datum_neu": 1632096000000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "13.09.2021 - 19.09.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 51.1,
+        "Fallzahl_aktiv": 617,
+        "Krh_N_belegt": 95,
+        "Krh_I_belegt": 35,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -44,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 39.9,
+        "Mutation": 992,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
