### PR TITLE
New data set: 2021-10-28T103404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-27T103603Z.json
+pjson/2021-10-28T103404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-27T103603Z.json pjson/2021-10-28T103404Z.json```:
```
--- pjson/2021-10-27T103603Z.json	2021-10-27 10:36:03.269038837 +0000
+++ pjson/2021-10-28T103404Z.json	2021-10-28 10:34:04.455818017 +0000
@@ -17644,7 +17644,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 18,
+        "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624060800000,
@@ -17718,7 +17718,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 7,
+        "Zuwachs_Genesung": 6,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624233600000,
@@ -17755,7 +17755,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 8,
+        "Zuwachs_Genesung": 10,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624320000000,
@@ -17792,7 +17792,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 3,
+        "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624406400000,
@@ -17829,7 +17829,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 25,
+        "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624492800000,
@@ -17866,7 +17866,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 5,
+        "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624579200000,
@@ -17903,7 +17903,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 6,
+        "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624665600000,
@@ -18051,7 +18051,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 10,
+        "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625011200000,
@@ -18088,7 +18088,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 10,
+        "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625097600000,
@@ -18236,7 +18236,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1,
+        "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625443200000,
@@ -18347,7 +18347,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 10,
+        "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625702400000,
@@ -18384,7 +18384,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 14,
+        "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625788800000,
@@ -18458,7 +18458,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 2,
+        "Zuwachs_Genesung": 1,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1625961600000,
@@ -18606,7 +18606,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 5,
+        "Zuwachs_Genesung": 4,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626307200000,
@@ -18791,7 +18791,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 7,
+        "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626739200000,
@@ -18828,7 +18828,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 9,
+        "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626825600000,
@@ -18865,7 +18865,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 3,
+        "Zuwachs_Genesung": 2,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1626912000000,
@@ -19161,7 +19161,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 14,
+        "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627603200000,
@@ -19383,7 +19383,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 12,
+        "Zuwachs_Genesung": 11,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1628121600000,
@@ -19753,7 +19753,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1628985600000,
@@ -19907,7 +19907,7 @@
         "Datum_neu": 1629331200000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19938,13 +19938,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 8,
+        "Zuwachs_Genesung": 7,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629417600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20123,13 +20123,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 22,
+        "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629849600000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20160,7 +20160,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 33,
+        "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629936000000,
@@ -20382,7 +20382,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 33,
+        "Zuwachs_Genesung": 32,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630454400000,
@@ -20425,7 +20425,7 @@
         "Datum_neu": 1630540800000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20456,13 +20456,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 24,
+        "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630627200000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20493,7 +20493,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 17,
+        "Zuwachs_Genesung": 16,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630713600000,
@@ -20573,7 +20573,7 @@
         "Datum_neu": 1630886400000,
         "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20604,13 +20604,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 59,
+        "Zuwachs_Genesung": 58,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630972800000,
         "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20641,7 +20641,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 47,
+        "Zuwachs_Genesung": 48,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631059200000,
@@ -20826,13 +20826,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 44,
+        "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631491200000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20863,13 +20863,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 38,
+        "Zuwachs_Genesung": 37,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
         "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20900,7 +20900,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 39,
+        "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631664000000,
@@ -20937,13 +20937,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 69,
+        "Zuwachs_Genesung": 71,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631750400000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20974,13 +20974,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 20,
+        "Zuwachs_Genesung": 22,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631836800000,
         "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21011,7 +21011,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 41,
+        "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631923200000,
@@ -21085,13 +21085,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 52,
+        "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632096000000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21122,13 +21122,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 80,
+        "Zuwachs_Genesung": 82,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632182400000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21165,7 +21165,7 @@
         "Datum_neu": 1632268800000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21196,7 +21196,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 43,
+        "Zuwachs_Genesung": 44,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632355200000,
@@ -21233,7 +21233,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 44,
+        "Zuwachs_Genesung": 42,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632441600000,
@@ -21270,7 +21270,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 49,
+        "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632528000000,
@@ -21307,7 +21307,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 9,
+        "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632614400000,
@@ -21344,7 +21344,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 58,
+        "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632700800000,
@@ -21381,7 +21381,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 49,
+        "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632787200000,
@@ -21418,7 +21418,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 43,
+        "Zuwachs_Genesung": 45,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632873600000,
@@ -21455,7 +21455,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 54,
+        "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632960000000,
@@ -21492,13 +21492,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 51,
+        "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633046400000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21529,7 +21529,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 32,
+        "Zuwachs_Genesung": 31,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633132800000,
@@ -21566,7 +21566,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 19,
+        "Zuwachs_Genesung": 17,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633219200000,
@@ -21603,7 +21603,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 29,
+        "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
@@ -21677,7 +21677,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 62,
+        "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633478400000,
@@ -21720,7 +21720,7 @@
         "Datum_neu": 1633564800000,
         "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21751,13 +21751,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 50,
