### PR TITLE
New data set: 2021-11-09T110704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-08T110803Z.json
+pjson/2021-11-09T110704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-08T110803Z.json pjson/2021-11-09T110704Z.json```:
```
--- pjson/2021-11-08T110803Z.json	2021-11-08 11:08:03.819735802 +0000
+++ pjson/2021-11-09T110704Z.json	2021-11-09 11:07:04.467581648 +0000
@@ -21866,7 +21866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22384,7 +22384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -22495,7 +22495,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -22641,15 +22641,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 158,
         "BelegteBetten": null,
-        "Inzidenz": 341.786702108553,
+        "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 480,
+        "F\u00e4lle_Meldedatum": 482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
-        "Inzidenz_RKI": 319.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 699,
-        "Krh_I_belegt": 179,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22659,7 +22659,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22680,9 +22680,9 @@
         "BelegteBetten": null,
         "Inzidenz": 347.713639139337,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 663,
+        "F\u00e4lle_Meldedatum": 670,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 311.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 776,
@@ -22696,7 +22696,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.17,
+        "H_Inzidenz": 11.34,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22717,9 +22717,9 @@
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 531,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 313.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 878,
@@ -22733,7 +22733,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.19,
+        "H_Inzidenz": 11.86,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22754,9 +22754,9 @@
         "BelegteBetten": null,
         "Inzidenz": 414.705988002443,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 664,
+        "F\u00e4lle_Meldedatum": 675,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 369.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 920,
@@ -22770,7 +22770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.04,
+        "H_Inzidenz": 11.76,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22780,34 +22780,34 @@
         "Datum": "05.11.2021",
         "Fallzahl": 39742,
         "ObjectId": 609,
-        "Sterbefall": 1155,
-        "Genesungsfall": 34305,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3008,
-        "Zuwachs_Fallzahl": 596,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 28,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 326,
         "BelegteBetten": null,
         "Inzidenz": 471.64050432846,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 455,
+        "F\u00e4lle_Meldedatum": 489,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 414.4,
-        "Fallzahl_aktiv": 4282,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 961,
         "Krh_I_belegt": 232,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 270,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2702,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.18,
+        "H_Inzidenz": 11.12,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22818,7 +22818,7 @@
         "Fallzahl": 40347,
         "ObjectId": 610,
         "Sterbefall": null,
-        "Genesungsfall": 34353,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -22828,7 +22828,7 @@
         "BelegteBetten": null,
         "Inzidenz": 571.859621394447,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 439.2,
@@ -22844,7 +22844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.17,
+        "H_Inzidenz": 10.4,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22855,7 +22855,7 @@
         "Fallzahl": 40370,
         "ObjectId": 611,
         "Sterbefall": null,
-        "Genesungsfall": 34450,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -22865,7 +22865,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.914436581774,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 460.1,
@@ -22881,7 +22881,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.21,
+        "H_Inzidenz": 9.54,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22891,36 +22891,73 @@
         "Datum": "08.11.2021",
         "Fallzahl": 40687,
         "ObjectId": 612,
-        "Sterbefall": 1155,
-        "Genesungsfall": 34643,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3015,
-        "Zuwachs_Fallzahl": 945,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 338,
         "BelegteBetten": null,
         "Inzidenz": 537.196019971982,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 57,
-        "Zeitraum": "01.11.2021 - 07.11.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 143,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 492.2,
-        "Fallzahl_aktiv": 4889,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 973,
         "Krh_I_belegt": 256,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 607,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.24,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.11.2021",
+        "Fallzahl": 41135,
+        "ObjectId": 613,
+        "Sterbefall": 1155,
+        "Genesungsfall": 35093,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3035,
+        "Zuwachs_Fallzahl": 448,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 450,
+        "BelegteBetten": null,
+        "Inzidenz": 526.240166672653,
+        "Datum_neu": 1636416000000,
+        "F\u00e4lle_Meldedatum": 82,
+        "Zeitraum": "02.11.2021 - 08.11.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 493.9,
+        "Fallzahl_aktiv": 4887,
+        "Krh_N_belegt": 1061,
+        "Krh_I_belegt": 268,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2892,
+        "Mutation": 2944,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
-        "H_Zeitraum": "01.11.2021 - 07.11.2021",
-        "H_Datum": "07.11.2021"
+        "H_Inzidenz": 6.98,
+        "H_Zeitraum": "02.11.2021 - 08.11.2021",
+        "H_Datum": "08.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
