### PR TITLE
New data set: 2021-11-23T112904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-23T110403Z.json
+pjson/2021-11-23T112904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-23T110403Z.json pjson/2021-11-23T112904Z.json```:
```
--- pjson/2021-11-23T110403Z.json	2021-11-23 11:04:03.425338567 +0000
+++ pjson/2021-11-23T112904Z.json	2021-11-23 11:29:05.437731298 +0000
@@ -23831,8 +23831,8 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 573.7,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1391,
-        "Krh_I_belegt": 330,
+        "Krh_N_belegt": 1524,
+        "Krh_I_belegt": 343,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23869,8 +23869,8 @@
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 565.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1524,
-        "Krh_I_belegt": 343,
+        "Krh_N_belegt": 1520,
+        "Krh_I_belegt": 357,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23907,8 +23907,8 @@
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 530.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1520,
-        "Krh_I_belegt": 357,
+        "Krh_N_belegt": 1615,
+        "Krh_I_belegt": 369,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23945,8 +23945,8 @@
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 333.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1615,
-        "Krh_I_belegt": 369,
+        "Krh_N_belegt": 1638,
+        "Krh_I_belegt": 385,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23983,8 +23983,8 @@
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 383.1,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 1596,
+        "Krh_I_belegt": 471,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24021,8 +24021,8 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 448.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 1700,
+        "Krh_I_belegt": 446,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
