### PR TITLE
New data set: 2021-11-22T113103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-19T113203Z.json
+pjson/2021-11-22T113103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-19T113203Z.json pjson/2021-11-22T113103Z.json```:
```
--- pjson/2021-11-19T113203Z.json	2021-11-19 11:32:03.883691873 +0000
+++ pjson/2021-11-22T113103Z.json	2021-11-22 11:31:04.034493335 +0000
@@ -10982,7 +10982,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607817600000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -11020,7 +11020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 428,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -11058,7 +11058,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -12084,7 +12084,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -23104,7 +23104,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23218,7 +23218,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635638400000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23382,7 +23382,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23446,7 +23446,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 256,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23458,7 +23458,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 688,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -23572,7 +23572,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23634,15 +23634,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 301,
         "BelegteBetten": null,
-        "Inzidenz": 537.555228276878,
+        "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1021,
+        "F\u00e4lle_Meldedatum": 1022,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 498.4,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1189,
-        "Krh_I_belegt": 288,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23672,25 +23672,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 197,
         "BelegteBetten": null,
-        "Inzidenz": 535.759186752398,
+        "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1049,
+        "F\u00e4lle_Meldedatum": 1055,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 476.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1204,
-        "Krh_I_belegt": 317,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.11.2021"
@@ -23710,25 +23710,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 287,
         "BelegteBetten": null,
-        "Inzidenz": 637.415137037968,
+        "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 480,
+        "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 471.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1217,
-        "Krh_I_belegt": 291,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.62,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.11.2021"
@@ -23748,15 +23748,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 98,
         "BelegteBetten": null,
-        "Inzidenz": 631.128991702288,
+        "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 473.7,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1200,
-        "Krh_I_belegt": 306,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23766,7 +23766,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.1,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.11.2021"
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": 637.594741190416,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 701,
+        "F\u00e4lle_Meldedatum": 1020,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 562.9,
@@ -23800,11 +23800,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 3293,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.76,
+        "H_Inzidenz": 12.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.11.2021"
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": 679.622112863249,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 396,
+        "F\u00e4lle_Meldedatum": 787,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 573.7,
@@ -23842,7 +23842,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3430,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.11,
+        "H_Inzidenz": 10.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2021"
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": 655.555156435217,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 565.4,
@@ -23880,7 +23880,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3546,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": 9.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2021"
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": 593.052911383311,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 530.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1520,
@@ -23918,7 +23918,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3564,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.14,
+        "H_Inzidenz": 7.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2021"
@@ -23931,7 +23931,7 @@
         "ObjectId": 623,
         "Sterbefall": 1193,
         "Genesungsfall": 39156,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3117,
         "Zuwachs_Fallzahl": 983,
         "Zuwachs_Sterbefall": 0,
@@ -23940,8 +23940,8 @@
         "BelegteBetten": null,
         "Inzidenz": 586.587161895183,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 31,
-        "Zeitraum": "12.11.2021 - 18.11.2021",
+        "F\u00e4lle_Meldedatum": 302,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 333.5,
         "Fallzahl_aktiv": 7882,
@@ -23956,11 +23956,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3622,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.39,
-        "H_Zeitraum": "12.11.2021 - 18.11.2021",
-        "H_Datum": "17.11.2022",
+        "H_Inzidenz": 5.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "18.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.11.2021",
+        "Fallzahl": 49336,
+        "ObjectId": 624,
+        "Sterbefall": null,
+        "Genesungsfall": 39464,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 308,
+        "BelegteBetten": null,
+        "Inzidenz": 583.354287151119,
+        "Datum_neu": 1637366400000,
+        "F\u00e4lle_Meldedatum": 533,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 383.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.03,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.11.2021",
+        "Fallzahl": 49340,
+        "ObjectId": 625,
+        "Sterbefall": null,
+        "Genesungsfall": 39690,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 226,
+        "BelegteBetten": null,
+        "Inzidenz": 592.154890621071,
+        "Datum_neu": 1637452800000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 448.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.58,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "20.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.11.2021",
+        "Fallzahl": 49865,
+        "ObjectId": 626,
+        "Sterbefall": 1202,
+        "Genesungsfall": 40352,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3123,
+        "Zuwachs_Fallzahl": 1634,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 1196,
+        "BelegteBetten": null,
+        "Inzidenz": 547.433456661518,
+        "Datum_neu": 1637539200000,
+        "F\u00e4lle_Meldedatum": 56,
+        "Zeitraum": "15.11.2021 - 21.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 465.5,
+        "Fallzahl_aktiv": 8311,
+        "Krh_N_belegt": 1838,
+        "Krh_I_belegt": 455,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 429,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3778,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.39,
+        "H_Zeitraum": "15.11.2021 - 21.11.2021",
+        "H_Datum": "22.11.2021",
+        "Datum_Bett": "21.11.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
