### PR TITLE
New data set: 2021-11-03T112903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-02T113303Z.json
+pjson/2021-11-03T112903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-02T113303Z.json pjson/2021-11-03T112903Z.json```:
```
--- pjson/2021-11-02T113303Z.json	2021-11-02 11:33:03.482574978 +0000
+++ pjson/2021-11-03T112903Z.json	2021-11-03 11:29:04.091066760 +0000
@@ -22310,7 +22310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634947200000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22322,7 +22322,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22384,7 +22384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22419,12 +22419,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 129,
         "BelegteBetten": null,
-        "Inzidenz": 249.110959445382,
+        "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 466,
+        "F\u00e4lle_Meldedatum": 469,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
-        "Inzidenz_RKI": 207.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -22433,11 +22433,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.52,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22456,9 +22456,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 298.86130967348,
+        "Inzidenz": 299.400122130824,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 253.9,
@@ -22474,7 +22474,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.08,
+        "H_Inzidenz": 8.63,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22495,7 +22495,7 @@
         "BelegteBetten": null,
         "Inzidenz": 296.885663996552,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 307,
+        "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 276,
@@ -22511,7 +22511,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.45,
+        "H_Inzidenz": 9.02,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22532,9 +22532,9 @@
         "BelegteBetten": null,
         "Inzidenz": 320.054599662344,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 285.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22548,7 +22548,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.68,
+        "H_Inzidenz": 9.47,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22569,9 +22569,9 @@
         "BelegteBetten": null,
         "Inzidenz": 299.220517978376,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 273.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22585,7 +22585,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.64,
+        "H_Inzidenz": 8.63,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22606,7 +22606,7 @@
         "BelegteBetten": null,
         "Inzidenz": 342.684722870793,
         "Datum_neu": 1635638400000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 295.2,
@@ -22622,7 +22622,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.35,
+        "H_Inzidenz": 8.65,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22632,34 +22632,34 @@
         "Datum": "01.11.2021",
         "Fallzahl": 37604,
         "ObjectId": 605,
-        "Sterbefall": 1146,
-        "Genesungsfall": 33188,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2921,
-        "Zuwachs_Fallzahl": 523,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 24,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 158,
         "BelegteBetten": null,
         "Inzidenz": 341.786702108553,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 226,
+        "F\u00e4lle_Meldedatum": 434,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 319.8,
-        "Fallzahl_aktiv": 3270,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 362,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7,
+        "H_Inzidenz": 8.41,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22671,7 +22671,7 @@
         "ObjectId": 606,
         "Sterbefall": 1150,
         "Genesungsfall": 33473,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 2945,
         "Zuwachs_Fallzahl": 281,
         "Zuwachs_Sterbefall": 4,
@@ -22680,13 +22680,13 @@
         "BelegteBetten": null,
         "Inzidenz": 347.713639139337,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 63,
-        "Zeitraum": "26.10.2021 - 01.11.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 422,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 311.4,
         "Fallzahl_aktiv": 3262,
-        "Krh_N_belegt": 776,
-        "Krh_I_belegt": 199,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -8,
         "Krh_I": null,
@@ -22694,11 +22694,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2389,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.45,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.11.2021",
+        "Fallzahl": 38590,
+        "ObjectId": 607,
+        "Sterbefall": 1153,
+        "Genesungsfall": 33741,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2968,
+        "Zuwachs_Fallzahl": 705,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 268,
+        "BelegteBetten": null,
+        "Inzidenz": 380.940407342218,
+        "Datum_neu": 1635897600000,
+        "F\u00e4lle_Meldedatum": 114,
+        "Zeitraum": "27.10.2021 - 02.11.2021",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 313.7,
+        "Fallzahl_aktiv": 3696,
+        "Krh_N_belegt": 878,
+        "Krh_I_belegt": 205,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 434,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2470,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.92,
-        "H_Zeitraum": "26.10.2021 - 01.11.2021",
-        "H_Datum": "01.11.2021"
+        "H_Inzidenz": 6.95,
+        "H_Zeitraum": "27.10.2021 - 02.11.2021",
+        "H_Datum": "02.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
