### PR TITLE
New data set: 2021-11-17T113104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-16T110603Z.json
+pjson/2021-11-17T113104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-16T110603Z.json pjson/2021-11-17T113104Z.json```:
```
--- pjson/2021-11-16T110603Z.json	2021-11-16 11:06:03.700068724 +0000
+++ pjson/2021-11-17T113104Z.json	2021-11-17 11:31:04.220147728 +0000
@@ -21977,7 +21977,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22199,7 +22199,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 279,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -22495,7 +22495,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -22532,7 +22532,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -22569,7 +22569,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22643,7 +22643,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 489,
+        "F\u00e4lle_Meldedatum": 491,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -22692,7 +22692,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22717,7 +22717,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 548,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -22729,7 +22729,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22754,7 +22754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 677,
+        "F\u00e4lle_Meldedatum": 678,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22791,7 +22791,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 525,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -22803,7 +22803,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22840,7 +22840,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22877,7 +22877,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22900,15 +22900,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 338,
         "BelegteBetten": null,
-        "Inzidenz": 537.196019971982,
+        "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 686,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
-        "Inzidenz_RKI": 492.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 973,
-        "Krh_I_belegt": 256,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22918,7 +22918,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.09,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22937,15 +22937,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 450,
         "BelegteBetten": null,
-        "Inzidenz": 526.240166672653,
+        "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 897,
+        "F\u00e4lle_Meldedatum": 997,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 493.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1061,
-        "Krh_I_belegt": 268,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -22955,7 +22955,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.47,
+        "H_Inzidenz": 12.97,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -22976,7 +22976,7 @@
         "BelegteBetten": null,
         "Inzidenz": 531.628291246094,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 870,
+        "F\u00e4lle_Meldedatum": 943,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 430,
@@ -22992,7 +22992,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.04,
+        "H_Inzidenz": 11.51,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23013,9 +23013,9 @@
         "BelegteBetten": null,
         "Inzidenz": 537.555228276878,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 903,
+        "F\u00e4lle_Meldedatum": 1094,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 498.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1189,
@@ -23029,7 +23029,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.72,
+        "H_Inzidenz": 11.34,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23050,9 +23050,9 @@
         "BelegteBetten": null,
         "Inzidenz": 535.759186752398,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 676,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 476.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1204,
@@ -23066,7 +23066,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.76,
+        "H_Inzidenz": 10.72,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23087,9 +23087,9 @@
         "BelegteBetten": null,
         "Inzidenz": 637.415137037968,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 471.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1217,
@@ -23103,7 +23103,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.9,
+        "H_Inzidenz": 9.93,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23124,7 +23124,7 @@
         "BelegteBetten": null,
         "Inzidenz": 631.128991702288,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 473.7,
@@ -23140,7 +23140,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.08,
+        "H_Inzidenz": 9.24,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23161,7 +23161,7 @@
         "BelegteBetten": null,
         "Inzidenz": 637.594741190416,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 298,
+        "F\u00e4lle_Meldedatum": 264,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 562.9,
@@ -23175,9 +23175,9 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3293,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.79,
+        "H_Inzidenz": 9,
         "H_Zeitraum": null,
         "H_Datum": null
       }
@@ -23187,36 +23187,73 @@
         "Datum": "16.11.2021",
         "Fallzahl": 45534,
         "ObjectId": 620,
-        "Sterbefall": 1186,
-        "Genesungsfall": 37445,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3104,
-        "Zuwachs_Fallzahl": 921,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 660,
         "BelegteBetten": null,
         "Inzidenz": 679.622112863249,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 25,
-        "Zeitraum": "09.11.2021 - 15.11.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 216,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 573.7,
-        "Fallzahl_aktiv": 6903,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1391,
         "Krh_I_belegt": 330,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 259,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.35,
+        "H_Zeitraum": null,
+        "H_Datum": null
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.11.2021",
+        "Fallzahl": 46485,
+        "ObjectId": 621,
+        "Sterbefall": 1193,
+        "Genesungsfall": 37990,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3106,
+        "Zuwachs_Fallzahl": 951,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 545,
+        "BelegteBetten": null,
+        "Inzidenz": 655.555156435217,
+        "Datum_neu": 1637107200000,
+        "F\u00e4lle_Meldedatum": 102,
+        "Zeitraum": "10.11.2021 - 16.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 565.4,
+        "Fallzahl_aktiv": 7302,
+        "Krh_N_belegt": 1524,
+        "Krh_I_belegt": 343,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 399,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3430,
+        "Mutation": 3546,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.01,
-        "H_Zeitraum": "09.11.2021 - 15.11.2021",
-        "H_Datum": "15.11.2021"
+        "H_Inzidenz": 5.64,
+        "H_Zeitraum": "10.11.2021 - 16.11.2021",
+        "H_Datum": "16.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
