### PR TITLE
New data set: 2021-10-02T102303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-01T104902Z.json
+pjson/2021-10-02T102303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-01T104902Z.json pjson/2021-10-02T102303Z.json```:
```
--- pjson/2021-10-01T104902Z.json	2021-10-01 10:49:02.983302760 +0000
+++ pjson/2021-10-02T102303Z.json	2021-10-02 10:23:03.931132561 +0000
@@ -21089,7 +21089,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632096000000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -21235,12 +21235,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 44,
         "BelegteBetten": null,
-        "Inzidenz": 55.4976831064334,
+        "Inzidenz": null,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 52.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21253,7 +21253,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.6,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21290,7 +21290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.4,
+        "H_Inzidenz": 1.73,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21327,7 +21327,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.36,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21401,7 +21401,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.13,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21438,7 +21438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.06,
+        "H_Inzidenz": 1.23,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21448,34 +21448,34 @@
         "Datum": "30.09.2021",
         "Fallzahl": 32916,
         "ObjectId": 573,
-        "Sterbefall": 1119,
-        "Genesungsfall": 31137,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2738,
-        "Zuwachs_Fallzahl": 57,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 54,
         "BelegteBetten": null,
         "Inzidenz": 63.2,
         "Datum_neu": 1632960000000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 59.5,
-        "Fallzahl_aktiv": 660,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.94,
+        "H_Inzidenz": 1.21,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21487,22 +21487,22 @@
         "ObjectId": 574,
         "Sterbefall": 1119,
         "Genesungsfall": 31188,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2738,
         "Zuwachs_Fallzahl": 80,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
-        "Inzidenz": 64.6574948812817,
+        "Inzidenz": 64.7,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "24.09.2021 - 30.09.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 57,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.7,
         "Fallzahl_aktiv": 689,
-        "Krh_N_belegt": 141,
-        "Krh_I_belegt": 37,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 29,
         "Krh_I": null,
@@ -21510,11 +21510,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1190,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.06,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.10.2021",
+        "Fallzahl": 33069,
+        "ObjectId": 575,
+        "Sterbefall": 1119,
+        "Genesungsfall": 31220,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2742,
+        "Zuwachs_Fallzahl": 73,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 32,
+        "BelegteBetten": null,
+        "Inzidenz": 67.8903696253457,
+        "Datum_neu": 1633132800000,
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": "25.09.2021 - 01.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 61.7,
+        "Fallzahl_aktiv": 730,
+        "Krh_N_belegt": 129,
+        "Krh_I_belegt": 39,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 41,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1204,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.04,
         "H_Zeitraum": "24.09.2021 - 30.09.2021",
-        "H_Datum": "30.09.2021"
+        "H_Datum": "01.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
