### PR TITLE
New data set: 2021-09-29T104102Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-28T101903Z.json
+pjson/2021-09-29T104102Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-28T101903Z.json pjson/2021-09-29T104102Z.json```:
```
--- pjson/2021-09-28T101903Z.json	2021-09-28 10:19:03.181492732 +0000
+++ pjson/2021-09-29T104102Z.json	2021-09-29 10:41:02.994980673 +0000
@@ -20361,7 +20361,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -20472,7 +20472,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -21089,7 +21089,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632096000000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -21124,12 +21124,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 80,
         "BelegteBetten": null,
-        "Inzidenz": 46.6970796364812,
+        "Inzidenz": null,
         "Datum_neu": 1632182400000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 42.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21142,7 +21142,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21163,7 +21163,7 @@
         "BelegteBetten": null,
         "Inzidenz": 50.8279751427853,
         "Datum_neu": 1632268800000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 47.1,
@@ -21179,7 +21179,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": 1.7,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21200,7 +21200,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.4444125148173,
         "Datum_neu": 1632355200000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.6,
@@ -21216,7 +21216,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.43,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21237,7 +21237,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.4976831064334,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 52.3,
@@ -21253,7 +21253,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.36,
+        "H_Inzidenz": 1.53,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21290,7 +21290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.18,
+        "H_Inzidenz": 1.31,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21311,7 +21311,7 @@
         "BelegteBetten": null,
         "Inzidenz": 53.8812457344014,
         "Datum_neu": 1632614400000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 49.3,
@@ -21327,7 +21327,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.13,
+        "H_Inzidenz": 1.26,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21337,26 +21337,26 @@
         "Datum": "27.09.2021",
         "Fallzahl": 32675,
         "ObjectId": 570,
-        "Sterbefall": 1117,
-        "Genesungsfall": 30991,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2731,
-        "Zuwachs_Fallzahl": 11,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 58,
         "BelegteBetten": null,
         "Inzidenz": 52.6240166672654,
         "Datum_neu": 1632700800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.2,
-        "Fallzahl_aktiv": 567,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -47,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -21364,7 +21364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.18,
+        "H_Inzidenz": 1.36,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21376,7 +21376,7 @@
         "ObjectId": 571,
         "Sterbefall": 1117,
         "Genesungsfall": 31040,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2732,
         "Zuwachs_Fallzahl": 50,
         "Zuwachs_Sterbefall": 0,
@@ -21385,8 +21385,8 @@
         "BelegteBetten": null,
         "Inzidenz": 50.6483709903373,
         "Datum_neu": 1632787200000,
-        "F\u00e4lle_Meldedatum": 36,
-        "Zeitraum": "21.09.2021 - 27.09.2021",
+        "F\u00e4lle_Meldedatum": 78,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 48.9,
         "Fallzahl_aktiv": 568,
@@ -21401,9 +21401,46 @@
         "Inzi_SN_RKI": null,
         "Mutation": 1118,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.86,
+        "H_Inzidenz": 1.01,
         "H_Zeitraum": "21.09.2021 - 27.09.2021",
-        "H_Datum": "27.09.2021"
+        "H_Datum": "20210927"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.09.2021",
+        "Fallzahl": 32859,
+        "ObjectId": 572,
+        "Sterbefall": 1119,
+        "Genesungsfall": 31041,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2732,
+        "Zuwachs_Fallzahl": 134,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 60.1673910700815,
+        "Datum_neu": 1632873600000,
+        "F\u00e4lle_Meldedatum": 54,
+        "Zeitraum": "22.09.2021 - 28.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 53.4,
+        "Fallzahl_aktiv": 699,
+        "Krh_N_belegt": 116,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 131,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1124,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.79,
+        "H_Zeitraum": "22.09.2021 - 28.09.2021",
+        "H_Datum": "20210928"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
