### PR TITLE
New data set: 2021-10-22T100904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-21T101503Z.json
+pjson/2021-10-22T100904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-21T101503Z.json pjson/2021-10-22T100904Z.json```:
```
--- pjson/2021-10-21T101503Z.json	2021-10-21 10:15:03.341335858 +0000
+++ pjson/2021-10-22T100904Z.json	2021-10-22 10:09:04.141685775 +0000
@@ -10951,7 +10951,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -10988,7 +10988,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 434,
+        "F\u00e4lle_Meldedatum": 433,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -12061,7 +12061,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -14219,7 +14219,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -21866,7 +21866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -21903,7 +21903,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21940,7 +21940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -21956,7 +21956,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.39,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -21975,12 +21975,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 77,
         "BelegteBetten": null,
-        "Inzidenz": 93.2145551205144,
+        "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 84.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -21993,7 +21993,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.24,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22014,7 +22014,7 @@
         "BelegteBetten": null,
         "Inzidenz": 96.9862423219225,
         "Datum_neu": 1634256000000,
-        "F\u00e4lle_Meldedatum": 167,
+        "F\u00e4lle_Meldedatum": 166,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 89.7,
@@ -22030,7 +22030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.04,
+        "H_Inzidenz": 4.17,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22051,7 +22051,7 @@
         "BelegteBetten": null,
         "Inzidenz": 95.5494091023385,
         "Datum_neu": 1634342400000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 95.5,
@@ -22067,7 +22067,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 3.99,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22088,7 +22088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 88.3652430044183,
         "Datum_neu": 1634428800000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 96.2,
@@ -22104,7 +22104,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.72,
+        "H_Inzidenz": 3.89,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22125,7 +22125,7 @@
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 110.4,
@@ -22137,11 +22137,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22162,7 +22162,7 @@
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 277,
+        "F\u00e4lle_Meldedatum": 285,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 111.6,
@@ -22174,11 +22174,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.52,
+        "H_Inzidenz": 3.85,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22199,7 +22199,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.202342038148,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 226,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 135.2,
@@ -22215,7 +22215,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.03,
+        "H_Inzidenz": 3.52,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22227,7 +22227,7 @@
         "ObjectId": 594,
         "Sterbefall": 1132,
         "Genesungsfall": 32320,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2818,
         "Zuwachs_Fallzahl": 206,
         "Zuwachs_Sterbefall": 5,
@@ -22236,13 +22236,13 @@
         "BelegteBetten": null,
         "Inzidenz": 174.216027874564,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 63,
-        "Zeitraum": "14.10.2021 - 20.10.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 177,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 160.5,
         "Fallzahl_aktiv": 1527,
-        "Krh_N_belegt": 299,
-        "Krh_I_belegt": 119,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 123,
         "Krh_I": null,
@@ -22250,11 +22250,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1864,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.35,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.10.2021",
+        "Fallzahl": 35183,
+        "ObjectId": 595,
+        "Sterbefall": 1133,
+        "Genesungsfall": 32397,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2823,
+        "Zuwachs_Fallzahl": 204,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 77,
+        "BelegteBetten": null,
+        "Inzidenz": 194.511297101189,
+        "Datum_neu": 1634860800000,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": "15.10.2021 - 21.10.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 185.7,
+        "Fallzahl_aktiv": 1653,
+        "Krh_N_belegt": 328,
+        "Krh_I_belegt": 117,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 126,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1934,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.56,
-        "H_Zeitraum": "14.10.2021 - 20.10.2021",
-        "H_Datum": "20.10.2021"
+        "H_Inzidenz": 3.2,
+        "H_Zeitraum": "15.10.2021 - 21.10.2021",
+        "H_Datum": "21.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
