### PR TITLE
New data set: 2021-11-10T111302Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-09T110704Z.json
+pjson/2021-11-10T111302Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-09T110704Z.json pjson/2021-11-10T111302Z.json```:
```
--- pjson/2021-11-09T110704Z.json	2021-11-09 11:07:04.467581648 +0000
+++ pjson/2021-11-10T111302Z.json	2021-11-10 11:13:03.099182534 +0000
@@ -21866,7 +21866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22384,7 +22384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 353,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -22495,7 +22495,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -22507,7 +22507,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22544,7 +22544,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22581,7 +22581,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22643,7 +22643,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 482,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -22655,7 +22655,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22678,25 +22678,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 285,
         "BelegteBetten": null,
-        "Inzidenz": 347.713639139337,
+        "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 670,
+        "F\u00e4lle_Meldedatum": 671,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 311.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 776,
-        "Krh_I_belegt": 199,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22717,7 +22717,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 536,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 313.7,
@@ -22733,7 +22733,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.86,
+        "H_Inzidenz": 12.13,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22754,7 +22754,7 @@
         "BelegteBetten": null,
         "Inzidenz": 414.705988002443,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 675,
+        "F\u00e4lle_Meldedatum": 676,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 369.1,
@@ -22770,7 +22770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.76,
+        "H_Inzidenz": 12.3,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22791,9 +22791,9 @@
         "BelegteBetten": null,
         "Inzidenz": 471.64050432846,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 489,
+        "F\u00e4lle_Meldedatum": 508,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 414.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 961,
@@ -22803,11 +22803,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.12,
+        "H_Inzidenz": 11.88,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22828,9 +22828,9 @@
         "BelegteBetten": null,
         "Inzidenz": 571.859621394447,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 232,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 439.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 979,
@@ -22840,11 +22840,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.4,
+        "H_Inzidenz": 11.36,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22865,9 +22865,9 @@
         "BelegteBetten": null,
         "Inzidenz": 537.914436581774,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 460.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 959,
@@ -22881,7 +22881,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.54,
+        "H_Inzidenz": 10.53,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22902,9 +22902,9 @@
         "BelegteBetten": null,
         "Inzidenz": 537.196019971982,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 492.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 973,
@@ -22914,11 +22914,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.24,
+        "H_Inzidenz": 10.33,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22928,36 +22928,73 @@
         "Datum": "09.11.2021",
         "Fallzahl": 41135,
         "ObjectId": 613,
-        "Sterbefall": 1155,
-        "Genesungsfall": 35093,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3035,
-        "Zuwachs_Fallzahl": 448,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 450,
         "BelegteBetten": null,
         "Inzidenz": 526.240166672653,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 82,
-        "Zeitraum": "02.11.2021 - 08.11.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 291,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 493.9,
-        "Fallzahl_aktiv": 4887,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1061,
         "Krh_I_belegt": 268,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2944,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.92,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.11.2021",
+        "Fallzahl": 41807,
+        "ObjectId": 614,
+        "Sterbefall": 1167,
+        "Genesungsfall": 35441,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3070,
+        "Zuwachs_Fallzahl": 672,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 35,
+        "Zuwachs_Genesung": 348,
+        "BelegteBetten": null,
+        "Inzidenz": 531.628291246094,
+        "Datum_neu": 1636502400000,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": "03.11.2021 - 09.11.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 430,
+        "Fallzahl_aktiv": 5199,
+        "Krh_N_belegt": 1149,
+        "Krh_I_belegt": 269,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 312,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2981,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
-        "H_Zeitraum": "02.11.2021 - 08.11.2021",
-        "H_Datum": "08.11.2021"
+        "H_Inzidenz": 6.41,
+        "H_Zeitraum": "03.11.2021 - 09.11.2021",
+        "H_Datum": "09.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
