### PR TITLE
New data set: 2021-09-25T103403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-24T103302Z.json
+pjson/2021-09-25T103403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-24T104803Z.json pjson/2021-09-25T103403Z.json```:
```
--- pjson/2021-09-24T104803Z.json	2021-09-24 10:48:03.571139579 +0000
+++ pjson/2021-09-25T103403Z.json	2021-09-25 10:34:03.760738002 +0000
@@ -13948,7 +13948,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615420800000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -20349,7 +20349,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630368000000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -20386,7 +20386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630454400000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -20571,7 +20571,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -20756,7 +20756,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -20867,7 +20867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -20941,7 +20941,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -20976,12 +20976,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
-        "Inzidenz": 56.2160997162254,
+        "Inzidenz": null,
         "Datum_neu": 1631836800000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 52.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -20991,7 +20991,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 37.9,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": null,
@@ -21015,7 +21015,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.9345163260175,
         "Datum_neu": 1631923200000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.4,
@@ -21031,7 +21031,7 @@
         "Inzi_SN_RKI": 36.6,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.5,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21068,7 +21068,7 @@
         "Inzi_SN_RKI": 31.7,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.28,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21105,7 +21105,7 @@
         "Inzi_SN_RKI": 39.9,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21126,7 +21126,7 @@
         "BelegteBetten": null,
         "Inzidenz": 46.6970796364812,
         "Datum_neu": 1632182400000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 42.8,
@@ -21142,7 +21142,7 @@
         "Inzi_SN_RKI": 36.8,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.16,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21179,7 +21179,7 @@
         "Inzi_SN_RKI": 35.3,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.11,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21200,9 +21200,9 @@
         "BelegteBetten": null,
         "Inzidenz": 52.4444125148173,
         "Datum_neu": 1632355200000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21216,7 +21216,7 @@
         "Inzi_SN_RKI": 37.5,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.96,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21228,7 +21228,7 @@
         "ObjectId": 567,
         "Sterbefall": 1117,
         "Genesungsfall": 30875,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2725,
         "Zuwachs_Fallzahl": 55,
         "Zuwachs_Sterbefall": 0,
@@ -21237,13 +21237,13 @@
         "BelegteBetten": null,
         "Inzidenz": 55.4976831064334,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "17.09.2021 - 23.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 52.3,
         "Fallzahl_aktiv": 615,
-        "Krh_N_belegt": 116,
-        "Krh_I_belegt": 39,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 11,
         "Krh_I": null,
@@ -21251,11 +21251,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 38.3,
-        "Mutation": 1094,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.09.2021",
+        "Fallzahl": 32644,
+        "ObjectId": 568,
+        "Sterbefall": 1117,
+        "Genesungsfall": 30924,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2727,
+        "Zuwachs_Fallzahl": 37,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 49,
+        "BelegteBetten": null,
+        "Inzidenz": 51.9056000574733,
+        "Datum_neu": 1632528000000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "18.09.2021 - 24.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 45.8,
+        "Fallzahl_aktiv": 603,
+        "Krh_N_belegt": 121,
+        "Krh_I_belegt": 64,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 38.9,
+        "Mutation": 1099,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.89,
-        "H_Zeitraum": "16.09. - 22.09.2021",
-        "H_Datum": "22.09.2021"
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
