### PR TITLE
New data set: 2021-10-11T100603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-10T100904Z.json
+pjson/2021-10-11T100603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-11T100403Z.json pjson/2021-10-11T100603Z.json```:
```
--- pjson/2021-10-11T100403Z.json	2021-10-11 10:04:04.256782243 +0000
+++ pjson/2021-10-11T100603Z.json	2021-10-11 10:06:04.068787006 +0000
@@ -21883,7 +21883,7 @@
         "Mutation": 1446,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.82,
-        "H_Zeitraum": "04.10.2021 - 10.10.2021",
+        "H_Zeitraum": "03.10.2021 - 09.10.2021",
         "H_Datum": "10.10.2021"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
