### PR TITLE
New data set: 2021-11-08T110803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-05T110504Z.json
+pjson/2021-11-08T110803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-05T110504Z.json pjson/2021-11-08T110803Z.json```:
```
--- pjson/2021-11-05T110504Z.json	2021-11-05 11:05:04.685693095 +0000
+++ pjson/2021-11-08T110803Z.json	2021-11-08 11:08:03.819735802 +0000
@@ -22162,7 +22162,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22236,7 +22236,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22273,7 +22273,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 329,
+        "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -22384,7 +22384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22493,15 +22493,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 101,
         "BelegteBetten": null,
-        "Inzidenz": 296.885663996552,
+        "Inzidenz": null,
         "Datum_neu": 1635379200000,
         "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 276,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 532,
-        "Krh_I_belegt": 159,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22511,7 +22511,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22530,15 +22530,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 147,
         "BelegteBetten": null,
-        "Inzidenz": 320.054599662344,
+        "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 221,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 285.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 602,
-        "Krh_I_belegt": 172,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22548,7 +22548,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.25,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22567,15 +22567,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 8,
         "BelegteBetten": null,
-        "Inzidenz": 299.220517978376,
+        "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 273.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 647,
-        "Krh_I_belegt": 180,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22585,7 +22585,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22604,15 +22604,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 45,
         "BelegteBetten": null,
-        "Inzidenz": 342.684722870793,
+        "Inzidenz": null,
         "Datum_neu": 1635638400000,
-        "F\u00e4lle_Meldedatum": 100,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 295.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 671,
-        "Krh_I_belegt": 179,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22622,7 +22622,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22643,9 +22643,9 @@
         "BelegteBetten": null,
         "Inzidenz": 341.786702108553,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 468,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 319.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 699,
@@ -22659,7 +22659,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.76,
+        "H_Inzidenz": 10.7,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22680,7 +22680,7 @@
         "BelegteBetten": null,
         "Inzidenz": 347.713639139337,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 648,
+        "F\u00e4lle_Meldedatum": 663,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 311.4,
@@ -22696,7 +22696,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.2,
+        "H_Inzidenz": 11.17,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22717,7 +22717,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 510,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 313.7,
@@ -22733,7 +22733,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.74,
+        "H_Inzidenz": 11.19,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22754,9 +22754,9 @@
         "BelegteBetten": null,
         "Inzidenz": 414.705988002443,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 664,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 369.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 920,
@@ -22770,7 +22770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.87,
+        "H_Inzidenz": 11.04,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22782,7 +22782,7 @@
         "ObjectId": 609,
         "Sterbefall": 1155,
         "Genesungsfall": 34305,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3008,
         "Zuwachs_Fallzahl": 596,
         "Zuwachs_Sterbefall": 0,
@@ -22791,9 +22791,9 @@
         "BelegteBetten": null,
         "Inzidenz": 471.64050432846,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 91,
-        "Zeitraum": "29.10.2021 - 04.11.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 455,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 414.4,
         "Fallzahl_aktiv": 4282,
         "Krh_N_belegt": 961,
@@ -22807,9 +22807,120 @@
         "Inzi_SN_RKI": null,
         "Mutation": 2702,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7,
-        "H_Zeitraum": "29.10.2021 - 04.11.2021",
-        "H_Datum": "05.11.2021"
+        "H_Inzidenz": 10.18,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.11.2021",
+        "Fallzahl": 40347,
+        "ObjectId": 610,
+        "Sterbefall": null,
+        "Genesungsfall": 34353,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 48,
+        "BelegteBetten": null,
+        "Inzidenz": 571.859621394447,
+        "Datum_neu": 1636156800000,
+        "F\u00e4lle_Meldedatum": 103,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 439.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 979,
+        "Krh_I_belegt": 240,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.17,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.11.2021",
+        "Fallzahl": 40370,
+        "ObjectId": 611,
+        "Sterbefall": null,
+        "Genesungsfall": 34450,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 97,
+        "BelegteBetten": null,
+        "Inzidenz": 537.914436581774,
+        "Datum_neu": 1636243200000,
+        "F\u00e4lle_Meldedatum": 95,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 460.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 959,
+        "Krh_I_belegt": 256,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.21,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.11.2021",
+        "Fallzahl": 40687,
+        "ObjectId": 612,
+        "Sterbefall": 1155,
+        "Genesungsfall": 34643,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3015,
+        "Zuwachs_Fallzahl": 945,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 338,
+        "BelegteBetten": null,
+        "Inzidenz": 537.196019971982,
+        "Datum_neu": 1636329600000,
+        "F\u00e4lle_Meldedatum": 57,
+        "Zeitraum": "01.11.2021 - 07.11.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 492.2,
+        "Fallzahl_aktiv": 4889,
+        "Krh_N_belegt": 973,
+        "Krh_I_belegt": 256,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 607,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2892,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.69,
+        "H_Zeitraum": "01.11.2021 - 07.11.2021",
+        "H_Datum": "07.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
