### PR TITLE
New data set: 2021-11-18T112203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-17T113104Z.json
+pjson/2021-11-18T112203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-18T105003Z.json pjson/2021-11-18T112203Z.json```:
```
--- pjson/2021-11-18T105003Z.json	2021-11-18 10:50:03.451958050 +0000
+++ pjson/2021-11-18T112203Z.json	2021-11-18 11:22:03.412495008 +0000
@@ -22800,7 +22800,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 281,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22838,7 +22838,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23104,7 +23104,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 491,
+        "F\u00e4lle_Meldedatum": 493,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 682,
+        "F\u00e4lle_Meldedatum": 683,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 548,
+        "F\u00e4lle_Meldedatum": 555,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 686,
+        "F\u00e4lle_Meldedatum": 688,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 997,
+        "F\u00e4lle_Meldedatum": 1209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23576,7 +23576,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.97,
+        "H_Inzidenz": 13.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.11.2021"
@@ -23596,9 +23596,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 348,
         "BelegteBetten": null,
-        "Inzidenz": 531.628291246094,
+        "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 943,
+        "F\u00e4lle_Meldedatum": 919,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 430,
@@ -23614,7 +23614,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.51,
+        "H_Inzidenz": 11.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.11.2021"
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.555228276878,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1094,
+        "F\u00e4lle_Meldedatum": 1017,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 498.4,
@@ -23652,7 +23652,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.34,
+        "H_Inzidenz": 11.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.11.2021"
@@ -23674,9 +23674,9 @@
         "BelegteBetten": null,
         "Inzidenz": 535.759186752398,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 676,
+        "F\u00e4lle_Meldedatum": 909,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 476.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1204,
@@ -23690,7 +23690,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.72,
+        "H_Inzidenz": 11.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.11.2021"
@@ -23712,9 +23712,9 @@
         "BelegteBetten": null,
         "Inzidenz": 637.415137037968,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 182,
+        "F\u00e4lle_Meldedatum": 283,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 471.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1217,
@@ -23728,7 +23728,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.93,
+        "H_Inzidenz": 10.62,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.11.2021"
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": 631.128991702288,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 268,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 473.7,
@@ -23766,7 +23766,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.24,
+        "H_Inzidenz": 10.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.11.2021"
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": 637.594741190416,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 264,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 562.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1281,
@@ -23804,7 +23804,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9,
+        "H_Inzidenz": 9.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.11.2021"
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": 679.622112863249,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 573.7,
@@ -23842,7 +23842,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.35,
+        "H_Inzidenz": 8.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2021"
@@ -23853,38 +23853,76 @@
         "Datum": "17.11.2021",
         "Fallzahl": 46485,
         "ObjectId": 621,
-        "Sterbefall": 1193,
-        "Genesungsfall": 37990,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3106,
-        "Zuwachs_Fallzahl": 951,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 545,
         "BelegteBetten": null,
         "Inzidenz": 655.555156435217,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 102,
-        "Zeitraum": "10.11.2021 - 16.11.2021",
+        "F\u00e4lle_Meldedatum": 218,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 565.4,
-        "Fallzahl_aktiv": 7302,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1524,
         "Krh_I_belegt": 343,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 399,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3546,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.64,
-        "H_Zeitraum": "10.11.2021 - 16.11.2021",
-        "H_Datum": "16.11.2021",
+        "H_Inzidenz": 6.38,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.11.2021",
+        "Fallzahl": 47248,
+        "ObjectId": 622,
+        "Sterbefall": 1193,
+        "Genesungsfall": 38643,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3109,
+        "Zuwachs_Fallzahl": 763,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 653,
+        "BelegteBetten": null,
+        "Inzidenz": 593.052911383311,
+        "Datum_neu": 1637193600000,
+        "F\u00e4lle_Meldedatum": 67,
+        "Zeitraum": "11.11.2021 - 17.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 530.4,
+        "Fallzahl_aktiv": 7412,
+        "Krh_N_belegt": 1520,
+        "Krh_I_belegt": 357,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 110,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3564,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.14,
+        "H_Zeitraum": "11.11.2021 - 17.11.2021",
+        "H_Datum": "17.11.2021",
+        "Datum_Bett": "17.11.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
