### PR TITLE
New data set: 2021-11-11T110803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-10T111302Z.json
+pjson/2021-11-11T110803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-10T111302Z.json pjson/2021-11-11T110803Z.json```:
```
--- pjson/2021-11-10T111302Z.json	2021-11-10 11:13:03.099182534 +0000
+++ pjson/2021-11-11T110803Z.json	2021-11-11 11:08:03.131035811 +0000
@@ -12949,7 +12949,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613088000000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -14355,7 +14355,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -22273,7 +22273,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 330,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -22347,7 +22347,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635033600000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22421,9 +22421,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 470,
+        "F\u00e4lle_Meldedatum": 469,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22643,7 +22643,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -22680,7 +22680,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 671,
+        "F\u00e4lle_Meldedatum": 673,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -22715,15 +22715,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 268,
         "BelegteBetten": null,
-        "Inzidenz": 380.940407342218,
+        "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 539,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 313.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 878,
-        "Krh_I_belegt": 205,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22733,7 +22733,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.13,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22770,7 +22770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.3,
+        "H_Inzidenz": 12.94,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22791,7 +22791,7 @@
         "BelegteBetten": null,
         "Inzidenz": 471.64050432846,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 508,
+        "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 414.4,
@@ -22807,7 +22807,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.88,
+        "H_Inzidenz": 12.72,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22844,7 +22844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.36,
+        "H_Inzidenz": 12.32,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22881,7 +22881,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.53,
+        "H_Inzidenz": 11.71,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22902,7 +22902,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.196019971982,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 622,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 492.2,
@@ -22918,7 +22918,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.33,
+        "H_Inzidenz": 11.63,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22939,7 +22939,7 @@
         "BelegteBetten": null,
         "Inzidenz": 526.240166672653,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 493.9,
@@ -22951,11 +22951,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.92,
+        "H_Inzidenz": 10.6,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22965,36 +22965,73 @@
         "Datum": "10.11.2021",
         "Fallzahl": 41807,
         "ObjectId": 614,
-        "Sterbefall": 1167,
-        "Genesungsfall": 35441,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3070,
-        "Zuwachs_Fallzahl": 672,
-        "Zuwachs_Sterbefall": 12,
-        "Zuwachs_Krankenhauseinweisung": 35,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 348,
         "BelegteBetten": null,
         "Inzidenz": 531.628291246094,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 52,
-        "Zeitraum": "03.11.2021 - 09.11.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 241,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 430,
-        "Fallzahl_aktiv": 5199,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1149,
         "Krh_I_belegt": 269,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 312,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.41,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.11.2021",
+        "Fallzahl": 42399,
+        "ObjectId": 615,
+        "Sterbefall": 1168,
+        "Genesungsfall": 35742,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3078,
+        "Zuwachs_Fallzahl": 592,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 301,
+        "BelegteBetten": null,
+        "Inzidenz": 537.555228276878,
+        "Datum_neu": 1636588800000,
+        "F\u00e4lle_Meldedatum": 69,
+        "Zeitraum": "04.11.2021 - 10.11.2021",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 498.4,
+        "Fallzahl_aktiv": 5489,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 288,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 290,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2981,
+        "Mutation": 3001,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.41,
-        "H_Zeitraum": "03.11.2021 - 09.11.2021",
-        "H_Datum": "09.11.2021"
+        "H_Inzidenz": 6.58,
+        "H_Zeitraum": "04.11.2021 - 10.11.2021",
+        "H_Datum": "10.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
