### PR TITLE
New data set: 2021-10-10T100904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-08T111605Z.json
+pjson/2021-10-10T100904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-09T102903Z.json pjson/2021-10-10T100904Z.json```:
```
--- pjson/2021-10-09T102903Z.json	2021-10-09 10:29:03.700826185 +0000
+++ pjson/2021-10-10T100904Z.json	2021-10-10 10:09:04.197595877 +0000
@@ -15021,7 +15021,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -21237,7 +21237,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632441600000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21494,12 +21494,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
-        "Inzidenz": 64.7,
+        "Inzidenz": null,
         "Datum_neu": 1633046400000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 61.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21512,7 +21512,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.5,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21549,7 +21549,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.65,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21586,7 +21586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.75,
+        "H_Inzidenz": 1.65,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21607,7 +21607,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.5600775889939,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 69.2,
@@ -21623,7 +21623,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.8,
+        "H_Inzidenz": 1.75,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21660,7 +21660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.77,
+        "H_Inzidenz": 1.8,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21697,7 +21697,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.92,
+        "H_Inzidenz": 1.77,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21718,7 +21718,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 82.3,
@@ -21734,7 +21734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.9,
+        "H_Inzidenz": 1.92,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21755,7 +21755,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.5692014799382,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 79.1,
@@ -21771,7 +21771,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.92,
+        "H_Inzidenz": 1.9,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21781,32 +21781,69 @@
         "Datum": "09.10.2021",
         "Fallzahl": 33564,
         "ObjectId": 582,
-        "Sterbefall": 1120,
-        "Genesungsfall": 31536,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2756,
-        "Zuwachs_Fallzahl": 61,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
         "Inzidenz": 85.6711807176982,
         "Datum_neu": 1633737600000,
-        "F\u00e4lle_Meldedatum": 18,
-        "Zeitraum": "02.10.2021 - 08.10.2021",
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 77.3,
-        "Fallzahl_aktiv": 908,
-        "Krh_N_belegt": 153,
-        "Krh_I_belegt": 75,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.92,
+        "H_Zeitraum": "01.10.2021 - 07.10.2021",
+        "H_Datum": "07.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.10.2021",
+        "Fallzahl": 33593,
+        "ObjectId": 583,
+        "Sterbefall": 1120,
+        "Genesungsfall": 31546,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2756,
+        "Zuwachs_Fallzahl": 29,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 10,
+        "BelegteBetten": null,
+        "Inzidenz": 84.5935558030102,
+        "Datum_neu": 1633824000000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "03.10.2021 - 09.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 83.6,
+        "Fallzahl_aktiv": 927,
+        "Krh_N_belegt": 170,
+        "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 29,
+        "Fallzahl_aktiv_Zuwachs": 19,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1393,
+        "Mutation": 1435,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.73,
         "H_Zeitraum": "01.10.2021 - 07.10.2021",
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
