### PR TITLE
New data set: 2021-11-05T074803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-04T110504Z.json
+pjson/2021-11-05T074803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-04T110504Z.json pjson/2021-11-05T074803Z.json```:
```
--- pjson/2021-11-04T110504Z.json	2021-11-04 11:05:04.733946166 +0000
+++ pjson/2021-11-05T074803Z.json	2021-11-05 07:48:04.099546158 +0000
@@ -22456,12 +22456,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 299.220517978376,
+        "Inzidenz": null,
         "Datum_neu": 1635292800000,
         "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 253.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -22474,7 +22474,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22500,8 +22500,8 @@
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 276,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 602,
+        "Krh_I_belegt": 172,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22537,8 +22537,8 @@
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 285.1,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 647,
+        "Krh_I_belegt": 180,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22574,8 +22574,8 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 273.1,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 671,
+        "Krh_I_belegt": 179,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22611,8 +22611,8 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 295.2,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 699,
+        "Krh_I_belegt": 179,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22648,8 +22648,8 @@
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 319.8,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 776,
+        "Krh_I_belegt": 199,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22685,8 +22685,8 @@
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 311.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 878,
+        "Krh_I_belegt": 205,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22706,13 +22706,13 @@
         "Datum": "03.11.2021",
         "Fallzahl": 38590,
         "ObjectId": 607,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1153,
+        "Genesungsfall": 33741,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 2968,
+        "Zuwachs_Fallzahl": 705,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 23,
         "Zuwachs_Genesung": 268,
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
@@ -22721,13 +22721,13 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 313.7,
-        "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Fallzahl_aktiv": 3696,
+        "Krh_N_belegt": 920,
+        "Krh_I_belegt": 224,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 434,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
@@ -22759,8 +22759,8 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 369.1,
         "Fallzahl_aktiv": 4012,
-        "Krh_N_belegt": 920,
-        "Krh_I_belegt": 224,
+        "Krh_N_belegt": 961,
+        "Krh_I_belegt": 232,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 316,
         "Krh_I": null,
@@ -22772,7 +22772,7 @@
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 7.07,
         "H_Zeitraum": "28.10.2021 - 03.11.2021",
-        "H_Datum": "03.11.2021"
+        "H_Datum": "04.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
