### PR TITLE
New data set: 2021-11-16T110603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-15T111203Z.json
+pjson/2021-11-16T110603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-15T111203Z.json pjson/2021-11-16T110603Z.json```:
```
--- pjson/2021-11-15T111203Z.json	2021-11-15 11:12:03.297011155 +0000
+++ pjson/2021-11-16T110603Z.json	2021-11-16 11:06:03.700068724 +0000
@@ -9027,7 +9027,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603929600000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -10729,7 +10729,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 428,
+        "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -17315,7 +17315,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1623283200000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22273,7 +22273,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -22532,7 +22532,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 223,
+        "F\u00e4lle_Meldedatum": 224,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -22606,7 +22606,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635638400000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22680,7 +22680,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 677,
+        "F\u00e4lle_Meldedatum": 682,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -22717,7 +22717,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 545,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -22754,7 +22754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 676,
+        "F\u00e4lle_Meldedatum": 677,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22791,7 +22791,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 522,
+        "F\u00e4lle_Meldedatum": 525,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -22828,7 +22828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22840,7 +22840,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22902,7 +22902,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.196019971982,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 674,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 492.2,
@@ -22914,11 +22914,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.01,
+        "H_Inzidenz": 13.09,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22939,7 +22939,7 @@
         "BelegteBetten": null,
         "Inzidenz": 526.240166672653,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 863,
+        "F\u00e4lle_Meldedatum": 897,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 493.9,
@@ -22955,7 +22955,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.87,
+        "H_Inzidenz": 12.47,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22976,7 +22976,7 @@
         "BelegteBetten": null,
         "Inzidenz": 531.628291246094,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 841,
+        "F\u00e4lle_Meldedatum": 870,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 430,
@@ -22992,7 +22992,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.1,
+        "H_Inzidenz": 11.04,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23013,7 +23013,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.555228276878,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 441,
+        "F\u00e4lle_Meldedatum": 903,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 498.4,
@@ -23029,7 +23029,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.67,
+        "H_Inzidenz": 10.72,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23039,34 +23039,34 @@
         "Datum": "12.11.2021",
         "Fallzahl": 43096,
         "ObjectId": 616,
-        "Sterbefall": 1177,
-        "Genesungsfall": 35939,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3088,
-        "Zuwachs_Fallzahl": 697,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
         "Inzidenz": 535.759186752398,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 261,
+        "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 476.2,
-        "Fallzahl_aktiv": 5980,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1204,
         "Krh_I_belegt": 317,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 491,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3070,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.93,
+        "H_Inzidenz": 9.76,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23077,7 +23077,7 @@
         "Fallzahl": 44074,
         "ObjectId": 617,
         "Sterbefall": null,
-        "Genesungsfall": 36226,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -23087,7 +23087,7 @@
         "BelegteBetten": null,
         "Inzidenz": 637.415137037968,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 215,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 471.4,
@@ -23103,7 +23103,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.85,
+        "H_Inzidenz": 8.9,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23114,7 +23114,7 @@
         "Fallzahl": 44152,
         "ObjectId": 618,
         "Sterbefall": null,
-        "Genesungsfall": 36324,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -23124,7 +23124,7 @@
         "BelegteBetten": null,
         "Inzidenz": 631.128991702288,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 473.7,
@@ -23140,7 +23140,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.89,
+        "H_Inzidenz": 8.08,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23150,36 +23150,73 @@
         "Datum": "15.11.2021",
         "Fallzahl": 44613,
         "ObjectId": 619,
-        "Sterbefall": 1184,
-        "Genesungsfall": 36785,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3102,
-        "Zuwachs_Fallzahl": 1517,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 461,
         "BelegteBetten": null,
         "Inzidenz": 637.594741190416,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "08.11.2021 - 14.11.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 298,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 562.9,
-        "Fallzahl_aktiv": 6644,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1281,
         "Krh_I_belegt": 315,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1049,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": 3293,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
-        "H_Zeitraum": "08.11.2021 - 14.11.2021",
-        "H_Datum": "14.11.2021"
+        "H_Inzidenz": 7.79,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.11.2021",
+        "Fallzahl": 45534,
+        "ObjectId": 620,
+        "Sterbefall": 1186,
+        "Genesungsfall": 37445,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3104,
+        "Zuwachs_Fallzahl": 921,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 660,
+        "BelegteBetten": null,
+        "Inzidenz": 679.622112863249,
+        "Datum_neu": 1637020800000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "09.11.2021 - 15.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 573.7,
+        "Fallzahl_aktiv": 6903,
+        "Krh_N_belegt": 1391,
+        "Krh_I_belegt": 330,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 259,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3430,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.01,
+        "H_Zeitraum": "09.11.2021 - 15.11.2021",
+        "H_Datum": "15.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
