### PR TITLE
New data set: 2021-09-26T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-25T103403Z.json
+pjson/2021-09-26T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-25T103403Z.json pjson/2021-09-26T100203Z.json```:
```
--- pjson/2021-09-25T103403Z.json	2021-09-25 10:34:03.760738002 +0000
+++ pjson/2021-09-26T100203Z.json	2021-09-26 10:02:03.261854781 +0000
@@ -13393,7 +13393,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614124800000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -20756,7 +20756,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21013,12 +21013,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 41,
         "BelegteBetten": null,
-        "Inzidenz": 56.9345163260175,
+        "Inzidenz": null,
         "Datum_neu": 1631923200000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 51.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21028,7 +21028,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
-        "Inzi_SN_RKI": 36.6,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": null,
@@ -21226,28 +21226,28 @@
         "Datum": "24.09.2021",
         "Fallzahl": 32607,
         "ObjectId": 567,
-        "Sterbefall": 1117,
-        "Genesungsfall": 30875,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2725,
-        "Zuwachs_Fallzahl": 55,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 44,
         "BelegteBetten": null,
         "Inzidenz": 55.4976831064334,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 33,
+        "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 52.3,
-        "Fallzahl_aktiv": 615,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 38.3,
@@ -21265,7 +21265,7 @@
         "ObjectId": 568,
         "Sterbefall": 1117,
         "Genesungsfall": 30924,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2727,
         "Zuwachs_Fallzahl": 37,
         "Zuwachs_Sterbefall": 0,
@@ -21274,13 +21274,13 @@
         "BelegteBetten": null,
         "Inzidenz": 51.9056000574733,
         "Datum_neu": 1632528000000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "18.09.2021 - 24.09.2021",
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 45.8,
         "Fallzahl_aktiv": 603,
-        "Krh_N_belegt": 121,
-        "Krh_I_belegt": 64,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -12,
         "Krh_I": null,
@@ -21288,7 +21288,44 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 38.9,
-        "Mutation": 1099,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.09.2021",
+        "Fallzahl": 32664,
+        "ObjectId": 569,
+        "Sterbefall": 1117,
+        "Genesungsfall": 30933,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2727,
+        "Zuwachs_Fallzahl": 20,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 9,
+        "BelegteBetten": null,
+        "Inzidenz": 53.8812457344014,
+        "Datum_neu": 1632614400000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "19.09.2021 - 25.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 49.3,
+        "Fallzahl_aktiv": 614,
+        "Krh_N_belegt": 98,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 40.8,
+        "Mutation": 1112,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": null,
         "H_Zeitraum": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
