### PR TITLE
New data set: 2021-09-27T195004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-27T101503Z.json
+pjson/2021-09-27T195004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-27T152102Z.json pjson/2021-09-27T195004Z.json```:
```
--- pjson/2021-09-27T152102Z.json	2021-09-27 15:21:02.542744825 +0000
+++ pjson/2021-09-27T195004Z.json	2021-09-27 19:50:04.139579925 +0000
@@ -21179,7 +21179,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.8,
+        "H_Inzidenz": 1.48,
         "H_Zeitraum": null,
         "H_Datum": null
       }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
