### PR TITLE
New data set: 2021-09-22T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-21T102303Z.json
+pjson/2021-09-22T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-21T102303Z.json pjson/2021-09-22T100403Z.json```:
```
--- pjson/2021-09-21T102303Z.json	2021-09-21 10:23:03.452658917 +0000
+++ pjson/2021-09-22T100403Z.json	2021-09-22 10:04:03.320506546 +0000
@@ -19037,9 +19037,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19071,7 +19071,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -19141,7 +19141,7 @@
         "Datum_neu": 1631491200000,
         "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19173,7 +19173,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.5265993749776,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 50.5,
@@ -19207,9 +19207,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 53.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19241,7 +19241,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.0852042099213,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 49.3,
@@ -19275,7 +19275,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.2160997162254,
         "Datum_neu": 1631836800000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 52.1,
@@ -19309,7 +19309,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.9345163260175,
         "Datum_neu": 1631923200000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.4,
@@ -19343,7 +19343,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.2648083623693,
         "Datum_neu": 1632009600000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 42.2,
@@ -19366,26 +19366,26 @@
         "Datum": "20.09.2021",
         "Fallzahl": 32381,
         "ObjectId": 563,
-        "Sterbefall": 1116,
-        "Genesungsfall": 30648,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2713,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
         "Inzidenz": 52.0852042099213,
         "Datum_neu": 1632096000000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 51.1,
-        "Fallzahl_aktiv": 617,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -44,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -19400,32 +19400,66 @@
         "Datum": "21.09.2021",
         "Fallzahl": 32446,
         "ObjectId": 564,
-        "Sterbefall": 1116,
-        "Genesungsfall": 30728,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2719,
-        "Zuwachs_Fallzahl": 65,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 80,
         "BelegteBetten": null,
         "Inzidenz": 46.6970796364812,
         "Datum_neu": 1632182400000,
-        "F\u00e4lle_Meldedatum": 42,
-        "Zeitraum": "14.09.2021 - 20.09.2021",
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 42.8,
-        "Fallzahl_aktiv": 602,
-        "Krh_N_belegt": 107,
-        "Krh_I_belegt": 35,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -15,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 36.8,
-        "Mutation": 1017,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.09.2021",
+        "Fallzahl": 32502,
+        "ObjectId": 565,
+        "Sterbefall": 1116,
+        "Genesungsfall": 30788,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2721,
+        "Zuwachs_Fallzahl": 56,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 60,
+        "BelegteBetten": null,
+        "Inzidenz": 50.8279751427853,
+        "Datum_neu": 1632268800000,
+        "F\u00e4lle_Meldedatum": 28,
+        "Zeitraum": "15.09.2021 - 21.09.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 47.1,
+        "Fallzahl_aktiv": 598,
+        "Krh_N_belegt": 114,
+        "Krh_I_belegt": 37,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 35.3,
+        "Mutation": 1047,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
