### PR TITLE
New data set: 2021-10-27T103603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-26T103103Z.json
+pjson/2021-10-27T103603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-26T103103Z.json pjson/2021-10-27T103603Z.json```:
```
--- pjson/2021-10-26T103103Z.json	2021-10-26 10:31:03.956340067 +0000
+++ pjson/2021-10-27T103603Z.json	2021-10-27 10:36:03.269038837 +0000
@@ -22088,7 +22088,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634428800000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22100,7 +22100,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22137,7 +22137,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22162,7 +22162,7 @@
         "BelegteBetten": null,
         "Inzidenz": 120.514386292611,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 111.6,
@@ -22174,11 +22174,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.17,
+        "H_Inzidenz": 4.24,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22199,7 +22199,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.202342038148,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 135.2,
@@ -22215,7 +22215,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.97,
+        "H_Inzidenz": 4.17,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22236,7 +22236,7 @@
         "BelegteBetten": null,
         "Inzidenz": 174.216027874564,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 160.5,
@@ -22252,7 +22252,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.14,
+        "H_Inzidenz": 4.34,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22273,7 +22273,7 @@
         "BelegteBetten": null,
         "Inzidenz": 194.511297101189,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 185.7,
@@ -22289,7 +22289,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.44,
+        "H_Inzidenz": 4.78,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22308,9 +22308,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 232.946585725062,
+        "Inzidenz": 234.203814792198,
         "Datum_neu": 1634947200000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 190.4,
@@ -22326,7 +22326,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 5.32,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22345,9 +22345,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
-        "Inzidenz": 237.077481231366,
+        "Inzidenz": 239.591939365638,
         "Datum_neu": 1635033600000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 212,
@@ -22363,7 +22363,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.51,
+        "H_Inzidenz": 5.32,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22373,34 +22373,34 @@
         "Datum": "25.10.2021",
         "Fallzahl": 35665,
         "ObjectId": 598,
-        "Sterbefall": 1135,
-        "Genesungsfall": 32510,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2828,
-        "Zuwachs_Fallzahl": 482,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
         "Inzidenz": 241.20837673767,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 227.2,
-        "Fallzahl_aktiv": 2020,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 367,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 5.25,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22412,7 +22412,7 @@
         "ObjectId": 599,
         "Sterbefall": 1135,
         "Genesungsfall": 32654,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2834,
         "Zuwachs_Fallzahl": 288,
         "Zuwachs_Sterbefall": 0,
@@ -22421,25 +22421,62 @@
         "BelegteBetten": null,
         "Inzidenz": 249.110959445382,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 160,
-        "Zeitraum": "19.10.2021 - 25.10.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 413,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 207.1,
         "Fallzahl_aktiv": 2164,
-        "Krh_N_belegt": 461,
-        "Krh_I_belegt": 134,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 144,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.98,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.10.2021",
+        "Fallzahl": 36382,
+        "ObjectId": 600,
+        "Sterbefall": 1138,
+        "Genesungsfall": 32768,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2844,
+        "Zuwachs_Fallzahl": 429,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 114,
+        "BelegteBetten": null,
+        "Inzidenz": 285.929810697223,
+        "Datum_neu": 1635292800000,
+        "F\u00e4lle_Meldedatum": 96,
+        "Zeitraum": "20.10.2021 - 26.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 253.9,
+        "Fallzahl_aktiv": 2476,
+        "Krh_N_belegt": 528,
+        "Krh_I_belegt": 149,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 312,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2114,
+        "Mutation": 2205,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.65,
-        "H_Zeitraum": "19.10.2021 - 25.10.2021",
-        "H_Datum": "25.10.2021"
+        "H_Inzidenz": 4.39,
+        "H_Zeitraum": "20.10.2021 - 26.10.2021",
+        "H_Datum": "26.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
