### PR TITLE
New data set: 2021-09-28T101903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-27T101503Z.json
+pjson/2021-09-28T101903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-27T195004Z.json pjson/2021-09-28T101903Z.json```:
```
--- pjson/2021-09-27T195004Z.json	2021-09-27 19:50:04.139579925 +0000
+++ pjson/2021-09-28T101903Z.json	2021-09-28 10:19:03.181492732 +0000
@@ -20386,7 +20386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630454400000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -20756,7 +20756,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -20978,7 +20978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631836800000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -21087,12 +21087,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
-        "Inzidenz": 52.0852042099213,
+        "Inzidenz": null,
         "Datum_neu": 1632096000000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 51.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21105,7 +21105,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21126,7 +21126,7 @@
         "BelegteBetten": null,
         "Inzidenz": 46.6970796364812,
         "Datum_neu": 1632182400000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 42.8,
@@ -21142,7 +21142,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.65,
+        "H_Inzidenz": 1.68,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21163,7 +21163,7 @@
         "BelegteBetten": null,
         "Inzidenz": 50.8279751427853,
         "Datum_neu": 1632268800000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 47.1,
@@ -21179,7 +21179,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.48,
+        "H_Inzidenz": 1.53,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21200,7 +21200,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.4444125148173,
         "Datum_neu": 1632355200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.6,
@@ -21216,7 +21216,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.43,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21237,9 +21237,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.4976831064334,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 52.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21253,7 +21253,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.28,
+        "H_Inzidenz": 1.36,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21274,7 +21274,7 @@
         "BelegteBetten": null,
         "Inzidenz": 51.9056000574733,
         "Datum_neu": 1632528000000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 45.8,
@@ -21290,7 +21290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.04,
+        "H_Inzidenz": 1.18,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21300,34 +21300,34 @@
         "Datum": "26.09.2021",
         "Fallzahl": 32664,
         "ObjectId": 569,
-        "Sterbefall": 1117,
-        "Genesungsfall": 30933,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2727,
-        "Zuwachs_Fallzahl": 20,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": 53.8812457344014,
         "Datum_neu": 1632614400000,
-        "F\u00e4lle_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 49.3,
-        "Fallzahl_aktiv": 614,
-        "Krh_N_belegt": 98,
-        "Krh_I_belegt": 48,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1112,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.91,
+        "H_Inzidenz": 1.13,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21339,7 +21339,7 @@
         "ObjectId": 570,
         "Sterbefall": 1117,
         "Genesungsfall": 30991,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2731,
         "Zuwachs_Fallzahl": 11,
         "Zuwachs_Sterbefall": 0,
@@ -21348,13 +21348,13 @@
         "BelegteBetten": null,
         "Inzidenz": 52.6240166672654,
         "Datum_neu": 1632700800000,
-        "F\u00e4lle_Meldedatum": 5,
-        "Zeitraum": "20.09.2021 - 26.09.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.2,
         "Fallzahl_aktiv": 567,
-        "Krh_N_belegt": 101,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -47,
         "Krh_I": null,
@@ -21362,11 +21362,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1112,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.18,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.09.2021",
+        "Fallzahl": 32725,
+        "ObjectId": 571,
+        "Sterbefall": 1117,
+        "Genesungsfall": 31040,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2732,
+        "Zuwachs_Fallzahl": 50,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 49,
+        "BelegteBetten": null,
+        "Inzidenz": 50.6483709903373,
+        "Datum_neu": 1632787200000,
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": "21.09.2021 - 27.09.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 48.9,
+        "Fallzahl_aktiv": 568,
+        "Krh_N_belegt": 103,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1118,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.96,
-        "H_Zeitraum": "20.09.2021 - 26.09.2021",
-        "H_Datum": "26.09.2021"
+        "H_Inzidenz": 0.86,
+        "H_Zeitraum": "21.09.2021 - 27.09.2021",
+        "H_Datum": "27.09.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
