### PR TITLE
New data set: 2021-09-27T101503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-26T100203Z.json
+pjson/2021-09-27T101503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-26T100203Z.json pjson/2021-09-27T101503Z.json```:
```
--- pjson/2021-09-26T100203Z.json	2021-09-26 10:02:03.261854781 +0000
+++ pjson/2021-09-27T101503Z.json	2021-09-27 10:15:03.566373447 +0000
@@ -20904,7 +20904,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21015,7 +21015,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631923200000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -21050,12 +21050,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
-        "Inzidenz": 52.2648083623693,
+        "Inzidenz": null,
         "Datum_neu": 1632009600000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 42.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21065,7 +21065,7 @@
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": 31.7,
+        "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": null,
@@ -21237,9 +21237,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.4976831064334,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 52.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21263,26 +21263,26 @@
         "Datum": "25.09.2021",
         "Fallzahl": 32644,
         "ObjectId": 568,
-        "Sterbefall": 1117,
-        "Genesungsfall": 30924,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2727,
-        "Zuwachs_Fallzahl": 37,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
         "Inzidenz": 51.9056000574733,
         "Datum_neu": 1632528000000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 45.8,
-        "Fallzahl_aktiv": 603,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -21302,7 +21302,7 @@
         "ObjectId": 569,
         "Sterbefall": 1117,
         "Genesungsfall": 30933,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2727,
         "Zuwachs_Fallzahl": 20,
         "Zuwachs_Sterbefall": 0,
@@ -21311,13 +21311,13 @@
         "BelegteBetten": null,
         "Inzidenz": 53.8812457344014,
         "Datum_neu": 1632614400000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "19.09.2021 - 25.09.2021",
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 49.3,
         "Fallzahl_aktiv": 614,
-        "Krh_N_belegt": 98,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 11,
         "Krh_I": null,
@@ -21325,6 +21325,43 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": 40.8,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.09.2021",
+        "Fallzahl": 32675,
+        "ObjectId": 570,
+        "Sterbefall": 1117,
+        "Genesungsfall": 30991,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2731,
+        "Zuwachs_Fallzahl": 11,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 58,
+        "BelegteBetten": null,
+        "Inzidenz": 52.6240166672654,
+        "Datum_neu": 1632700800000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": "20.09.2021 - 26.09.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 51.2,
+        "Fallzahl_aktiv": 567,
+        "Krh_N_belegt": 101,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -47,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": 42.5,
         "Mutation": 1112,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
