### PR TITLE
New data set: 2021-10-05T101803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-04T100505Z.json
+pjson/2021-10-05T101803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-04T100505Z.json pjson/2021-10-05T101803Z.json```:
```
--- pjson/2021-10-04T100505Z.json	2021-10-04 10:05:05.576093833 +0000
+++ pjson/2021-10-05T101803Z.json	2021-10-05 10:18:04.051678435 +0000
@@ -21346,12 +21346,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 58,
         "BelegteBetten": null,
-        "Inzidenz": 52.6240166672654,
+        "Inzidenz": null,
         "Datum_neu": 1632700800000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 51.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21364,7 +21364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21397,11 +21397,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": 1.28,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21422,7 +21422,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.1673910700815,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.4,
@@ -21438,7 +21438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.33,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21459,7 +21459,7 @@
         "BelegteBetten": null,
         "Inzidenz": 63.2,
         "Datum_neu": 1632960000000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 59.5,
@@ -21475,7 +21475,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.13,
+        "H_Inzidenz": 1.23,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21496,7 +21496,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.7,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.7,
@@ -21512,7 +21512,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.33,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21533,7 +21533,7 @@
         "BelegteBetten": null,
         "Inzidenz": 67.9,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 61.7,
@@ -21549,7 +21549,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.18,
+        "H_Inzidenz": 1.33,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21559,34 +21559,34 @@
         "Datum": "03.10.2021",
         "Fallzahl": 33094,
         "ObjectId": 576,
-        "Sterbefall": 1119,
-        "Genesungsfall": 31239,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2742,
-        "Zuwachs_Fallzahl": 25,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 19,
         "BelegteBetten": null,
         "Inzidenz": 73.0988900463379,
         "Datum_neu": 1633219200000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 70.3,
-        "Fallzahl_aktiv": 736,
-        "Krh_N_belegt": 119,
-        "Krh_I_belegt": 39,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 6,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1227,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.11,
+        "H_Inzidenz": 1.28,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21598,7 +21598,7 @@
         "ObjectId": 577,
         "Sterbefall": 1119,
         "Genesungsfall": 31268,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2743,
         "Zuwachs_Fallzahl": 4,
         "Zuwachs_Sterbefall": 0,
@@ -21607,13 +21607,13 @@
         "BelegteBetten": null,
         "Inzidenz": 72.5600775889939,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 1,
-        "Zeitraum": "27.09.2021 - 03.10.2021",
+        "F\u00e4lle_Meldedatum": 50,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 69.2,
         "Fallzahl_aktiv": 711,
-        "Krh_N_belegt": 119,
-        "Krh_I_belegt": 41,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -25,
         "Krh_I": null,
@@ -21621,11 +21621,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1228,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.21,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.10.2021",
+        "Fallzahl": 33203,
+        "ObjectId": 578,
+        "Sterbefall": 1120,
+        "Genesungsfall": 31330,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2743,
+        "Zuwachs_Fallzahl": 105,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 62,
+        "BelegteBetten": null,
+        "Inzidenz": 72.9192858938899,
+        "Datum_neu": 1633392000000,
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": "28.09.2021 - 04.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 63.3,
+        "Fallzahl_aktiv": 753,
+        "Krh_N_belegt": 124,
+        "Krh_I_belegt": 41,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 42,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1237,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.01,
-        "H_Zeitraum": "27.09.2021 - 03.10.2021",
-        "H_Datum": "03.10.2021"
+        "H_Inzidenz": 1.16,
+        "H_Zeitraum": "28.09.2021 - 04.10.2021",
+        "H_Datum": "04.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
