### PR TITLE
New data set: 2021-11-04T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-03T112903Z.json
+pjson/2021-11-04T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-03T112903Z.json pjson/2021-11-04T110504Z.json```:
```
--- pjson/2021-11-03T112903Z.json	2021-11-03 11:29:04.091066760 +0000
+++ pjson/2021-11-04T110504Z.json	2021-11-04 11:05:04.733946166 +0000
@@ -22125,7 +22125,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -22199,7 +22199,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 283,
+        "F\u00e4lle_Meldedatum": 282,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22273,7 +22273,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 331,
+        "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -22384,7 +22384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22421,7 +22421,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 469,
+        "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -22433,7 +22433,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22456,7 +22456,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 299.400122130824,
+        "Inzidenz": 299.220517978376,
         "Datum_neu": 1635292800000,
         "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
@@ -22474,7 +22474,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.63,
+        "H_Inzidenz": 8.92,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22495,7 +22495,7 @@
         "BelegteBetten": null,
         "Inzidenz": 296.885663996552,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 276,
@@ -22511,7 +22511,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.02,
+        "H_Inzidenz": 9.29,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22532,9 +22532,9 @@
         "BelegteBetten": null,
         "Inzidenz": 320.054599662344,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 285.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22548,7 +22548,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.47,
+        "H_Inzidenz": 9.84,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22569,9 +22569,9 @@
         "BelegteBetten": null,
         "Inzidenz": 299.220517978376,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 273.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22585,7 +22585,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.63,
+        "H_Inzidenz": 9.12,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22606,7 +22606,7 @@
         "BelegteBetten": null,
         "Inzidenz": 342.684722870793,
         "Datum_neu": 1635638400000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 295.2,
@@ -22622,7 +22622,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.65,
+        "H_Inzidenz": 9.22,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22643,9 +22643,9 @@
         "BelegteBetten": null,
         "Inzidenz": 341.786702108553,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 434,
+        "F\u00e4lle_Meldedatum": 458,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 319.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22659,7 +22659,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.41,
+        "H_Inzidenz": 9.05,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22669,26 +22669,26 @@
         "Datum": "02.11.2021",
         "Fallzahl": 37885,
         "ObjectId": 606,
-        "Sterbefall": 1150,
-        "Genesungsfall": 33473,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2945,
-        "Zuwachs_Fallzahl": 281,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 24,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 285,
         "BelegteBetten": null,
         "Inzidenz": 347.713639139337,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 422,
+        "F\u00e4lle_Meldedatum": 626,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 311.4,
-        "Fallzahl_aktiv": 3262,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -8,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -22696,7 +22696,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.45,
+        "H_Inzidenz": 9.44,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22706,36 +22706,73 @@
         "Datum": "03.11.2021",
         "Fallzahl": 38590,
         "ObjectId": 607,
-        "Sterbefall": 1153,
-        "Genesungsfall": 33741,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2968,
-        "Zuwachs_Fallzahl": 705,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 268,
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 114,
-        "Zeitraum": "27.10.2021 - 02.11.2021",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 311,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 313.7,
-        "Fallzahl_aktiv": 3696,
-        "Krh_N_belegt": 878,
-        "Krh_I_belegt": 205,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.53,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.11.2021",
+        "Fallzahl": 39146,
+        "ObjectId": 608,
+        "Sterbefall": 1155,
+        "Genesungsfall": 33979,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 2980,
+        "Zuwachs_Fallzahl": 556,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 238,
+        "BelegteBetten": null,
+        "Inzidenz": 414.705988002443,
+        "Datum_neu": 1635984000000,
+        "F\u00e4lle_Meldedatum": 123,
+        "Zeitraum": "28.10.2021 - 03.11.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 369.1,
+        "Fallzahl_aktiv": 4012,
+        "Krh_N_belegt": 920,
+        "Krh_I_belegt": 224,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 434,
+        "Fallzahl_aktiv_Zuwachs": 316,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2470,
+        "Mutation": 2594,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.95,
-        "H_Zeitraum": "27.10.2021 - 02.11.2021",
-        "H_Datum": "02.11.2021"
+        "H_Inzidenz": 7.07,
+        "H_Zeitraum": "28.10.2021 - 03.11.2021",
+        "H_Datum": "03.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
