### PR TITLE
New data set: 2021-10-13T101704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-12T101604Z.json
+pjson/2021-10-13T101704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-12T101604Z.json pjson/2021-10-13T101704Z.json```:
```
--- pjson/2021-10-12T101604Z.json	2021-10-12 10:16:04.547296825 +0000
+++ pjson/2021-10-13T101704Z.json	2021-10-13 10:17:04.647669454 +0000
@@ -8398,7 +8398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602460800000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -21200,7 +21200,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632355200000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21385,7 +21385,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632787200000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21459,7 +21459,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632960000000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -21660,7 +21660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.12,
+        "H_Inzidenz": 2.22,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21681,7 +21681,7 @@
         "BelegteBetten": null,
         "Inzidenz": 80.2830561442581,
         "Datum_neu": 1633478400000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 74.1,
@@ -21697,7 +21697,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.12,
+        "H_Inzidenz": 2.29,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21720,7 +21720,7 @@
         "Datum_neu": 1633564800000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 82.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21734,7 +21734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.24,
+        "H_Inzidenz": 2.51,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21755,7 +21755,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.5692014799382,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 79.1,
@@ -21771,7 +21771,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.27,
+        "H_Inzidenz": 2.59,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21792,7 +21792,7 @@
         "BelegteBetten": null,
         "Inzidenz": 85.6711807176982,
         "Datum_neu": 1633737600000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.3,
@@ -21808,7 +21808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.27,
+        "H_Inzidenz": 2.64,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21829,7 +21829,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.5935558030102,
         "Datum_neu": 1633824000000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 83.6,
@@ -21841,11 +21841,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.19,
+        "H_Inzidenz": 2.74,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21855,26 +21855,26 @@
         "Datum": "11.10.2021",
         "Fallzahl": 33604,
         "ObjectId": 584,
-        "Sterbefall": 1120,
-        "Genesungsfall": 31599,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2758,
-        "Zuwachs_Fallzahl": 11,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
         "Inzidenz": 86.2099931750422,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 85,
-        "Fallzahl_aktiv": 885,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -42,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -21882,7 +21882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.24,
+        "H_Inzidenz": 2.86,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21892,36 +21892,73 @@
         "Datum": "12.10.2021",
         "Fallzahl": 33706,
         "ObjectId": 585,
-        "Sterbefall": 1121,
-        "Genesungsfall": 31680,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2771,
-        "Zuwachs_Fallzahl": 102,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 81,
         "BelegteBetten": null,
         "Inzidenz": 86.0303890225942,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 46,
-        "Zeitraum": "05.10.2021 - 11.10.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 121,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.7,
-        "Fallzahl_aktiv": 905,
-        "Krh_N_belegt": 183,
-        "Krh_I_belegt": 79,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.16,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.10.2021",
+        "Fallzahl": 33816,
+        "ObjectId": 586,
+        "Sterbefall": 1122,
+        "Genesungsfall": 31763,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2775,
+        "Zuwachs_Fallzahl": 110,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 83,
+        "BelegteBetten": null,
+        "Inzidenz": 87.4672222421782,
+        "Datum_neu": 1634083200000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "06.10.2021 - 12.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 77.3,
+        "Fallzahl_aktiv": 931,
+        "Krh_N_belegt": 199,
+        "Krh_I_belegt": 96,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 20,
+        "Fallzahl_aktiv_Zuwachs": 26,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1457,
+        "Mutation": 1494,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.14,
-        "H_Zeitraum": "05.10.2021 - 11.10.2021",
-        "H_Datum": "11.10.2021"
+        "H_Inzidenz": 2.76,
+        "H_Zeitraum": "06.10.2021 - 12.10.2021",
+        "H_Datum": "12.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
