### PR TITLE
New data set: 2021-11-23T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-22T113103Z.json
+pjson/2021-11-23T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-22T113103Z.json pjson/2021-11-23T110403Z.json```:
```
--- pjson/2021-11-22T113103Z.json	2021-11-22 11:31:04.034493335 +0000
+++ pjson/2021-11-23T110403Z.json	2021-11-23 11:04:03.425338567 +0000
@@ -18240,7 +18240,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1624320000000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -21280,7 +21280,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22230,7 +22230,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633392000000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22762,7 +22762,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22800,7 +22800,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 281,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23028,7 +23028,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 469,
+        "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 493,
+        "F\u00e4lle_Meldedatum": 494,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 685,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 536,
+        "F\u00e4lle_Meldedatum": 535,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23524,7 +23524,7 @@
         "Datum_neu": 1636329600000,
         "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1212,
+        "F\u00e4lle_Meldedatum": 1214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 924,
+        "F\u00e4lle_Meldedatum": 929,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1022,
+        "F\u00e4lle_Meldedatum": 1023,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1055,
+        "F\u00e4lle_Meldedatum": 1056,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23786,15 +23786,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 461,
         "BelegteBetten": null,
-        "Inzidenz": 637.594741190416,
+        "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1020,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 562.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1281,
-        "Krh_I_belegt": 315,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23802,9 +23802,9 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 3293,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.15,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.11.2021"
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": 679.622112863249,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 787,
+        "F\u00e4lle_Meldedatum": 1439,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 573.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1391,
@@ -23842,7 +23842,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3430,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.97,
+        "H_Inzidenz": 11.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2021"
@@ -23864,9 +23864,9 @@
         "BelegteBetten": null,
         "Inzidenz": 655.555156435217,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 565.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1524,
@@ -23880,7 +23880,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3546,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.34,
+        "H_Inzidenz": 10.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2021"
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": 593.052911383311,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 530.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1520,
@@ -23918,7 +23918,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3564,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.03,
+        "H_Inzidenz": 7.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2021"
@@ -23929,34 +23929,34 @@
         "Datum": "19.11.2021",
         "Fallzahl": 48231,
         "ObjectId": 623,
-        "Sterbefall": 1193,
-        "Genesungsfall": 39156,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3117,
-        "Zuwachs_Fallzahl": 983,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 513,
         "BelegteBetten": null,
         "Inzidenz": 586.587161895183,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 302,
+        "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 333.5,
-        "Fallzahl_aktiv": 7882,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1615,
         "Krh_I_belegt": 369,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 470,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 3622,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2021"
@@ -23968,7 +23968,7 @@
         "Fallzahl": 49336,
         "ObjectId": 624,
         "Sterbefall": null,
-        "Genesungsfall": 39464,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -23978,9 +23978,9 @@
         "BelegteBetten": null,
         "Inzidenz": 583.354287151119,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 533,
+        "F\u00e4lle_Meldedatum": 584,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 383.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23994,7 +23994,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.03,
+        "H_Inzidenz": 6.04,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2021"
@@ -24006,7 +24006,7 @@
         "Fallzahl": 49340,
         "ObjectId": 625,
         "Sterbefall": null,
-        "Genesungsfall": 39690,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -24016,9 +24016,9 @@
         "BelegteBetten": null,
         "Inzidenz": 592.154890621071,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 448.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24028,11 +24028,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 5.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2021"
@@ -24045,7 +24045,7 @@
         "ObjectId": 626,
         "Sterbefall": 1202,
         "Genesungsfall": 40352,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3123,
         "Zuwachs_Fallzahl": 1634,
         "Zuwachs_Sterbefall": 9,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 56,
-        "Zeitraum": "15.11.2021 - 21.11.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 293,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 465.5,
         "Fallzahl_aktiv": 8311,
         "Krh_N_belegt": 1838,
@@ -24066,15 +24066,53 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 3778,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.39,
-        "H_Zeitraum": "15.11.2021 - 21.11.2021",
-        "H_Datum": "22.11.2021",
+        "H_Inzidenz": 5.4,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.11.2021",
+        "Fallzahl": 51258,
+        "ObjectId": 627,
+        "Sterbefall": 1206,
+        "Genesungsfall": 41558,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3137,
+        "Zuwachs_Fallzahl": 1393,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 1206,
+        "BelegteBetten": null,
+        "Inzidenz": 587.125974352527,
+        "Datum_neu": 1637625600000,
+        "F\u00e4lle_Meldedatum": 141,
+        "Zeitraum": "16.11.2021 - 22.11.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 446.4,
+        "Fallzahl_aktiv": 8494,
+        "Krh_N_belegt": 1928,
+        "Krh_I_belegt": 495,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 183,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3892,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.36,
+        "H_Zeitraum": "16.11.2021 - 22.11.2021",
+        "H_Datum": "23.11.2021",
+        "Datum_Bett": "22.11.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
