### PR TITLE
New data set: 2021-10-01T104902Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-09-30T101103Z.json
+pjson/2021-10-01T104902Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-09-30T101103Z.json pjson/2021-10-01T104902Z.json```:
```
--- pjson/2021-09-30T101103Z.json	2021-09-30 10:11:03.096308789 +0000
+++ pjson/2021-10-01T104902Z.json	2021-10-01 10:49:02.983302760 +0000
@@ -21163,7 +21163,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632268800000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -21198,12 +21198,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 52.4444125148173,
+        "Inzidenz": null,
         "Datum_neu": 1632355200000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 51.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21216,7 +21216,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21237,9 +21237,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.4976831064334,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 52.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21253,7 +21253,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": 1.6,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21290,7 +21290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.31,
+        "H_Inzidenz": 1.4,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21327,7 +21327,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.26,
+        "H_Inzidenz": 1.36,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21348,7 +21348,7 @@
         "BelegteBetten": null,
         "Inzidenz": 52.6240166672654,
         "Datum_neu": 1632700800000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 51.2,
@@ -21364,7 +21364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.36,
+        "H_Inzidenz": 1.45,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21401,7 +21401,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.01,
+        "H_Inzidenz": 1.13,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21411,34 +21411,34 @@
         "Datum": "29.09.2021",
         "Fallzahl": 32859,
         "ObjectId": 572,
-        "Sterbefall": 1119,
-        "Genesungsfall": 31083,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2732,
-        "Zuwachs_Fallzahl": 134,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
         "Inzidenz": 60.1673910700815,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.4,
-        "Fallzahl_aktiv": 657,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 89,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.79,
+        "H_Inzidenz": 1.06,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21450,22 +21450,22 @@
         "ObjectId": 573,
         "Sterbefall": 1119,
         "Genesungsfall": 31137,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2738,
         "Zuwachs_Fallzahl": 57,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 6,
         "Zuwachs_Genesung": 54,
         "BelegteBetten": null,
-        "Inzidenz": 63.2206616616976,
+        "Inzidenz": 63.2,
         "Datum_neu": 1632960000000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "23.09.2021 - 29.09.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 59.5,
         "Fallzahl_aktiv": 660,
-        "Krh_N_belegt": 138,
-        "Krh_I_belegt": 41,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 3,
         "Krh_I": null,
@@ -21473,11 +21473,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1157,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.94,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.10.2021",
+        "Fallzahl": 32996,
+        "ObjectId": 574,
+        "Sterbefall": 1119,
+        "Genesungsfall": 31188,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2738,
+        "Zuwachs_Fallzahl": 80,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 51,
+        "BelegteBetten": null,
+        "Inzidenz": 64.6574948812817,
+        "Datum_neu": 1633046400000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "24.09.2021 - 30.09.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 61.7,
+        "Fallzahl_aktiv": 689,
+        "Krh_N_belegt": 141,
+        "Krh_I_belegt": 37,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 29,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1190,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.79,
-        "H_Zeitraum": "22.09.2021 - 28.09.2021",
-        "H_Datum": "29.09.2021"
+        "H_Inzidenz": 1.04,
+        "H_Zeitraum": "24.09.2021 - 30.09.2021",
+        "H_Datum": "30.09.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
