### PR TITLE
New data set: 2021-09-24T102602Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-23T103602Z.json
+pjson/2021-09-24T102602Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-24T053402Z.json pjson/2021-09-24T102602Z.json```:
```
--- pjson/2021-09-24T053402Z.json	2021-09-24 05:34:02.605811448 +0000
+++ pjson/2021-09-24T102602Z.json	2021-09-24 10:26:03.031576476 +0000
@@ -9729,7 +9729,7 @@
         "Datum_neu": 1606867200000,
         "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9974,7 +9974,7 @@
         "Datum_neu": 1607472000000,
         "F\u00e4lle_Meldedatum": 396,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10009,7 +10009,7 @@
         "Datum_neu": 1607558400000,
         "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10079,7 +10079,7 @@
         "Datum_neu": 1607731200000,
         "F\u00e4lle_Meldedatum": 338,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10114,7 +10114,7 @@
         "Datum_neu": 1607817600000,
         "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10184,7 +10184,7 @@
         "Datum_neu": 1607990400000,
         "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 41,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10219,7 +10219,7 @@
         "Datum_neu": 1608076800000,
         "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10289,7 +10289,7 @@
         "Datum_neu": 1608249600000,
         "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10359,7 +10359,7 @@
         "Datum_neu": 1608422400000,
         "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10429,7 +10429,7 @@
         "Datum_neu": 1608595200000,
         "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10464,7 +10464,7 @@
         "Datum_neu": 1608681600000,
         "F\u00e4lle_Meldedatum": 446,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10499,7 +10499,7 @@
         "Datum_neu": 1608768000000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10534,7 +10534,7 @@
         "Datum_neu": 1608854400000,
         "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10569,7 +10569,7 @@
         "Datum_neu": 1608940800000,
         "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10604,7 +10604,7 @@
         "Datum_neu": 1609027200000,
         "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10639,7 +10639,7 @@
         "Datum_neu": 1609113600000,
         "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 46,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10674,7 +10674,7 @@
         "Datum_neu": 1609200000000,
         "F\u00e4lle_Meldedatum": 574,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10709,7 +10709,7 @@
         "Datum_neu": 1609286400000,
         "F\u00e4lle_Meldedatum": 452,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10744,7 +10744,7 @@
         "Datum_neu": 1609372800000,
         "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10779,7 +10779,7 @@
         "Datum_neu": 1609459200000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10814,7 +10814,7 @@
         "Datum_neu": 1609545600000,
         "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10919,7 +10919,7 @@
         "Datum_neu": 1609804800000,
         "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10954,7 +10954,7 @@
         "Datum_neu": 1609891200000,
         "F\u00e4lle_Meldedatum": 346,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -10989,7 +10989,7 @@
         "Datum_neu": 1609977600000,
         "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11024,7 +11024,7 @@
         "Datum_neu": 1610064000000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11129,7 +11129,7 @@
         "Datum_neu": 1610323200000,
         "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11164,7 +11164,7 @@
         "Datum_neu": 1610409600000,
         "F\u00e4lle_Meldedatum": 269,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11199,7 +11199,7 @@
         "Datum_neu": 1610496000000,
         "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11269,7 +11269,7 @@
         "Datum_neu": 1610668800000,
         "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11374,7 +11374,7 @@
         "Datum_neu": 1610928000000,
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11444,7 +11444,7 @@
         "Datum_neu": 1611100800000,
         "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11479,7 +11479,7 @@
         "Datum_neu": 1611187200000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11514,7 +11514,7 @@
         "Datum_neu": 1611273600000,
         "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11619,7 +11619,7 @@
         "Datum_neu": 1611532800000,
         "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11654,7 +11654,7 @@
         "Datum_neu": 1611619200000,
         "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11689,7 +11689,7 @@
         "Datum_neu": 1611705600000,
         "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11759,7 +11759,7 @@
         "Datum_neu": 1611878400000,
         "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11794,7 +11794,7 @@
         "Datum_neu": 1611964800000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11899,7 +11899,7 @@
         "Datum_neu": 1612224000000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11934,7 +11934,7 @@
         "Datum_neu": 1612310400000,
         "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11969,7 +11969,7 @@
         "Datum_neu": 1612396800000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12074,7 +12074,7 @@
         "Datum_neu": 1612656000000,
         "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12109,7 +12109,7 @@
         "Datum_neu": 1612742400000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12144,7 +12144,7 @@
         "Datum_neu": 1612828800000,
         "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12179,7 +12179,7 @@
         "Datum_neu": 1612915200000,
         "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12249,7 +12249,7 @@
         "Datum_neu": 1613088000000,
         "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12319,7 +12319,7 @@
         "Datum_neu": 1613260800000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12424,7 +12424,7 @@
         "Datum_neu": 1613520000000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12459,7 +12459,7 @@
         "Datum_neu": 1613606400000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12599,7 +12599,7 @@
         "Datum_neu": 1613952000000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12634,7 +12634,7 @@
         "Datum_neu": 1614038400000,
         "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12669,7 +12669,7 @@
         "Datum_neu": 1614124800000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12774,7 +12774,7 @@
         "Datum_neu": 1614384000000,
         "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12844,7 +12844,7 @@
         "Datum_neu": 1614556800000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12879,7 +12879,7 @@
         "Datum_neu": 1614643200000,
         "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12914,7 +12914,7 @@
         "Datum_neu": 1614729600000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12949,7 +12949,7 @@
         "Datum_neu": 1614816000000,
         "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12984,7 +12984,7 @@
         "Datum_neu": 1614902400000,
         "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13019,7 +13019,7 @@
         "Datum_neu": 1614988800000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13089,7 +13089,7 @@
         "Datum_neu": 1615161600000,
         "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13229,7 +13229,7 @@
         "Datum_neu": 1615507200000,
         "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13299,7 +13299,7 @@
         "Datum_neu": 1615680000000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13334,7 +13334,7 @@
         "Datum_neu": 1615766400000,
         "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13369,7 +13369,7 @@
         "Datum_neu": 1615852800000,
         "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13439,7 +13439,7 @@
         "Datum_neu": 1616025600000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13474,7 +13474,7 @@
         "Datum_neu": 1616112000000,
         "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13509,7 +13509,7 @@
         "Datum_neu": 1616198400000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13544,7 +13544,7 @@
         "Datum_neu": 1616284800000,
         "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13684,7 +13684,7 @@
         "Datum_neu": 1616630400000,
         "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13719,7 +13719,7 @@
         "Datum_neu": 1616716800000,
         "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13754,7 +13754,7 @@
         "Datum_neu": 1616803200000,
         "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13859,7 +13859,7 @@
         "Datum_neu": 1617062400000,
         "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13894,7 +13894,7 @@
         "Datum_neu": 1617148800000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13929,7 +13929,7 @@
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13964,7 +13964,7 @@
         "Datum_neu": 1617321600000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13999,7 +13999,7 @@
         "Datum_neu": 1617408000000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14069,7 +14069,7 @@
         "Datum_neu": 1617580800000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14104,7 +14104,7 @@
         "Datum_neu": 1617667200000,
         "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14139,7 +14139,7 @@
         "Datum_neu": 1617753600000,
         "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14209,7 +14209,7 @@
         "Datum_neu": 1617926400000,
         "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14244,7 +14244,7 @@
         "Datum_neu": 1618012800000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14314,7 +14314,7 @@
         "Datum_neu": 1618185600000,
         "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14384,7 +14384,7 @@
         "Datum_neu": 1618358400000,
         "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14594,7 +14594,7 @@
         "Datum_neu": 1618876800000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14664,7 +14664,7 @@
         "Datum_neu": 1619049600000,
         "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14944,7 +14944,7 @@
         "Datum_neu": 1619740800000,
         "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15539,7 +15539,7 @@
         "Datum_neu": 1621209600000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15574,7 +15574,7 @@
         "Datum_neu": 1621296000000,
         "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15609,7 +15609,7 @@
         "Datum_neu": 1621382400000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15644,7 +15644,7 @@
         "Datum_neu": 1621468800000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15714,7 +15714,7 @@
         "Datum_neu": 1621641600000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15819,7 +15819,7 @@
         "Datum_neu": 1621900800000,
         "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16274,7 +16274,7 @@
         "Datum_neu": 1623024000000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16344,7 +16344,7 @@
         "Datum_neu": 1623196800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16414,7 +16414,7 @@
         "Datum_neu": 1623369600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19214,7 +19214,7 @@
         "Datum_neu": 1630281600000,
         "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19457,7 +19457,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -19527,7 +19527,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631059200000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -19632,7 +19632,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -19704,7 +19704,7 @@
         "Datum_neu": 1631491200000,
         "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19772,7 +19772,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -19805,12 +19805,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 69,
         "BelegteBetten": null,
