### PR TITLE
New data set: 2021-09-30T100902Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-29T164003Z.json
+pjson/2021-09-30T100902Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-29T164003Z.json pjson/2021-09-30T100902Z.json```:
```
--- pjson/2021-09-29T164003Z.json	2021-09-29 16:40:03.122734380 +0000
+++ pjson/2021-09-30T100902Z.json	2021-09-30 10:09:03.032310936 +0000
@@ -11580,7 +11580,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 346,
+        "F\u00e4lle_Meldedatum": 347,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -20386,7 +20386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630454400000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -20571,7 +20571,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -20756,7 +20756,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -20867,7 +20867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21126,7 +21126,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632182400000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -21161,12 +21161,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
-        "Inzidenz": 50.8279751427853,
+        "Inzidenz": null,
         "Datum_neu": 1632268800000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 47.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21179,7 +21179,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21200,7 +21200,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.4444125148173,
         "Datum_neu": 1632355200000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.6,
@@ -21237,7 +21237,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.4976831064334,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 52.3,
@@ -21274,9 +21274,9 @@
         "BelegteBetten": null,
         "Inzidenz": 51.9056000574733,
         "Datum_neu": 1632528000000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 45.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21348,9 +21348,9 @@
         "BelegteBetten": null,
         "Inzidenz": 52.6240166672654,
         "Datum_neu": 1632700800000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 51.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21374,36 +21374,36 @@
         "Datum": "28.09.2021",
         "Fallzahl": 32725,
         "ObjectId": 571,
-        "Sterbefall": 1117,
-        "Genesungsfall": 31040,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2732,
-        "Zuwachs_Fallzahl": 50,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
         "Inzidenz": 50.6483709903373,
         "Datum_neu": 1632787200000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 48.9,
-        "Fallzahl_aktiv": 568,
-        "Krh_N_belegt": 103,
-        "Krh_I_belegt": 50,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1118,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.01,
-        "H_Zeitraum": "21.09.2021 - 27.09.2021",
-        "H_Datum": "20210927"
+        "H_Zeitraum": null,
+        "H_Datum": null
       }
     },
     {
@@ -21413,7 +21413,7 @@
         "ObjectId": 572,
         "Sterbefall": 1119,
         "Genesungsfall": 31083,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2732,
         "Zuwachs_Fallzahl": 134,
         "Zuwachs_Sterbefall": 2,
@@ -21422,13 +21422,13 @@
         "BelegteBetten": null,
         "Inzidenz": 60.1673910700815,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 54,
-        "Zeitraum": "22.09.2021 - 28.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 82,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.4,
         "Fallzahl_aktiv": 657,
-        "Krh_N_belegt": 116,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 89,
         "Krh_I": null,
@@ -21436,11 +21436,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1124,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.79,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.09.2021",
+        "Fallzahl": 32916,
+        "ObjectId": 573,
+        "Sterbefall": 1119,
+        "Genesungsfall": 31137,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2738,
+        "Zuwachs_Fallzahl": 57,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 54,
+        "BelegteBetten": null,
+        "Inzidenz": 63.2206616616976,
+        "Datum_neu": 1632960000000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "23.09.2021 - 29.09.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 59.5,
+        "Fallzahl_aktiv": 660,
+        "Krh_N_belegt": 138,
+        "Krh_I_belegt": 41,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1157,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 0.79,
         "H_Zeitraum": "22.09.2021 - 28.09.2021",
-        "H_Datum": "20210928"
+        "H_Datum": "44468.0"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
