### PR TITLE
New data set: 2021-10-04T100505Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-03T095003Z.json
+pjson/2021-10-04T100505Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-03T095003Z.json pjson/2021-10-04T100505Z.json```:
```
--- pjson/2021-10-03T095003Z.json	2021-10-03 09:50:03.594193163 +0000
+++ pjson/2021-10-04T100505Z.json	2021-10-04 10:05:05.576093833 +0000
@@ -21309,12 +21309,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
-        "Inzidenz": 53.8812457344014,
+        "Inzidenz": null,
         "Datum_neu": 1632614400000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 49.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21327,7 +21327,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.58,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21364,7 +21364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.48,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21385,9 +21385,9 @@
         "BelegteBetten": null,
         "Inzidenz": 50.6483709903373,
         "Datum_neu": 1632787200000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 48.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21401,7 +21401,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": 1.23,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21422,7 +21422,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.1673910700815,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.4,
@@ -21475,7 +21475,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.18,
+        "H_Inzidenz": 1.13,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21496,7 +21496,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.7,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.7,
@@ -21512,7 +21512,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.06,
+        "H_Inzidenz": 1.21,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21522,34 +21522,34 @@
         "Datum": "02.10.2021",
         "Fallzahl": 33069,
         "ObjectId": 575,
-        "Sterbefall": 1119,
-        "Genesungsfall": 31220,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2742,
-        "Zuwachs_Fallzahl": 73,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
         "Inzidenz": 67.9,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 61.7,
-        "Fallzahl_aktiv": 730,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 41,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.08,
+        "H_Inzidenz": 1.18,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21561,7 +21561,7 @@
         "ObjectId": 576,
         "Sterbefall": 1119,
         "Genesungsfall": 31239,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2742,
         "Zuwachs_Fallzahl": 25,
         "Zuwachs_Sterbefall": 0,
@@ -21571,7 +21571,7 @@
         "Inzidenz": 73.0988900463379,
         "Datum_neu": 1633219200000,
         "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "26.09.2021 - 02.10.2021",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 70.3,
         "Fallzahl_aktiv": 736,
@@ -21586,9 +21586,46 @@
         "Inzi_SN_RKI": null,
         "Mutation": 1227,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.99,
-        "H_Zeitraum": "26.09.2021 - 02.10.2021",
-        "H_Datum": "02.10.2021"
+        "H_Inzidenz": 1.11,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.10.2021",
+        "Fallzahl": 33098,
+        "ObjectId": 577,
+        "Sterbefall": 1119,
+        "Genesungsfall": 31268,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2743,
+        "Zuwachs_Fallzahl": 4,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 29,
+        "BelegteBetten": null,
+        "Inzidenz": 72.5600775889939,
+        "Datum_neu": 1633305600000,
+        "F\u00e4lle_Meldedatum": 1,
+        "Zeitraum": "27.09.2021 - 03.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 69.2,
+        "Fallzahl_aktiv": 711,
+        "Krh_N_belegt": 119,
+        "Krh_I_belegt": 41,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -25,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1228,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.01,
+        "H_Zeitraum": "27.09.2021 - 03.10.2021",
+        "H_Datum": "03.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