-        "Inzidenz": 52.0852042099213,
+        "Inzidenz": null,
         "Datum_neu": 1631750400000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 49.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -19820,7 +19820,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 38,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": null
@@ -19844,7 +19844,7 @@
         "Datum_neu": 1631836800000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 52.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19877,7 +19877,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.9345163260175,
         "Datum_neu": 1631923200000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.4,
@@ -19893,7 +19893,7 @@
         "Inzi_SN_RKI": 36.6,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.5
+        "H_Inzidenz": null
       }
     },
     {
@@ -19912,7 +19912,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.2648083623693,
         "Datum_neu": 1632009600000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 42.2,
@@ -19928,7 +19928,7 @@
         "Inzi_SN_RKI": 31.7,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.28
+        "H_Inzidenz": null
       }
     },
     {
@@ -19963,7 +19963,7 @@
         "Inzi_SN_RKI": 39.9,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23
+        "H_Inzidenz": null
       }
     },
     {
@@ -19982,7 +19982,7 @@
         "BelegteBetten": null,
         "Inzidenz": 46.6970796364812,
         "Datum_neu": 1632182400000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 42.8,
@@ -19998,7 +19998,7 @@
         "Inzi_SN_RKI": 36.8,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.16
+        "H_Inzidenz": null
       }
     },
     {
@@ -20017,7 +20017,7 @@
         "BelegteBetten": null,
         "Inzidenz": 50.8279751427853,
         "Datum_neu": 1632268800000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 47.1,
@@ -20033,7 +20033,7 @@
         "Inzi_SN_RKI": 35.3,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.11
+        "H_Inzidenz": null
       }
     },
     {
@@ -20041,34 +20041,69 @@
         "Datum": "23.09.2021",
         "Fallzahl": 32552,
         "ObjectId": 566,
-        "Sterbefall": 1117,
-        "Genesungsfall": 30831,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2722,
-        "Zuwachs_Fallzahl": 50,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
         "Inzidenz": 52.4444125148173,
         "Datum_neu": 1632355200000,
-        "F\u00e4lle_Meldedatum": 25,
-        "Zeitraum": "16.09.2021 - 22.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 51.6,
-        "Fallzahl_aktiv": 604,
-        "Krh_N_belegt": 104,
-        "Krh_I_belegt": 43,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 6,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 37.5,
-        "Mutation": 1071,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.09.2021",
+        "Fallzahl": 32607,
+        "ObjectId": 567,
+        "Sterbefall": 1117,
+        "Genesungsfall": 30875,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2725,
+        "Zuwachs_Fallzahl": 55,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 44,
+        "BelegteBetten": null,
+        "Inzidenz": 55.4976831064334,
+        "Datum_neu": 1632441600000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "17.09.2021 - 23.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 52.3,
+        "Fallzahl_aktiv": 615,
+        "Krh_N_belegt": 116,
+        "Krh_I_belegt": 39,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 38.3,
+        "Mutation": 1094,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.96
+        "H_Inzidenz": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
