### PR TITLE
New data set: 2021-11-19T113203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-18T112203Z.json
+pjson/2021-11-19T113203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-18T112203Z.json pjson/2021-11-19T113203Z.json```:
```
--- pjson/2021-11-18T112203Z.json	2021-11-18 11:22:03.412495008 +0000
+++ pjson/2021-11-19T113203Z.json	2021-11-19 11:32:03.883691873 +0000
@@ -23104,7 +23104,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 555,
+        "F\u00e4lle_Meldedatum": 558,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 678,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23408,9 +23408,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 529,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23446,7 +23446,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 251,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23560,9 +23560,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1209,
+        "F\u00e4lle_Meldedatum": 1212,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23576,7 +23576,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.21,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.11.2021"
@@ -23598,13 +23598,13 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 919,
+        "F\u00e4lle_Meldedatum": 924,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 430,
+        "Hosp_Meldedatum": 11,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1149,
-        "Krh_I_belegt": 269,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23614,7 +23614,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.91,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.11.2021"
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.555228276878,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1017,
+        "F\u00e4lle_Meldedatum": 1021,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 498.4,
@@ -23652,7 +23652,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.11.2021"
@@ -23674,9 +23674,9 @@
         "BelegteBetten": null,
         "Inzidenz": 535.759186752398,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 909,
+        "F\u00e4lle_Meldedatum": 1049,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 476.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1204,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": 637.415137037968,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 283,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 471.4,
@@ -23750,9 +23750,9 @@
         "BelegteBetten": null,
         "Inzidenz": 631.128991702288,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 268,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 473.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1200,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": 637.594741190416,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 701,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 562.9,
@@ -23802,7 +23802,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
+        "Mutation": 3293,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 9.76,
         "H_Zeitraum": null,
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": 679.622112863249,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 396,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 573.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1391,
@@ -23840,7 +23840,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
+        "Mutation": 3430,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 8.11,
         "H_Zeitraum": null,
@@ -23864,9 +23864,9 @@
         "BelegteBetten": null,
         "Inzidenz": 655.555156435217,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 218,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 565.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1524,
@@ -23878,7 +23878,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": null,
+        "Mutation": 3546,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 6.38,
         "H_Zeitraum": null,
@@ -23891,38 +23891,76 @@
         "Datum": "18.11.2021",
         "Fallzahl": 47248,
         "ObjectId": 622,
-        "Sterbefall": 1193,
-        "Genesungsfall": 38643,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3109,
-        "Zuwachs_Fallzahl": 763,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 653,
         "BelegteBetten": null,
         "Inzidenz": 593.052911383311,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 67,
-        "Zeitraum": "11.11.2021 - 17.11.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 110,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 530.4,
-        "Fallzahl_aktiv": 7412,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1520,
         "Krh_I_belegt": 357,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 110,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": 3564,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 4.14,
-        "H_Zeitraum": "11.11.2021 - 17.11.2021",
-        "H_Datum": "17.11.2021",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "19.11.2021",
+        "Fallzahl": 48231,
+        "ObjectId": 623,
+        "Sterbefall": 1193,
+        "Genesungsfall": 39156,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3117,
+        "Zuwachs_Fallzahl": 983,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 513,
+        "BelegteBetten": null,
+        "Inzidenz": 586.587161895183,
+        "Datum_neu": 1637280000000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "12.11.2021 - 18.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 333.5,
+        "Fallzahl_aktiv": 7882,
+        "Krh_N_belegt": 1615,
+        "Krh_I_belegt": 369,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 470,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3622,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.39,
+        "H_Zeitraum": "12.11.2021 - 18.11.2021",
+        "H_Datum": "17.11.2022",
+        "Datum_Bett": "18.11.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
