### PR TITLE
New data set: 2021-10-06T100305Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-05T101803Z.json
+pjson/2021-10-06T100305Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-05T101803Z.json pjson/2021-10-06T100305Z.json```:
```
--- pjson/2021-10-05T101803Z.json	2021-10-05 10:18:04.051678435 +0000
+++ pjson/2021-10-06T100305Z.json	2021-10-06 10:03:05.654587512 +0000
@@ -21237,7 +21237,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21383,12 +21383,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
-        "Inzidenz": 50.6483709903373,
+        "Inzidenz": null,
         "Datum_neu": 1632787200000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 48.9,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21401,7 +21401,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.28,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21422,7 +21422,7 @@
         "BelegteBetten": null,
         "Inzidenz": 60.1673910700815,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.4,
@@ -21438,7 +21438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.41,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21475,7 +21475,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": 1.31,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21496,7 +21496,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.7,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.7,
@@ -21512,7 +21512,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.41,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21533,7 +21533,7 @@
         "BelegteBetten": null,
         "Inzidenz": 67.9,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 61.7,
@@ -21549,7 +21549,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.48,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21586,7 +21586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.28,
+        "H_Inzidenz": 1.45,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21596,26 +21596,26 @@
         "Datum": "04.10.2021",
         "Fallzahl": 33098,
         "ObjectId": 577,
-        "Sterbefall": 1119,
-        "Genesungsfall": 31268,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2743,
-        "Zuwachs_Fallzahl": 4,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
         "Inzidenz": 72.5600775889939,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 69.2,
-        "Fallzahl_aktiv": 711,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -25,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -21623,7 +21623,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.41,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21635,7 +21635,7 @@
         "ObjectId": 578,
         "Sterbefall": 1120,
         "Genesungsfall": 31330,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2743,
         "Zuwachs_Fallzahl": 105,
         "Zuwachs_Sterbefall": 1,
@@ -21644,13 +21644,13 @@
         "BelegteBetten": null,
         "Inzidenz": 72.9192858938899,
         "Datum_neu": 1633392000000,
-        "F\u00e4lle_Meldedatum": 51,
-        "Zeitraum": "28.09.2021 - 04.10.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 100,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 63.3,
         "Fallzahl_aktiv": 753,
-        "Krh_N_belegt": 124,
-        "Krh_I_belegt": 41,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 42,
         "Krh_I": null,
@@ -21658,11 +21658,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1237,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.16,
-        "H_Zeitraum": "28.09.2021 - 04.10.2021",
-        "H_Datum": "04.10.2021"
+        "H_Inzidenz": 1.53,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.10.2021",
+        "Fallzahl": 33309,
+        "ObjectId": 579,
+        "Sterbefall": 1120,
+        "Genesungsfall": 31392,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2753,
+        "Zuwachs_Fallzahl": 106,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 62,
+        "BelegteBetten": null,
+        "Inzidenz": 80.2830561442581,
+        "Datum_neu": 1633478400000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "29.09.2021 - 05.10.2021",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 74.1,
+        "Fallzahl_aktiv": 797,
+        "Krh_N_belegt": 137,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 44,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1251,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.23,
+        "H_Zeitraum": "29.09.2021 - 05.10.2021",
+        "H_Datum": "05.10.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
