### PR TITLE
New data set: 2021-10-26T103103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-25T102104Z.json
+pjson/2021-10-26T103103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-25T102104Z.json pjson/2021-10-26T103103Z.json```:
```
--- pjson/2021-10-25T102104Z.json	2021-10-25 10:21:04.205657230 +0000
+++ pjson/2021-10-26T103103Z.json	2021-10-26 10:31:03.956340067 +0000
@@ -10803,7 +10803,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -21755,7 +21755,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -21940,7 +21940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -21977,7 +21977,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22123,12 +22123,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 111,
         "BelegteBetten": null,
-        "Inzidenz": 120.514386292611,
+        "Inzidenz": null,
         "Datum_neu": 1634515200000,
         "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 110.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -22141,7 +22141,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.14,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22162,7 +22162,7 @@
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 111.6,
@@ -22178,7 +22178,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.09,
+        "H_Inzidenz": 4.17,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22199,7 +22199,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.202342038148,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 135.2,
@@ -22215,7 +22215,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22225,34 +22225,34 @@
         "Datum": "21.10.2021",
         "Fallzahl": 34979,
         "ObjectId": 594,
-        "Sterbefall": 1132,
-        "Genesungsfall": 32320,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2818,
-        "Zuwachs_Fallzahl": 206,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 78,
         "BelegteBetten": null,
         "Inzidenz": 174.216027874564,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 160.5,
-        "Fallzahl_aktiv": 1527,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 123,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.04,
+        "H_Inzidenz": 4.14,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22262,34 +22262,34 @@
         "Datum": "22.10.2021",
         "Fallzahl": 35183,
         "ObjectId": 595,
-        "Sterbefall": 1133,
-        "Genesungsfall": 32397,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2823,
-        "Zuwachs_Fallzahl": 204,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 77,
         "BelegteBetten": null,
         "Inzidenz": 194.511297101189,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 185.7,
-        "Fallzahl_aktiv": 1653,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 126,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 4.44,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22300,7 +22300,7 @@
         "Fallzahl": 35523,
         "ObjectId": 596,
         "Sterbefall": null,
-        "Genesungsfall": 32426,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -22308,11 +22308,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 232.22816911527,
+        "Inzidenz": 232.946585725062,
         "Datum_neu": 1634947200000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 190.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22326,7 +22326,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.46,
+        "H_Inzidenz": 4.76,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22337,7 +22337,7 @@
         "Fallzahl": 35550,
         "ObjectId": 597,
         "Sterbefall": null,
-        "Genesungsfall": 32441,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -22345,11 +22345,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
-        "Inzidenz": 235.461043859334,
+        "Inzidenz": 237.077481231366,
         "Datum_neu": 1635033600000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 212,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22363,7 +22363,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.19,
+        "H_Inzidenz": 4.51,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22375,7 +22375,7 @@
         "ObjectId": 598,
         "Sterbefall": 1135,
         "Genesungsfall": 32510,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2828,
         "Zuwachs_Fallzahl": 482,
         "Zuwachs_Sterbefall": 2,
@@ -22384,13 +22384,13 @@
         "BelegteBetten": null,
         "Inzidenz": 241.20837673767,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "18.10.2021 - 24.10.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 138,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": 2020,
-        "Krh_N_belegt": 391,
-        "Krh_I_belegt": 124,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 367,
         "Krh_I": null,
@@ -22398,11 +22398,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2080,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.31,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.10.2021",
+        "Fallzahl": 35953,
+        "ObjectId": 599,
+        "Sterbefall": 1135,
+        "Genesungsfall": 32654,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2834,
+        "Zuwachs_Fallzahl": 288,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 144,
+        "BelegteBetten": null,
+        "Inzidenz": 249.110959445382,
+        "Datum_neu": 1635206400000,
+        "F\u00e4lle_Meldedatum": 160,
+        "Zeitraum": "19.10.2021 - 25.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 207.1,
+        "Fallzahl_aktiv": 2164,
+        "Krh_N_belegt": 461,
+        "Krh_I_belegt": 134,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 144,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2114,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
-        "H_Zeitraum": "18.10.2021 - 24.10.2021",
-        "H_Datum": "24.10.2021"
+        "H_Inzidenz": 3.65,
+        "H_Zeitraum": "19.10.2021 - 25.10.2021",
+        "H_Datum": "25.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
