### PR TITLE
New data set: 2021-10-18T101604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-15T100405Z.json
+pjson/2021-10-18T101604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-15T100405Z.json pjson/2021-10-18T101604Z.json```:
```
--- pjson/2021-10-15T100405Z.json	2021-10-15 10:04:05.394024877 +0000
+++ pjson/2021-10-18T101604Z.json	2021-10-18 10:16:04.363213389 +0000
@@ -21607,7 +21607,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21716,12 +21716,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
-        "Inzidenz": 84.7731599554582,
+        "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 82.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21734,7 +21734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21753,12 +21753,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
-        "Inzidenz": 86.5692014799382,
+        "Inzidenz": null,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 79.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21771,7 +21771,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21790,12 +21790,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
-        "Inzidenz": 85.6711807176982,
+        "Inzidenz": null,
         "Datum_neu": 1633737600000,
         "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 77.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21808,7 +21808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21829,7 +21829,7 @@
         "BelegteBetten": null,
         "Inzidenz": 84.5935558030102,
         "Datum_neu": 1633824000000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 83.6,
@@ -21845,7 +21845,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.08,
+        "H_Inzidenz": 3.45,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21866,7 +21866,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.2099931750422,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 85,
@@ -21882,7 +21882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.2,
+        "H_Inzidenz": 3.6,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21903,7 +21903,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.0303890225942,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.7,
@@ -21919,7 +21919,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.7,
+        "H_Inzidenz": 4.14,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21940,7 +21940,7 @@
         "BelegteBetten": null,
         "Inzidenz": 87.4672222421782,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 77.3,
@@ -21956,7 +21956,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
+        "H_Inzidenz": 4.31,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21977,7 +21977,7 @@
         "BelegteBetten": null,
         "Inzidenz": 93.2145551205144,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 84.5,
@@ -21993,7 +21993,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.77,
+        "H_Inzidenz": 4.07,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22005,7 +22005,7 @@
         "ObjectId": 588,
         "Sterbefall": 1124,
         "Genesungsfall": 31914,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2786,
         "Zuwachs_Fallzahl": 149,
         "Zuwachs_Sterbefall": 2,
@@ -22014,13 +22014,13 @@
         "BelegteBetten": null,
         "Inzidenz": 96.9862423219225,
         "Datum_neu": 1634256000000,
-        "F\u00e4lle_Meldedatum": 68,
-        "Zeitraum": "08.10.2021 - 14.10.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 162,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 89.7,
         "Fallzahl_aktiv": 1051,
-        "Krh_N_belegt": 213,
-        "Krh_I_belegt": 95,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 73,
         "Krh_I": null,
@@ -22028,11 +22028,122 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1603,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.8,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.10.2021",
+        "Fallzahl": 34205,
+        "ObjectId": 589,
+        "Sterbefall": null,
+        "Genesungsfall": 31958,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 44,
+        "BelegteBetten": null,
+        "Inzidenz": 95.5494091023385,
+        "Datum_neu": 1634342400000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 95.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 3.4,
-        "H_Zeitraum": "08.10.2021 - 14.10.2021",
-        "H_Datum": "14.10.2021"
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.10.2021",
+        "Fallzahl": 34225,
+        "ObjectId": 590,
+        "Sterbefall": null,
+        "Genesungsfall": 31967,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 9,
+        "BelegteBetten": null,
+        "Inzidenz": 88.3652430044183,
+        "Datum_neu": 1634428800000,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 96.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.01,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.10.2021",
+        "Fallzahl": 34299,
+        "ObjectId": 591,
+        "Sterbefall": 1124,
+        "Genesungsfall": 32025,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2791,
+        "Zuwachs_Fallzahl": 210,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 111,
+        "BelegteBetten": null,
+        "Inzidenz": 120.514386292611,
+        "Datum_neu": 1634515200000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "11.10.2021 - 17.10.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 110.4,
+        "Fallzahl_aktiv": 1150,
+        "Krh_N_belegt": 221,
+        "Krh_I_belegt": 107,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 99,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1718,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.79,
+        "H_Zeitraum": "11.10.2021 - 17.10.2021",
+        "H_Datum": "17.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
