### PR TITLE
New data set: 2021-10-29T100604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-10-28T103404Z.json
+pjson/2021-10-29T100604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-10-28T103404Z.json pjson/2021-10-29T100604Z.json```:
```
--- pjson/2021-10-28T103404Z.json	2021-10-28 10:34:04.455818017 +0000
+++ pjson/2021-10-29T100604Z.json	2021-10-29 10:06:04.455668895 +0000
@@ -19796,7 +19796,7 @@
         "Datum_neu": 1629072000000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19833,7 +19833,7 @@
         "Datum_neu": 1629158400000,
         "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20312,7 +20312,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630281600000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -20608,7 +20608,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630972800000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -21461,7 +21461,7 @@
         "Datum_neu": 1632960000000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21720,7 +21720,7 @@
         "Datum_neu": 1633564800000,
         "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21757,7 +21757,7 @@
         "Datum_neu": 1633651200000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21868,7 +21868,7 @@
         "Datum_neu": 1633910400000,
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21977,7 +21977,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22053,7 +22053,7 @@
         "Datum_neu": 1634342400000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22125,7 +22125,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 111,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -22162,7 +22162,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22197,12 +22197,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 88,
         "BelegteBetten": null,
-        "Inzidenz": 153.202342038148,
+        "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 282,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 135.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -22234,12 +22234,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 80,
         "BelegteBetten": null,
-        "Inzidenz": 174.216027874564,
+        "Inzidenz": null,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 160.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -22252,7 +22252,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22273,9 +22273,9 @@
         "BelegteBetten": null,
         "Inzidenz": 194.511297101189,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 185.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22285,11 +22285,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 5.42,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22308,7 +22308,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
-        "Inzidenz": 234.02421063975,
+        "Inzidenz": 235.999856316678,
         "Datum_neu": 1634947200000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
@@ -22322,11 +22322,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.84,
+        "H_Inzidenz": 6.11,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22345,9 +22345,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 15,
         "BelegteBetten": null,
-        "Inzidenz": 239.591939365638,
+        "Inzidenz": 241.567585042566,
         "Datum_neu": 1635033600000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 212,
@@ -22359,11 +22359,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.92,
+        "H_Inzidenz": 6.26,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22384,9 +22384,9 @@
         "BelegteBetten": null,
         "Inzidenz": 241.20837673767,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 227.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22396,11 +22396,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.94,
+        "H_Inzidenz": 6.33,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22421,7 +22421,7 @@
         "BelegteBetten": null,
         "Inzidenz": 249.110959445382,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 455,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 207.1,
@@ -22437,7 +22437,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.92,
+        "H_Inzidenz": 6.48,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22447,34 +22447,34 @@
         "Datum": "27.10.2021",
         "Fallzahl": 36382,
         "ObjectId": 600,
-        "Sterbefall": 1138,
-        "Genesungsfall": 32768,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2844,
-        "Zuwachs_Fallzahl": 429,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 117,
         "BelegteBetten": null,
-        "Inzidenz": 294.910018319624,
+        "Inzidenz": 297.244872301448,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 347,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 253.9,
-        "Fallzahl_aktiv": 2476,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 309,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.72,
+        "H_Inzidenz": 6.53,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22486,7 +22486,7 @@
         "ObjectId": 601,
         "Sterbefall": 1139,
         "Genesungsfall": 32873,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2882,
         "Zuwachs_Fallzahl": 317,
         "Zuwachs_Sterbefall": 1,
@@ -22495,13 +22495,13 @@
         "BelegteBetten": null,
         "Inzidenz": 296.885663996552,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 77,
-        "Zeitraum": "21.10.2021 - 27.10.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 292,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 276,
         "Fallzahl_aktiv": 2687,
-        "Krh_N_belegt": 532,
-        "Krh_I_belegt": 159,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 211,
         "Krh_I": null,
@@ -22509,11 +22509,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2255,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.61,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.10.2021",
+        "Fallzahl": 37081,
+        "ObjectId": 602,
+        "Sterbefall": 1143,
+        "Genesungsfall": 33030,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2897,
+        "Zuwachs_Fallzahl": 382,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 157,
+        "BelegteBetten": null,
+        "Inzidenz": 320.054599662344,
+        "Datum_neu": 1635465600000,
+        "F\u00e4lle_Meldedatum": 97,
+        "Zeitraum": "22.10.2021 - 28.10.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 285.1,
+        "Fallzahl_aktiv": 2908,
+        "Krh_N_belegt": 602,
+        "Krh_I_belegt": 172,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 221,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2305,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.2,
-        "H_Zeitraum": "21.10.2021 - 27.10.2021",
-        "H_Datum": "27.10.2021"
+        "H_Inzidenz": 5.82,
+        "H_Zeitraum": "22.10.2021 - 28.10.2021",
+        "H_Datum": "28.10.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
