### PR TITLE
New data set: 2021-09-21T102303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-20T101704Z.json
+pjson/2021-09-21T102303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-20T101704Z.json pjson/2021-09-21T102303Z.json```:
```
--- pjson/2021-09-20T101704Z.json	2021-09-20 10:17:04.164084401 +0000
+++ pjson/2021-09-21T102303Z.json	2021-09-21 10:23:03.452658917 +0000
@@ -11183,7 +11183,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -13393,7 +13393,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616889600000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -19003,7 +19003,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631145600000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -19137,12 +19137,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 44,
         "BelegteBetten": null,
-        "Inzidenz": 59.9877869176335,
+        "Inzidenz": null,
         "Datum_neu": 1631491200000,
         "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 59,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19152,7 +19152,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 43.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19275,9 +19275,9 @@
         "BelegteBetten": null,
         "Inzidenz": 56.2160997162254,
         "Datum_neu": 1631836800000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 52.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19309,7 +19309,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.9345163260175,
         "Datum_neu": 1631923200000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.4,
@@ -19332,28 +19332,28 @@
         "Datum": "19.09.2021",
         "Fallzahl": 32373,
         "ObjectId": 562,
-        "Sterbefall": 1116,
-        "Genesungsfall": 30596,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2709,
-        "Zuwachs_Fallzahl": 27,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
         "Inzidenz": 52.2648083623693,
         "Datum_neu": 1632009600000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 42.2,
-        "Fallzahl_aktiv": 661,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 31.7,
@@ -19368,7 +19368,7 @@
         "ObjectId": 563,
         "Sterbefall": 1116,
         "Genesungsfall": 30648,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2713,
         "Zuwachs_Fallzahl": 8,
         "Zuwachs_Sterbefall": 0,
@@ -19377,13 +19377,13 @@
         "BelegteBetten": null,
         "Inzidenz": 52.0852042099213,
         "Datum_neu": 1632096000000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "13.09.2021 - 19.09.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 51.1,
         "Fallzahl_aktiv": 617,
-        "Krh_N_belegt": 95,
-        "Krh_I_belegt": 35,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -44,
         "Krh_I": null,
@@ -19391,7 +19391,41 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 39.9,
-        "Mutation": 992,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.09.2021",
+        "Fallzahl": 32446,
+        "ObjectId": 564,
+        "Sterbefall": 1116,
+        "Genesungsfall": 30728,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2719,
+        "Zuwachs_Fallzahl": 65,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 80,
+        "BelegteBetten": null,
+        "Inzidenz": 46.6970796364812,
+        "Datum_neu": 1632182400000,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": "14.09.2021 - 20.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 42.8,
+        "Fallzahl_aktiv": 602,
+        "Krh_N_belegt": 107,
+        "Krh_I_belegt": 35,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -15,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 36.8,
+        "Mutation": 1017,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
