### PR TITLE
New data set: 2021-10-06T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-05T101803Z.json
+pjson/2021-10-06T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-06T100402Z.json pjson/2021-10-06T100503Z.json```:
```
--- pjson/2021-10-06T100402Z.json	2021-10-06 10:04:02.990600807 +0000
+++ pjson/2021-10-06T100503Z.json	2021-10-06 10:05:04.118614994 +0000
@@ -21699,7 +21699,7 @@
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.23,
         "H_Zeitraum": "29.09.2021 - 05.10.2021",
-        "H_Datum": "20211005"
+        "H_Datum": "05.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
