### PR TITLE
New data set: 2021-09-23T103602Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-22T100403Z.json
+pjson/2021-09-23T103602Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-22T100403Z.json pjson/2021-09-23T103602Z.json```:
```
--- pjson/2021-09-22T100403Z.json	2021-09-22 10:04:03.320506546 +0000
+++ pjson/2021-09-23T103602Z.json	2021-09-23 10:36:02.830826018 +0000
@@ -18665,7 +18665,7 @@
         "Datum_neu": 1630281600000,
         "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19139,7 +19139,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631491200000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -19171,12 +19171,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 38,
         "BelegteBetten": null,
-        "Inzidenz": 60.5265993749776,
+        "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 50.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19186,7 +19186,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 40.1,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19205,12 +19205,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 39,
         "BelegteBetten": null,
-        "Inzidenz": 55.6772872588814,
+        "Inzidenz": null,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 53.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19220,7 +19220,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 36.8,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null
       }
@@ -19241,7 +19241,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.0852042099213,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 49.3,
@@ -19277,7 +19277,7 @@
         "Datum_neu": 1631836800000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 52.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19309,7 +19309,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.9345163260175,
         "Datum_neu": 1631923200000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.4,
@@ -19321,7 +19321,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": 36.6,
         "Mutation": null,
         "Zuwachs_Mutation": null
@@ -19411,7 +19411,7 @@
         "BelegteBetten": null,
         "Inzidenz": 46.6970796364812,
         "Datum_neu": 1632182400000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 42.8,
@@ -19434,32 +19434,66 @@
         "Datum": "22.09.2021",
         "Fallzahl": 32502,
         "ObjectId": 565,
-        "Sterbefall": 1116,
-        "Genesungsfall": 30788,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2721,
-        "Zuwachs_Fallzahl": 56,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
         "Inzidenz": 50.8279751427853,
         "Datum_neu": 1632268800000,
-        "F\u00e4lle_Meldedatum": 28,
-        "Zeitraum": "15.09.2021 - 21.09.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 47.1,
-        "Fallzahl_aktiv": 598,
-        "Krh_N_belegt": 114,
-        "Krh_I_belegt": 37,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -4,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 35.3,
-        "Mutation": 1047,
+        "Mutation": null,
+        "Zuwachs_Mutation": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.09.2021",
+        "Fallzahl": 32552,
+        "ObjectId": 566,
+        "Sterbefall": 1117,
+        "Genesungsfall": 30831,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2722,
+        "Zuwachs_Fallzahl": 50,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 43,
+        "BelegteBetten": null,
+        "Inzidenz": 52.4444125148173,
+        "Datum_neu": 1632355200000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "16.09.2021 - 22.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 51.6,
+        "Fallzahl_aktiv": 604,
+        "Krh_N_belegt": 104,
+        "Krh_I_belegt": 43,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 6,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 37.5,
+        "Mutation": 1071,
         "Zuwachs_Mutation": null
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
