### PR TITLE
New data set: 2021-11-15T111203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-12T112504Z.json
+pjson/2021-11-15T111203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-12T112504Z.json pjson/2021-11-15T111203Z.json```:
```
--- pjson/2021-11-12T112504Z.json	2021-11-12 11:25:04.510884488 +0000
+++ pjson/2021-11-15T111203Z.json	2021-11-15 11:12:03.297011155 +0000
@@ -9804,7 +9804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -10803,7 +10803,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 360,
+        "F\u00e4lle_Meldedatum": 361,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -12875,7 +12875,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612915200000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -20941,7 +20941,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631750400000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21496,7 +21496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633046400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21533,7 +21533,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21718,7 +21718,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22310,7 +22310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634947200000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -22347,7 +22347,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635033600000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22396,7 +22396,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 354,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -22470,7 +22470,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22581,7 +22581,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22643,7 +22643,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 488,
+        "F\u00e4lle_Meldedatum": 489,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -22680,7 +22680,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 673,
+        "F\u00e4lle_Meldedatum": 677,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -22717,7 +22717,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 545,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -22754,13 +22754,13 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 675,
+        "F\u00e4lle_Meldedatum": 676,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 369.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 920,
-        "Krh_I_belegt": 224,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22770,7 +22770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.26,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22789,15 +22789,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 326,
         "BelegteBetten": null,
-        "Inzidenz": 471.64050432846,
+        "Inzidenz": null,
         "Datum_neu": 1636070400000,
         "F\u00e4lle_Meldedatum": 522,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 414.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 961,
-        "Krh_I_belegt": 232,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22807,7 +22807,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.11,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22826,15 +22826,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 48,
         "BelegteBetten": null,
-        "Inzidenz": 571.859621394447,
+        "Inzidenz": null,
         "Datum_neu": 1636156800000,
         "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 439.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 979,
-        "Krh_I_belegt": 240,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22844,7 +22844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.77,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22863,15 +22863,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 97,
         "BelegteBetten": null,
-        "Inzidenz": 537.914436581774,
+        "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 217,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 460.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 959,
-        "Krh_I_belegt": 256,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22881,7 +22881,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.13,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22902,7 +22902,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.196019971982,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 653,
+        "F\u00e4lle_Meldedatum": 674,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 492.2,
@@ -22918,7 +22918,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.03,
+        "H_Inzidenz": 13.01,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22939,7 +22939,7 @@
         "BelegteBetten": null,
         "Inzidenz": 526.240166672653,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 787,
+        "F\u00e4lle_Meldedatum": 863,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 493.9,
@@ -22955,7 +22955,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.12,
+        "H_Inzidenz": 12.87,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22976,9 +22976,9 @@
         "BelegteBetten": null,
         "Inzidenz": 531.628291246094,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 841,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 430,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1149,
@@ -22988,11 +22988,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.02,
+        "H_Inzidenz": 12.1,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23002,34 +23002,34 @@
         "Datum": "11.11.2021",
         "Fallzahl": 42399,
         "ObjectId": 615,
-        "Sterbefall": 1168,
-        "Genesungsfall": 35742,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3078,
-        "Zuwachs_Fallzahl": 592,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 301,
         "BelegteBetten": null,
         "Inzidenz": 537.555228276878,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 267,
+        "F\u00e4lle_Meldedatum": 441,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 498.4,
-        "Fallzahl_aktiv": 5489,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1189,
         "Krh_I_belegt": 288,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 290,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.06,
+        "H_Inzidenz": 10.67,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23041,7 +23041,7 @@
         "ObjectId": 616,
         "Sterbefall": 1177,
         "Genesungsfall": 35939,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3088,
         "Zuwachs_Fallzahl": 697,
         "Zuwachs_Sterbefall": 9,
@@ -23050,9 +23050,9 @@
         "BelegteBetten": null,
         "Inzidenz": 535.759186752398,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 92,
-        "Zeitraum": "05.11.2021 - 11.11.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 261,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 476.2,
         "Fallzahl_aktiv": 5980,
         "Krh_N_belegt": 1204,
@@ -23066,9 +23066,120 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3070,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.21,
-        "H_Zeitraum": "05.11.2021 - 11.11.2021",
-        "H_Datum": "11.11.2021"
+        "H_Inzidenz": 9.93,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.11.2021",
+        "Fallzahl": 44074,
+        "ObjectId": 617,
+        "Sterbefall": null,
+        "Genesungsfall": 36226,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 287,
+        "BelegteBetten": null,
+        "Inzidenz": 637.415137037968,
+        "Datum_neu": 1636761600000,
+        "F\u00e4lle_Meldedatum": 215,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 471.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1217,
+        "Krh_I_belegt": 291,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.85,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.11.2021",
+        "Fallzahl": 44152,
+        "ObjectId": 618,
+        "Sterbefall": null,
+        "Genesungsfall": 36324,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 98,
+        "BelegteBetten": null,
+        "Inzidenz": 631.128991702288,
+        "Datum_neu": 1636848000000,
+        "F\u00e4lle_Meldedatum": 255,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 473.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1200,
+        "Krh_I_belegt": 306,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.89,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.11.2021",
+        "Fallzahl": 44613,
+        "ObjectId": 619,
+        "Sterbefall": 1184,
+        "Genesungsfall": 36785,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3102,
+        "Zuwachs_Fallzahl": 1517,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 461,
+        "BelegteBetten": null,
+        "Inzidenz": 637.594741190416,
+        "Datum_neu": 1636934400000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "08.11.2021 - 14.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 562.9,
+        "Fallzahl_aktiv": 6644,
+        "Krh_N_belegt": 1281,
+        "Krh_I_belegt": 315,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1049,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3293,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.98,
+        "H_Zeitraum": "08.11.2021 - 14.11.2021",
+        "H_Datum": "14.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
