### PR TITLE
New data set: 2021-10-19T101204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-18T101604Z.json
+pjson/2021-10-19T101204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-18T101604Z.json pjson/2021-10-19T101204Z.json```:
```
--- pjson/2021-10-18T101604Z.json	2021-10-18 10:16:04.363213389 +0000
+++ pjson/2021-10-19T101204Z.json	2021-10-19 10:12:04.999689916 +0000
@@ -21718,7 +21718,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -21827,12 +21827,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
-        "Inzidenz": 84.5935558030102,
+        "Inzidenz": null,
         "Datum_neu": 1633824000000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 83.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21845,7 +21845,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.45,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21864,12 +21864,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
-        "Inzidenz": 86.2099931750422,
+        "Inzidenz": null,
         "Datum_neu": 1633910400000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 85,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21882,7 +21882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.6,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21903,7 +21903,7 @@
         "BelegteBetten": null,
         "Inzidenz": 86.0303890225942,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 77.7,
@@ -21919,7 +21919,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.14,
+        "H_Inzidenz": 4.19,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21940,7 +21940,7 @@
         "BelegteBetten": null,
         "Inzidenz": 87.4672222421782,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 77.3,
@@ -21956,7 +21956,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 4.34,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21977,7 +21977,7 @@
         "BelegteBetten": null,
         "Inzidenz": 93.2145551205144,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 84.5,
@@ -21993,7 +21993,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
+        "H_Inzidenz": 4.14,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22003,34 +22003,34 @@
         "Datum": "15.10.2021",
         "Fallzahl": 34089,
         "ObjectId": 588,
-        "Sterbefall": 1124,
-        "Genesungsfall": 31914,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2786,
-        "Zuwachs_Fallzahl": 149,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 74,
         "BelegteBetten": null,
         "Inzidenz": 96.9862423219225,
         "Datum_neu": 1634256000000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 89.7,
-        "Fallzahl_aktiv": 1051,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 73,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 3.89,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22041,7 +22041,7 @@
         "Fallzahl": 34205,
         "ObjectId": 589,
         "Sterbefall": null,
-        "Genesungsfall": 31958,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -22051,7 +22051,7 @@
         "BelegteBetten": null,
         "Inzidenz": 95.5494091023385,
         "Datum_neu": 1634342400000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 95.5,
@@ -22067,7 +22067,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.4,
+        "H_Inzidenz": 3.57,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22078,7 +22078,7 @@
         "Fallzahl": 34225,
         "ObjectId": 590,
         "Sterbefall": null,
-        "Genesungsfall": 31967,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -22088,7 +22088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 88.3652430044183,
         "Datum_neu": 1634428800000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 96.2,
@@ -22104,7 +22104,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.01,
+        "H_Inzidenz": 3.23,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22116,7 +22116,7 @@
         "ObjectId": 591,
         "Sterbefall": 1124,
         "Genesungsfall": 32025,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2791,
         "Zuwachs_Fallzahl": 210,
         "Zuwachs_Sterbefall": 0,
@@ -22125,13 +22125,13 @@
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "11.10.2021 - 17.10.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 56,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 110.4,
         "Fallzahl_aktiv": 1150,
-        "Krh_N_belegt": 221,
-        "Krh_I_belegt": 107,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 99,
         "Krh_I": null,
@@ -22139,11 +22139,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1718,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.16,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.10.2021",
+        "Fallzahl": 34420,
+        "ObjectId": 592,
+        "Sterbefall": 1124,
+        "Genesungsfall": 32153,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2806,
+        "Zuwachs_Fallzahl": 121,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 128,
+        "BelegteBetten": null,
+        "Inzidenz": 120.514386292611,
+        "Datum_neu": 1634601600000,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": "12.10.2021 - 18.10.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 111.6,
+        "Fallzahl_aktiv": 1143,
+        "Krh_N_belegt": 248,
+        "Krh_I_belegt": 105,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -7,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1732,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
-        "H_Zeitraum": "11.10.2021 - 17.10.2021",
-        "H_Datum": "17.10.2021"
+        "H_Inzidenz": 2.44,
+        "H_Zeitraum": "12.10.2021 - 18.10.2021",
+        "H_Datum": "18.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
