### PR TITLE
New data set: 2021-10-08T111605Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-07T100503Z.json
+pjson/2021-10-08T111605Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-07T100503Z.json pjson/2021-10-08T111605Z.json```:
```
--- pjson/2021-10-07T100503Z.json	2021-10-07 10:05:04.160062484 +0000
+++ pjson/2021-10-08T111605Z.json	2021-10-08 11:16:05.552764327 +0000
@@ -9804,7 +9804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -20867,7 +20867,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -20941,7 +20941,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21200,7 +21200,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632355200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21237,7 +21237,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21348,7 +21348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632700800000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -21385,7 +21385,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632787200000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21422,7 +21422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21457,12 +21457,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 54,
         "BelegteBetten": null,
-        "Inzidenz": 63.2,
+        "Inzidenz": null,
         "Datum_neu": 1632960000000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 59.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21475,7 +21475,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.41,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21496,7 +21496,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.7,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 61.7,
@@ -21512,7 +21512,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.5,
+        "H_Inzidenz": 1.65,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21549,7 +21549,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": 1.75,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21586,7 +21586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.58,
+        "H_Inzidenz": 1.8,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21607,7 +21607,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.5600775889939,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 69.2,
@@ -21623,7 +21623,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.58,
+        "H_Inzidenz": 1.77,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21644,7 +21644,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.9192858938899,
         "Datum_neu": 1633392000000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 63.3,
@@ -21660,7 +21660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": 1.92,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21670,34 +21670,34 @@
         "Datum": "06.10.2021",
         "Fallzahl": 33309,
         "ObjectId": 579,
-        "Sterbefall": 1120,
-        "Genesungsfall": 31392,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2753,
-        "Zuwachs_Fallzahl": 106,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
         "Inzidenz": 80.2830561442581,
         "Datum_neu": 1633478400000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 74.1,
-        "Fallzahl_aktiv": 797,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 44,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.58,
+        "H_Inzidenz": 1.9,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21707,36 +21707,73 @@
         "Datum": "07.10.2021",
         "Fallzahl": 33400,
         "ObjectId": 580,
-        "Sterbefall": 1120,
-        "Genesungsfall": 31454,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2754,
-        "Zuwachs_Fallzahl": 91,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "30.09.2021 - 06.10.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 73,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 82.3,
-        "Fallzahl_aktiv": 826,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.92,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.10.2021",
+        "Fallzahl": 33503,
+        "ObjectId": 581,
+        "Sterbefall": 1120,
+        "Genesungsfall": 31504,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2755,
+        "Zuwachs_Fallzahl": 103,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 50,
+        "BelegteBetten": null,
+        "Inzidenz": 85.6711807176982,
+        "Datum_neu": 1633651200000,
+        "F\u00e4lle_Meldedatum": 32,
+        "Zeitraum": "01.10.2021 - 07.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 79.1,
+        "Fallzahl_aktiv": 879,
         "Krh_N_belegt": 155,
-        "Krh_I_belegt": 56,
+        "Krh_I_belegt": 75,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 29,
+        "Fallzahl_aktiv_Zuwachs": 53,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1293,
+        "Mutation": 1348,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
-        "H_Zeitraum": "30.09.2021 - 06.10.2021",
-        "H_Datum": "06.10.2021"
+        "H_Inzidenz": 1.73,
+        "H_Zeitraum": "01.10.2021 - 07.10.2021",
+        "H_Datum": "07.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
