### PR TITLE
New data set: 2021-10-07T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-06T100503Z.json
+pjson/2021-10-07T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-06T100503Z.json pjson/2021-10-07T100503Z.json```:
```
--- pjson/2021-10-06T100503Z.json	2021-10-06 10:05:04.118614994 +0000
+++ pjson/2021-10-07T100503Z.json	2021-10-07 10:05:04.160062484 +0000
@@ -9138,7 +9138,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604188800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -9804,7 +9804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -9989,7 +9989,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 264,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10026,7 +10026,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 272,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10063,7 +10063,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 277,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -10211,7 +10211,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606694400000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -10248,7 +10248,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606780800000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 338,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -10285,7 +10285,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606867200000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -10322,7 +10322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -10359,7 +10359,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 223,
+        "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10396,7 +10396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607126400000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -10470,7 +10470,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 378,
+        "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -10729,7 +10729,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 428,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -10766,7 +10766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -10803,7 +10803,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -13615,7 +13615,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614643200000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -20610,7 +20610,7 @@
         "Datum_neu": 1630972800000,
         "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20830,7 +20830,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631491200000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -20867,7 +20867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21385,7 +21385,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632787200000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21420,12 +21420,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 60.1673910700815,
+        "Inzidenz": null,
         "Datum_neu": 1632873600000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 53.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21438,7 +21438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.41,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21475,7 +21475,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.31,
+        "H_Inzidenz": 1.41,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21496,7 +21496,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.7,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.7,
@@ -21512,7 +21512,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.41,
+        "H_Inzidenz": 1.5,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21533,7 +21533,7 @@
         "BelegteBetten": null,
         "Inzidenz": 67.9,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 61.7,
@@ -21549,7 +21549,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.48,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21586,7 +21586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.45,
+        "H_Inzidenz": 1.58,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21607,7 +21607,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.5600775889939,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 69.2,
@@ -21623,7 +21623,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.41,
+        "H_Inzidenz": 1.58,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21633,34 +21633,34 @@
         "Datum": "05.10.2021",
         "Fallzahl": 33203,
         "ObjectId": 578,
-        "Sterbefall": 1120,
-        "Genesungsfall": 31330,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2743,
-        "Zuwachs_Fallzahl": 105,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
         "Inzidenz": 72.9192858938899,
         "Datum_neu": 1633392000000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 63.3,
-        "Fallzahl_aktiv": 753,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 42,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": 1.7,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21672,7 +21672,7 @@
         "ObjectId": 579,
         "Sterbefall": 1120,
         "Genesungsfall": 31392,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2753,
         "Zuwachs_Fallzahl": 106,
         "Zuwachs_Sterbefall": 0,
@@ -21681,13 +21681,13 @@
         "BelegteBetten": null,
         "Inzidenz": 80.2830561442581,
         "Datum_neu": 1633478400000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "29.09.2021 - 05.10.2021",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 76,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 74.1,
         "Fallzahl_aktiv": 797,
-        "Krh_N_belegt": 137,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 44,
         "Krh_I": null,
@@ -21695,11 +21695,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1251,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
-        "H_Zeitraum": "29.09.2021 - 05.10.2021",
-        "H_Datum": "05.10.2021"
+        "H_Inzidenz": 1.58,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.10.2021",
+        "Fallzahl": 33400,
+        "ObjectId": 580,
+        "Sterbefall": 1120,
+        "Genesungsfall": 31454,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2754,
+        "Zuwachs_Fallzahl": 91,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 62,
+        "BelegteBetten": null,
+        "Inzidenz": 84.7731599554582,
+        "Datum_neu": 1633564800000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "30.09.2021 - 06.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 82.3,
+        "Fallzahl_aktiv": 826,
+        "Krh_N_belegt": 155,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 29,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1293,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.53,
+        "H_Zeitraum": "30.09.2021 - 06.10.2021",
+        "H_Datum": "06.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
