### PR TITLE
New data set: 2021-10-21T101503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-20T104003Z.json
+pjson/2021-10-21T101503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-20T104003Z.json pjson/2021-10-21T101503Z.json```:
```
--- pjson/2021-10-20T104003Z.json	2021-10-20 10:40:03.808700348 +0000
+++ pjson/2021-10-21T101503Z.json	2021-10-21 10:15:03.341335858 +0000
@@ -21878,7 +21878,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -21903,7 +21903,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21938,12 +21938,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
-        "Inzidenz": 87.4672222421782,
+        "Inzidenz": null,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 77.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21956,7 +21956,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": 4.39,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21977,7 +21977,7 @@
         "BelegteBetten": null,
         "Inzidenz": 93.2145551205144,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 84.5,
@@ -21993,7 +21993,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.26,
+        "H_Inzidenz": 4.24,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22014,7 +22014,7 @@
         "BelegteBetten": null,
         "Inzidenz": 96.9862423219225,
         "Datum_neu": 1634256000000,
-        "F\u00e4lle_Meldedatum": 168,
+        "F\u00e4lle_Meldedatum": 167,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 89.7,
@@ -22030,7 +22030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.02,
+        "H_Inzidenz": 4.04,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22051,7 +22051,7 @@
         "BelegteBetten": null,
         "Inzidenz": 95.5494091023385,
         "Datum_neu": 1634342400000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 95.5,
@@ -22067,7 +22067,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.72,
+        "H_Inzidenz": 3.8,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22088,7 +22088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 88.3652430044183,
         "Datum_neu": 1634428800000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 96.2,
@@ -22104,7 +22104,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 3.72,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22125,7 +22125,7 @@
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 110.4,
@@ -22137,11 +22137,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.55,
+        "H_Inzidenz": 3.75,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22151,26 +22151,26 @@
         "Datum": "19.10.2021",
         "Fallzahl": 34420,
         "ObjectId": 592,
-        "Sterbefall": 1124,
-        "Genesungsfall": 32153,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2806,
-        "Zuwachs_Fallzahl": 121,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 128,
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 270,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 111.6,
-        "Fallzahl_aktiv": 1143,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -7,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -22178,7 +22178,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.13,
+        "H_Inzidenz": 3.52,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22188,36 +22188,73 @@
         "Datum": "20.10.2021",
         "Fallzahl": 34773,
         "ObjectId": 593,
-        "Sterbefall": 1127,
-        "Genesungsfall": 32242,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2809,
-        "Zuwachs_Fallzahl": 353,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 89,
         "BelegteBetten": null,
         "Inzidenz": 153.202342038148,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 90,
-        "Zeitraum": "13.10.2021 - 19.10.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 226,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 135.2,
-        "Fallzahl_aktiv": 1404,
-        "Krh_N_belegt": 280,
-        "Krh_I_belegt": 118,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.03,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.10.2021",
+        "Fallzahl": 34979,
+        "ObjectId": 594,
+        "Sterbefall": 1132,
+        "Genesungsfall": 32320,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2818,
+        "Zuwachs_Fallzahl": 206,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 78,
+        "BelegteBetten": null,
+        "Inzidenz": 174.216027874564,
+        "Datum_neu": 1634774400000,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": "14.10.2021 - 20.10.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 160.5,
+        "Fallzahl_aktiv": 1527,
+        "Krh_N_belegt": 299,
+        "Krh_I_belegt": 119,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 261,
+        "Fallzahl_aktiv_Zuwachs": 123,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1790,
+        "Mutation": 1864,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.42,
-        "H_Zeitraum": "13.10.2021 - 19.10.2021",
-        "H_Datum": "19.10.2021"
+        "H_Inzidenz": 2.56,
+        "H_Zeitraum": "14.10.2021 - 20.10.2021",
+        "H_Datum": "20.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
