### PR TITLE
New data set: 2021-10-03T095003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-02T102303Z.json
+pjson/2021-10-03T095003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-02T102303Z.json pjson/2021-10-03T095003Z.json```:
```
--- pjson/2021-10-02T102303Z.json	2021-10-02 10:23:03.931132561 +0000
+++ pjson/2021-10-03T095003Z.json	2021-10-03 09:50:03.594193163 +0000
@@ -21272,12 +21272,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
-        "Inzidenz": 51.9056000574733,
+        "Inzidenz": null,
         "Datum_neu": 1632528000000,
         "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 45.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21290,7 +21290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.73,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21327,7 +21327,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": 1.58,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21364,7 +21364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.45,
+        "H_Inzidenz": 1.48,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21401,7 +21401,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": 1.53,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21422,7 +21422,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.1673910700815,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.4,
@@ -21438,7 +21438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": 1.21,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21459,7 +21459,7 @@
         "BelegteBetten": null,
         "Inzidenz": 63.2,
         "Datum_neu": 1632960000000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 59.5,
@@ -21475,7 +21475,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.18,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21485,28 +21485,28 @@
         "Datum": "01.10.2021",
         "Fallzahl": 32996,
         "ObjectId": 574,
-        "Sterbefall": 1119,
-        "Genesungsfall": 31188,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2738,
-        "Zuwachs_Fallzahl": 80,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": 64.7,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.7,
-        "Fallzahl_aktiv": 689,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 29,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -21524,22 +21524,22 @@
         "ObjectId": 575,
         "Sterbefall": 1119,
         "Genesungsfall": 31220,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2742,
         "Zuwachs_Fallzahl": 73,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 4,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 67.8903696253457,
+        "Inzidenz": 67.9,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 39,
-        "Zeitraum": "25.09.2021 - 01.10.2021",
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 61.7,
         "Fallzahl_aktiv": 730,
-        "Krh_N_belegt": 129,
-        "Krh_I_belegt": 39,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 41,
         "Krh_I": null,
@@ -21547,11 +21547,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1204,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.08,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.10.2021",
+        "Fallzahl": 33094,
+        "ObjectId": 576,
+        "Sterbefall": 1119,
+        "Genesungsfall": 31239,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2742,
+        "Zuwachs_Fallzahl": 25,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 19,
+        "BelegteBetten": null,
+        "Inzidenz": 73.0988900463379,
+        "Datum_neu": 1633219200000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "26.09.2021 - 02.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 70.3,
+        "Fallzahl_aktiv": 736,
+        "Krh_N_belegt": 119,
+        "Krh_I_belegt": 39,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 6,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1227,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.04,
-        "H_Zeitraum": "24.09.2021 - 30.09.2021",
-        "H_Datum": "01.10.2021"
+        "H_Inzidenz": 0.99,
+        "H_Zeitraum": "26.09.2021 - 02.10.2021",
+        "H_Datum": "02.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
