### PR TITLE
New data set: 2021-10-15T100405Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-14T100604Z.json
+pjson/2021-10-15T100405Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-14T100604Z.json pjson/2021-10-15T100405Z.json```:
```
--- pjson/2021-10-14T100604Z.json	2021-10-14 10:06:04.941176440 +0000
+++ pjson/2021-10-15T100405Z.json	2021-10-15 10:04:05.394024877 +0000
@@ -16661,7 +16661,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -20472,7 +20472,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -21471,7 +21471,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -21582,7 +21582,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -21679,12 +21679,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
-        "Inzidenz": 80.2830561442581,
+        "Inzidenz": null,
         "Datum_neu": 1633478400000,
         "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 74.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21697,7 +21697,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21718,7 +21718,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.7731599554582,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 82.3,
@@ -21734,7 +21734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.61,
+        "H_Inzidenz": 2.69,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21755,7 +21755,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.5692014799382,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 79.1,
@@ -21771,7 +21771,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
+        "H_Inzidenz": 2.86,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21792,7 +21792,7 @@
         "BelegteBetten": null,
         "Inzidenz": 85.6711807176982,
         "Datum_neu": 1633737600000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.3,
@@ -21808,7 +21808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.88,
+        "H_Inzidenz": 2.98,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21829,7 +21829,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.5935558030102,
         "Datum_neu": 1633824000000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 83.6,
@@ -21845,7 +21845,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
+        "H_Inzidenz": 3.08,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21866,7 +21866,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.2099931750422,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 85,
@@ -21882,7 +21882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.11,
+        "H_Inzidenz": 3.2,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21903,7 +21903,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.0303890225942,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.7,
@@ -21919,7 +21919,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.62,
+        "H_Inzidenz": 3.7,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21940,7 +21940,7 @@
         "BelegteBetten": null,
         "Inzidenz": 87.4672222421782,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 77.3,
@@ -21956,7 +21956,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.7,
+        "H_Inzidenz": 3.89,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21966,36 +21966,73 @@
         "Datum": "14.10.2021",
         "Fallzahl": 33940,
         "ObjectId": 587,
-        "Sterbefall": 1122,
-        "Genesungsfall": 31840,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2780,
-        "Zuwachs_Fallzahl": 124,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 77,
         "BelegteBetten": null,
         "Inzidenz": 93.2145551205144,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "07.10.2021 - 13.10.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 80,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 84.5,
-        "Fallzahl_aktiv": 978,
-        "Krh_N_belegt": 232,
-        "Krh_I_belegt": 97,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.77,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.10.2021",
+        "Fallzahl": 34089,
+        "ObjectId": 588,
+        "Sterbefall": 1124,
+        "Genesungsfall": 31914,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2786,
+        "Zuwachs_Fallzahl": 149,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 74,
+        "BelegteBetten": null,
+        "Inzidenz": 96.9862423219225,
+        "Datum_neu": 1634256000000,
+        "F\u00e4lle_Meldedatum": 68,
+        "Zeitraum": "08.10.2021 - 14.10.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 89.7,
+        "Fallzahl_aktiv": 1051,
+        "Krh_N_belegt": 213,
+        "Krh_I_belegt": 95,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 47,
+        "Fallzahl_aktiv_Zuwachs": 73,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1524,
+        "Mutation": 1603,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.33,
-        "H_Zeitraum": "07.10.2021 - 13.10.2021",
-        "H_Datum": "13.10.2021"
+        "H_Inzidenz": 3.4,
+        "H_Zeitraum": "08.10.2021 - 14.10.2021",
+        "H_Datum": "14.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
