### PR TITLE
New data set: 2021-10-11T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-10T100904Z.json
+pjson/2021-10-11T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-10T100904Z.json pjson/2021-10-11T100403Z.json```:
```
--- pjson/2021-10-10T100904Z.json	2021-10-10 10:09:04.197595877 +0000
+++ pjson/2021-10-11T100403Z.json	2021-10-11 10:04:04.256782243 +0000
@@ -21531,12 +21531,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 67.9,
+        "Inzidenz": null,
         "Datum_neu": 1633132800000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 61.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21568,12 +21568,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 19,
         "BelegteBetten": null,
-        "Inzidenz": 73.0988900463379,
+        "Inzidenz": null,
         "Datum_neu": 1633219200000,
         "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 70.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21586,7 +21586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.65,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21623,7 +21623,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.75,
+        "H_Inzidenz": 1.82,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21644,7 +21644,7 @@
         "BelegteBetten": null,
         "Inzidenz": 72.9192858938899,
         "Datum_neu": 1633392000000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 63.3,
@@ -21660,7 +21660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.8,
+        "H_Inzidenz": 1.2,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21697,7 +21697,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.77,
+        "H_Inzidenz": 1.97,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21734,7 +21734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.92,
+        "H_Inzidenz": 2.07,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21757,7 +21757,7 @@
         "Datum_neu": 1633651200000,
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 79.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21771,7 +21771,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.9,
+        "H_Inzidenz": 2.05,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21792,7 +21792,7 @@
         "BelegteBetten": null,
         "Inzidenz": 85.6711807176982,
         "Datum_neu": 1633737600000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 77.3,
@@ -21808,9 +21808,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.92,
-        "H_Zeitraum": "01.10.2021 - 07.10.2021",
-        "H_Datum": "07.10.2022"
+        "H_Inzidenz": 1.97,
+        "H_Zeitraum": null,
+        "H_Datum": null
       }
     },
     {
@@ -21820,7 +21820,7 @@
         "ObjectId": 583,
         "Sterbefall": 1120,
         "Genesungsfall": 31546,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2756,
         "Zuwachs_Fallzahl": 29,
         "Zuwachs_Sterbefall": 0,
@@ -21829,13 +21829,13 @@
         "BelegteBetten": null,
         "Inzidenz": 84.5935558030102,
         "Datum_neu": 1633824000000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "03.10.2021 - 09.10.2021",
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 83.6,
         "Fallzahl_aktiv": 927,
-        "Krh_N_belegt": 170,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 19,
         "Krh_I": null,
@@ -21843,11 +21843,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1435,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.82,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.10.2021",
+        "Fallzahl": 33604,
+        "ObjectId": 584,
+        "Sterbefall": 1120,
+        "Genesungsfall": 31599,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2758,
+        "Zuwachs_Fallzahl": 11,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 53,
+        "BelegteBetten": null,
+        "Inzidenz": 86.2099931750422,
+        "Datum_neu": 1633910400000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "04.10.2021 - 10.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 85,
+        "Fallzahl_aktiv": 885,
+        "Krh_N_belegt": 161,
+        "Krh_I_belegt": 89,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -42,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1446,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.73,
-        "H_Zeitraum": "01.10.2021 - 07.10.2021",
-        "H_Datum": "07.10.2022"
+        "H_Inzidenz": 1.82,
+        "H_Zeitraum": "04.10.2021 - 10.10.2021",
+        "H_Datum": "10.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
