### PR TITLE
New data set: 2021-10-12T101604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-11T100603Z.json
+pjson/2021-10-12T101604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-11T100603Z.json pjson/2021-10-12T101604Z.json```:
```
--- pjson/2021-10-11T100603Z.json	2021-10-11 10:06:04.068787006 +0000
+++ pjson/2021-10-12T101604Z.json	2021-10-12 10:16:04.547296825 +0000
@@ -21459,7 +21459,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632960000000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -21605,12 +21605,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 72.5600775889939,
+        "Inzidenz": null,
         "Datum_neu": 1633305600000,
         "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 69.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21623,7 +21623,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21660,7 +21660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.2,
+        "H_Inzidenz": 2.12,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21697,7 +21697,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": 2.12,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21718,9 +21718,9 @@
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 82.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21730,11 +21730,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
+        "H_Inzidenz": 2.24,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21757,7 +21757,7 @@
         "Datum_neu": 1633651200000,
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 79.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21771,7 +21771,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
+        "H_Inzidenz": 2.27,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21792,9 +21792,9 @@
         "BelegteBetten": null,
         "Inzidenz": 85.6711807176982,
         "Datum_neu": 1633737600000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21808,7 +21808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": 2.27,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21818,13 +21818,13 @@
         "Datum": "10.10.2021",
         "Fallzahl": 33593,
         "ObjectId": 583,
-        "Sterbefall": 1120,
-        "Genesungsfall": 31546,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2756,
-        "Zuwachs_Fallzahl": 29,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
         "Inzidenz": 84.5935558030102,
@@ -21833,19 +21833,19 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 83.6,
-        "Fallzahl_aktiv": 927,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 19,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.82,
+        "H_Inzidenz": 2.19,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21857,7 +21857,7 @@
         "ObjectId": 584,
         "Sterbefall": 1120,
         "Genesungsfall": 31599,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2758,
         "Zuwachs_Fallzahl": 11,
         "Zuwachs_Sterbefall": 0,
@@ -21866,13 +21866,13 @@
         "BelegteBetten": null,
         "Inzidenz": 86.2099931750422,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "04.10.2021 - 10.10.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 85,
         "Fallzahl_aktiv": 885,
-        "Krh_N_belegt": 161,
-        "Krh_I_belegt": 89,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -42,
         "Krh_I": null,
@@ -21880,11 +21880,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1446,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.24,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.10.2021",
+        "Fallzahl": 33706,
+        "ObjectId": 585,
+        "Sterbefall": 1121,
+        "Genesungsfall": 31680,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2771,
+        "Zuwachs_Fallzahl": 102,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 81,
+        "BelegteBetten": null,
+        "Inzidenz": 86.0303890225942,
+        "Datum_neu": 1633996800000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "05.10.2021 - 11.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 77.7,
+        "Fallzahl_aktiv": 905,
+        "Krh_N_belegt": 183,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 20,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1457,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.82,
-        "H_Zeitraum": "03.10.2021 - 09.10.2021",
-        "H_Datum": "10.10.2021"
+        "H_Inzidenz": 2.14,
+        "H_Zeitraum": "05.10.2021 - 11.10.2021",
+        "H_Datum": "11.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
