### PR TITLE
New data set: 2021-10-14T100604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-13T101704Z.json
+pjson/2021-10-14T100604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-13T101704Z.json pjson/2021-10-14T100604Z.json```:
```
--- pjson/2021-10-13T101704Z.json	2021-10-13 10:17:04.647669454 +0000
+++ pjson/2021-10-14T100604Z.json	2021-10-14 10:06:04.941176440 +0000
@@ -8398,7 +8398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1602460800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -21642,12 +21642,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
-        "Inzidenz": 72.9192858938899,
+        "Inzidenz": null,
         "Datum_neu": 1633392000000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 63.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21660,7 +21660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.22,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21681,7 +21681,7 @@
         "BelegteBetten": null,
         "Inzidenz": 80.2830561442581,
         "Datum_neu": 1633478400000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 74.1,
@@ -21697,7 +21697,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.29,
+        "H_Inzidenz": 2.34,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21718,7 +21718,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 82.3,
@@ -21734,7 +21734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.51,
+        "H_Inzidenz": 2.61,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21755,7 +21755,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.5692014799382,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 79.1,
@@ -21771,7 +21771,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.59,
+        "H_Inzidenz": 2.79,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21808,7 +21808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.64,
+        "H_Inzidenz": 2.88,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21845,7 +21845,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": 2.98,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21866,7 +21866,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.2099931750422,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 85,
@@ -21882,7 +21882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
+        "H_Inzidenz": 3.11,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21903,7 +21903,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.0303890225942,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.7,
@@ -21919,7 +21919,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.16,
+        "H_Inzidenz": 3.62,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21929,36 +21929,73 @@
         "Datum": "13.10.2021",
         "Fallzahl": 33816,
         "ObjectId": 586,
-        "Sterbefall": 1122,
-        "Genesungsfall": 31763,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2775,
-        "Zuwachs_Fallzahl": 110,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
         "Inzidenz": 87.4672222421782,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "06.10.2021 - 12.10.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 97,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 77.3,
-        "Fallzahl_aktiv": 931,
-        "Krh_N_belegt": 199,
-        "Krh_I_belegt": 96,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.7,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.10.2021",
+        "Fallzahl": 33940,
+        "ObjectId": 587,
+        "Sterbefall": 1122,
+        "Genesungsfall": 31840,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2780,
+        "Zuwachs_Fallzahl": 124,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 77,
+        "BelegteBetten": null,
+        "Inzidenz": 93.2145551205144,
+        "Datum_neu": 1634169600000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "07.10.2021 - 13.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 84.5,
+        "Fallzahl_aktiv": 978,
+        "Krh_N_belegt": 232,
+        "Krh_I_belegt": 97,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 26,
+        "Fallzahl_aktiv_Zuwachs": 47,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1494,
+        "Mutation": 1524,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.76,
-        "H_Zeitraum": "06.10.2021 - 12.10.2021",
-        "H_Datum": "12.10.2021"
+        "H_Inzidenz": 3.33,
+        "H_Zeitraum": "07.10.2021 - 13.10.2021",
+        "H_Datum": "13.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
