### PR TITLE
New data set: 2021-10-20T101304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-19T101204Z.json
+pjson/2021-10-20T101304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-19T101204Z.json pjson/2021-10-20T101304Z.json```:
```
--- pjson/2021-10-19T101204Z.json	2021-10-19 10:12:04.999689916 +0000
+++ pjson/2021-10-20T101304Z.json	2021-10-20 10:13:04.131669572 +0000
@@ -14219,7 +14219,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -14503,7 +14503,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -18622,7 +18622,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -18696,7 +18696,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -18881,7 +18881,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -20361,7 +20361,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -21607,7 +21607,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21644,7 +21644,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633392000000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -21718,7 +21718,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -21755,7 +21755,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -21901,12 +21901,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 81,
         "BelegteBetten": null,
-        "Inzidenz": 86.0303890225942,
+        "Inzidenz": null,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 77.7,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21919,7 +21919,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.19,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21940,9 +21940,9 @@
         "BelegteBetten": null,
         "Inzidenz": 87.4672222421782,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 77.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21952,11 +21952,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.34,
+        "H_Inzidenz": 4.19,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21977,7 +21977,7 @@
         "BelegteBetten": null,
         "Inzidenz": 93.2145551205144,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 84.5,
@@ -21993,7 +21993,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.14,
+        "H_Inzidenz": 4.34,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22016,7 +22016,7 @@
         "Datum_neu": 1634256000000,
         "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 89.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22030,7 +22030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
+        "H_Inzidenz": 4.14,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22051,9 +22051,9 @@
         "BelegteBetten": null,
         "Inzidenz": 95.5494091023385,
         "Datum_neu": 1634342400000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 95.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22067,7 +22067,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 3.89,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22088,7 +22088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 88.3652430044183,
         "Datum_neu": 1634428800000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 96.2,
@@ -22100,11 +22100,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.23,
+        "H_Inzidenz": 3.57,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22114,34 +22114,34 @@
         "Datum": "18.10.2021",
         "Fallzahl": 34299,
         "ObjectId": 591,
-        "Sterbefall": 1124,
-        "Genesungsfall": 32025,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2791,
-        "Zuwachs_Fallzahl": 210,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 111,
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 110.4,
-        "Fallzahl_aktiv": 1150,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 99,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.16,
+        "H_Inzidenz": 3.23,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22153,7 +22153,7 @@
         "ObjectId": 592,
         "Sterbefall": 1124,
         "Genesungsfall": 32153,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2806,
         "Zuwachs_Fallzahl": 121,
         "Zuwachs_Sterbefall": 0,
@@ -22162,13 +22162,13 @@
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 63,
-        "Zeitraum": "12.10.2021 - 18.10.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 270,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 111.6,
         "Fallzahl_aktiv": 1143,
-        "Krh_N_belegt": 248,
-        "Krh_I_belegt": 105,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -7,
         "Krh_I": null,
@@ -22176,11 +22176,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1732,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.16,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.10.2021",
+        "Fallzahl": 34773,
+        "ObjectId": 593,
+        "Sterbefall": 1127,
+        "Genesungsfall": 32242,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2809,
+        "Zuwachs_Fallzahl": 353,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 89,
+        "BelegteBetten": null,
+        "Inzidenz": 153.202342038148,
+        "Datum_neu": 1634688000000,
+        "F\u00e4lle_Meldedatum": 90,
+        "Zeitraum": "13.10.2021 - 19.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 135.2,
+        "Fallzahl_aktiv": 1404,
+        "Krh_N_belegt": 280,
+        "Krh_I_belegt": 118,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 261,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1790,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 2.44,
-        "H_Zeitraum": "12.10.2021 - 18.10.2021",
-        "H_Datum": "18.10.2021"
+        "H_Zeitraum": "13.10.2021 - 19.10.2021",
+        "H_Datum": "19.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
