### PR TITLE
New data set: 2021-11-12T112504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-11T110803Z.json
+pjson/2021-11-12T112504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-11T110803Z.json pjson/2021-11-12T112504Z.json```:
```
--- pjson/2021-11-11T110803Z.json	2021-11-11 11:08:03.131035811 +0000
+++ pjson/2021-11-12T112504Z.json	2021-11-12 11:25:04.510884488 +0000
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -22532,7 +22532,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 221,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -22608,7 +22608,7 @@
         "Datum_neu": 1635638400000,
         "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22643,7 +22643,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 484,
+        "F\u00e4lle_Meldedatum": 488,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -22655,7 +22655,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22692,7 +22692,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22717,7 +22717,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 539,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -22729,7 +22729,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22752,9 +22752,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 238,
         "BelegteBetten": null,
-        "Inzidenz": 414.705988002443,
+        "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 676,
+        "F\u00e4lle_Meldedatum": 675,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 369.1,
@@ -22770,7 +22770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.94,
+        "H_Inzidenz": 13.26,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22791,9 +22791,9 @@
         "BelegteBetten": null,
         "Inzidenz": 471.64050432846,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 515,
+        "F\u00e4lle_Meldedatum": 522,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 414.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 961,
@@ -22807,7 +22807,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.72,
+        "H_Inzidenz": 13.11,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22828,7 +22828,7 @@
         "BelegteBetten": null,
         "Inzidenz": 571.859621394447,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 249,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 439.2,
@@ -22844,7 +22844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.32,
+        "H_Inzidenz": 12.77,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22865,7 +22865,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.914436581774,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 460.1,
@@ -22881,7 +22881,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.71,
+        "H_Inzidenz": 12.13,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22902,9 +22902,9 @@
         "BelegteBetten": null,
         "Inzidenz": 537.196019971982,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 622,
+        "F\u00e4lle_Meldedatum": 653,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 492.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 973,
@@ -22914,11 +22914,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.63,
+        "H_Inzidenz": 12.03,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22939,7 +22939,7 @@
         "BelegteBetten": null,
         "Inzidenz": 526.240166672653,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 476,
+        "F\u00e4lle_Meldedatum": 787,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 493.9,
@@ -22951,11 +22951,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.6,
+        "H_Inzidenz": 11.12,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22976,9 +22976,9 @@
         "BelegteBetten": null,
         "Inzidenz": 531.628291246094,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 430,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1149,
@@ -22992,7 +22992,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.41,
+        "H_Inzidenz": 9.02,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23004,7 +23004,7 @@
         "ObjectId": 615,
         "Sterbefall": 1168,
         "Genesungsfall": 35742,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3078,
         "Zuwachs_Fallzahl": 592,
         "Zuwachs_Sterbefall": 1,
@@ -23013,9 +23013,9 @@
         "BelegteBetten": null,
         "Inzidenz": 537.555228276878,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 69,
-        "Zeitraum": "04.11.2021 - 10.11.2021",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 267,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 498.4,
         "Fallzahl_aktiv": 5489,
         "Krh_N_belegt": 1189,
@@ -23027,11 +23027,48 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3001,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.06,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.11.2021",
+        "Fallzahl": 43096,
+        "ObjectId": 616,
+        "Sterbefall": 1177,
+        "Genesungsfall": 35939,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3088,
+        "Zuwachs_Fallzahl": 697,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 197,
+        "BelegteBetten": null,
+        "Inzidenz": 535.759186752398,
+        "Datum_neu": 1636675200000,
+        "F\u00e4lle_Meldedatum": 92,
+        "Zeitraum": "05.11.2021 - 11.11.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 476.2,
+        "Fallzahl_aktiv": 5980,
+        "Krh_N_belegt": 1204,
+        "Krh_I_belegt": 317,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 491,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3070,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.58,
-        "H_Zeitraum": "04.11.2021 - 10.11.2021",
-        "H_Datum": "10.11.2021"
+        "H_Inzidenz": 6.21,
+        "H_Zeitraum": "05.11.2021 - 11.11.2021",
+        "H_Datum": "11.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