+        "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633651200000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21788,7 +21788,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 32,
+        "Zuwachs_Genesung": 31,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633737600000,
@@ -21825,7 +21825,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 10,
+        "Zuwachs_Genesung": 9,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633824000000,
@@ -21862,13 +21862,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 53,
+        "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21899,7 +21899,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 81,
+        "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
@@ -21936,7 +21936,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 83,
+        "Zuwachs_Genesung": 84,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634083200000,
@@ -21973,11 +21973,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 77,
+        "Zuwachs_Genesung": 75,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22010,11 +22010,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 74,
+        "Zuwachs_Genesung": 75,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634256000000,
-        "F\u00e4lle_Meldedatum": 165,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22047,7 +22047,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 44,
+        "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634342400000,
@@ -22088,7 +22088,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634428800000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22121,13 +22121,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 111,
+        "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634515200000,
         "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22158,14 +22158,14 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 128,
+        "Zuwachs_Genesung": 124,
         "BelegteBetten": null,
-        "Inzidenz": 120.514386292611,
+        "Inzidenz": null,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 111.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -22174,11 +22174,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.24,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22195,11 +22195,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 89,
+        "Zuwachs_Genesung": 88,
         "BelegteBetten": null,
         "Inzidenz": 153.202342038148,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 135.2,
@@ -22215,7 +22215,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.17,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22232,11 +22232,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 78,
+        "Zuwachs_Genesung": 80,
         "BelegteBetten": null,
         "Inzidenz": 174.216027874564,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 160.5,
@@ -22252,7 +22252,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.34,
+        "H_Inzidenz": 4.68,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22269,13 +22269,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 77,
+        "Zuwachs_Genesung": 78,
         "BelegteBetten": null,
         "Inzidenz": 194.511297101189,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 326,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 185.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22289,7 +22289,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.78,
+        "H_Inzidenz": 5.23,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22306,11 +22306,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 29,
+        "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
-        "Inzidenz": 234.203814792198,
+        "Inzidenz": 234.02421063975,
         "Datum_neu": 1634947200000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 190.4,
@@ -22326,7 +22326,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
+        "H_Inzidenz": 5.84,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22347,9 +22347,9 @@
         "BelegteBetten": null,
         "Inzidenz": 239.591939365638,
         "Datum_neu": 1635033600000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 212,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22363,7 +22363,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
+        "H_Inzidenz": 5.92,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22380,13 +22380,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 113,
+        "Zuwachs_Genesung": 67,
         "BelegteBetten": null,
         "Inzidenz": 241.20837673767,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22400,7 +22400,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.25,
+        "H_Inzidenz": 5.94,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22410,34 +22410,34 @@
         "Datum": "26.10.2021",
         "Fallzahl": 35953,
         "ObjectId": 599,
-        "Sterbefall": 1135,
-        "Genesungsfall": 32654,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2834,
-        "Zuwachs_Fallzahl": 288,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
-        "Zuwachs_Genesung": 144,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 142,
         "BelegteBetten": null,
         "Inzidenz": 249.110959445382,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 455,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 207.1,
-        "Fallzahl_aktiv": 2164,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 144,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.98,
+        "H_Inzidenz": 5.92,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22449,34 +22449,71 @@
         "ObjectId": 600,
         "Sterbefall": 1138,
         "Genesungsfall": 32768,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2844,
         "Zuwachs_Fallzahl": 429,
         "Zuwachs_Sterbefall": 3,
         "Zuwachs_Krankenhauseinweisung": 10,
-        "Zuwachs_Genesung": 114,
+        "Zuwachs_Genesung": 117,
         "BelegteBetten": null,
-        "Inzidenz": 285.929810697223,
+        "Inzidenz": 294.910018319624,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 96,
-        "Zeitraum": "20.10.2021 - 26.10.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 289,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 253.9,
         "Fallzahl_aktiv": 2476,
-        "Krh_N_belegt": 528,
-        "Krh_I_belegt": 149,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 309,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.72,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.10.2021",
+        "Fallzahl": 36699,
+        "ObjectId": 601,
+        "Sterbefall": 1139,
+        "Genesungsfall": 32873,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2882,
+        "Zuwachs_Fallzahl": 317,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 38,
+        "Zuwachs_Genesung": 105,
+        "BelegteBetten": null,
+        "Inzidenz": 296.885663996552,
+        "Datum_neu": 1635379200000,
+        "F\u00e4lle_Meldedatum": 77,
+        "Zeitraum": "21.10.2021 - 27.10.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 276,
+        "Fallzahl_aktiv": 2687,
+        "Krh_N_belegt": 532,
+        "Krh_I_belegt": 159,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 312,
+        "Fallzahl_aktiv_Zuwachs": 211,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2205,
+        "Mutation": 2255,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.39,
-        "H_Zeitraum": "20.10.2021 - 26.10.2021",
-        "H_Datum": "26.10.2021"
+        "H_Inzidenz": 5.2,
+        "H_Zeitraum": "21.10.2021 - 27.10.2021",
+        "H_Datum": "27.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
