### PR TITLE
New data set: 2021-09-30T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-29T164003Z.json
+pjson/2021-09-30T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-30T100902Z.json pjson/2021-09-30T101103Z.json```:
```
--- pjson/2021-09-30T100902Z.json	2021-09-30 10:09:03.032310936 +0000
+++ pjson/2021-09-30T101103Z.json	2021-09-30 10:11:03.096308789 +0000
@@ -21477,7 +21477,7 @@
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 0.79,
         "H_Zeitraum": "22.09.2021 - 28.09.2021",
-        "H_Datum": "44468.0"
+        "H_Datum": "29.09.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
