### PR TITLE
New data set: 2021-11-05T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-04T110504Z.json
+pjson/2021-11-05T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-05T074803Z.json pjson/2021-11-05T110504Z.json```:
```
--- pjson/2021-11-05T074803Z.json	2021-11-05 07:48:04.099546158 +0000
+++ pjson/2021-11-05T110504Z.json	2021-11-05 11:05:04.685693095 +0000
@@ -21942,7 +21942,7 @@
         "Datum_neu": 1634083200000,
         "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22014,7 +22014,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634256000000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22051,7 +22051,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634342400000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22125,7 +22125,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -22162,7 +22162,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22199,7 +22199,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 282,
+        "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22310,9 +22310,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634947200000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22347,7 +22347,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635033600000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22384,7 +22384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -22495,13 +22495,13 @@
         "BelegteBetten": null,
         "Inzidenz": 296.885663996552,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 276,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 602,
-        "Krh_I_belegt": 172,
+        "Krh_N_belegt": 532,
+        "Krh_I_belegt": 159,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22511,7 +22511,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.29,
+        "H_Inzidenz": 9.69,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22532,13 +22532,13 @@
         "BelegteBetten": null,
         "Inzidenz": 320.054599662344,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 285.1,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 647,
-        "Krh_I_belegt": 180,
+        "Krh_N_belegt": 602,
+        "Krh_I_belegt": 172,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22548,7 +22548,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.84,
+        "H_Inzidenz": 10.25,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22569,13 +22569,13 @@
         "BelegteBetten": null,
         "Inzidenz": 299.220517978376,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 273.1,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 671,
-        "Krh_I_belegt": 179,
+        "Krh_N_belegt": 647,
+        "Krh_I_belegt": 180,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22585,7 +22585,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.12,
+        "H_Inzidenz": 9.56,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22611,7 +22611,7 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 295.2,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 699,
+        "Krh_N_belegt": 671,
         "Krh_I_belegt": 179,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -22622,7 +22622,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.22,
+        "H_Inzidenz": 9.81,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22643,13 +22643,13 @@
         "BelegteBetten": null,
         "Inzidenz": 341.786702108553,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 458,
+        "F\u00e4lle_Meldedatum": 468,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": 319.8,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 776,
-        "Krh_I_belegt": 199,
+        "Krh_N_belegt": 699,
+        "Krh_I_belegt": 179,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22659,7 +22659,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.05,
+        "H_Inzidenz": 9.76,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22680,13 +22680,13 @@
         "BelegteBetten": null,
         "Inzidenz": 347.713639139337,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 626,
+        "F\u00e4lle_Meldedatum": 648,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 311.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 878,
-        "Krh_I_belegt": 205,
+        "Krh_N_belegt": 776,
+        "Krh_I_belegt": 199,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22696,7 +22696,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.44,
+        "H_Inzidenz": 10.2,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22706,34 +22706,34 @@
         "Datum": "03.11.2021",
         "Fallzahl": 38590,
         "ObjectId": 607,
-        "Sterbefall": 1153,
-        "Genesungsfall": 33741,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 2968,
-        "Zuwachs_Fallzahl": 705,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 268,
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 510,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 313.7,
-        "Fallzahl_aktiv": 3696,
-        "Krh_N_belegt": 920,
-        "Krh_I_belegt": 224,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 878,
+        "Krh_I_belegt": 205,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 434,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.53,
+        "H_Inzidenz": 9.74,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22743,36 +22743,73 @@
         "Datum": "04.11.2021",
         "Fallzahl": 39146,
         "ObjectId": 608,
-        "Sterbefall": 1155,
-        "Genesungsfall": 33979,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 2980,
-        "Zuwachs_Fallzahl": 556,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 238,
         "BelegteBetten": null,
         "Inzidenz": 414.705988002443,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 123,
-        "Zeitraum": "28.10.2021 - 03.11.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 390,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 369.1,
-        "Fallzahl_aktiv": 4012,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 920,
+        "Krh_I_belegt": 224,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.87,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.11.2021",
+        "Fallzahl": 39742,
+        "ObjectId": 609,
+        "Sterbefall": 1155,
+        "Genesungsfall": 34305,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3008,
+        "Zuwachs_Fallzahl": 596,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 28,
+        "Zuwachs_Genesung": 326,
+        "BelegteBetten": null,
+        "Inzidenz": 471.64050432846,
+        "Datum_neu": 1636070400000,
+        "F\u00e4lle_Meldedatum": 91,
+        "Zeitraum": "29.10.2021 - 04.11.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 414.4,
+        "Fallzahl_aktiv": 4282,
         "Krh_N_belegt": 961,
         "Krh_I_belegt": 232,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 316,
+        "Fallzahl_aktiv_Zuwachs": 270,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2594,
+        "Mutation": 2702,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.07,
-        "H_Zeitraum": "28.10.2021 - 03.11.2021",
-        "H_Datum": "04.11.2021"
+        "H_Inzidenz": 7,
+        "H_Zeitraum": "29.10.2021 - 04.11.2021",
+        "H_Datum": "05.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
