### PR TITLE
New data set: 2021-11-24T113103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-23T110403Z.json
+pjson/2021-11-24T113103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-23T112904Z.json pjson/2021-11-24T113103Z.json```:
```
--- pjson/2021-11-23T112904Z.json	2021-11-23 11:29:05.437731298 +0000
+++ pjson/2021-11-24T113103Z.json	2021-11-24 11:31:04.007096839 +0000
@@ -9804,7 +9804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 197,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -11058,7 +11058,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -12616,7 +12616,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -15960,7 +15960,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -20294,7 +20294,7 @@
         "Datum_neu": 1628985600000,
         "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22192,7 +22192,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22306,7 +22306,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22534,7 +22534,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22990,7 +22990,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 212,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23028,7 +23028,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 470,
+        "F\u00e4lle_Meldedatum": 469,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23066,7 +23066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23104,9 +23104,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 494,
+        "F\u00e4lle_Meldedatum": 495,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 558,
+        "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 690,
+        "F\u00e4lle_Meldedatum": 688,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 690,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23562,7 +23562,7 @@
         "Datum_neu": 1636416000000,
         "F\u00e4lle_Meldedatum": 1214,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 929,
+        "F\u00e4lle_Meldedatum": 932,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -23674,9 +23674,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1056,
+        "F\u00e4lle_Meldedatum": 1055,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 484,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23750,9 +23750,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1064,
+        "F\u00e4lle_Meldedatum": 1089,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23800,7 +23800,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23824,15 +23824,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 660,
         "BelegteBetten": null,
-        "Inzidenz": 679.622112863249,
+        "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1439,
+        "F\u00e4lle_Meldedatum": 1513,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 573.7,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1524,
-        "Krh_I_belegt": 343,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23840,9 +23840,9 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3430,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.51,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2021"
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": 655.555156435217,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 402,
+        "F\u00e4lle_Meldedatum": 910,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 565.4,
@@ -23880,7 +23880,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3546,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.03,
+        "H_Inzidenz": 11.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2021"
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": 593.052911383311,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 168,
+        "F\u00e4lle_Meldedatum": 852,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 530.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1615,
@@ -23918,7 +23918,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3564,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.91,
+        "H_Inzidenz": 9.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2021"
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": 586.587161895183,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 335,
+        "F\u00e4lle_Meldedatum": 379,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 333.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1638,
@@ -23956,7 +23956,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3622,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": 8.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2021"
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": 583.354287151119,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 584,
+        "F\u00e4lle_Meldedatum": 627,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 383.1,
@@ -23990,11 +23990,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.04,
+        "H_Inzidenz": 7.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2021"
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": 592.154890621071,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 448.4,
@@ -24032,7 +24032,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.6,
+        "H_Inzidenz": 7.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2021"
@@ -24043,34 +24043,34 @@
         "Datum": "22.11.2021",
         "Fallzahl": 49865,
         "ObjectId": 626,
-        "Sterbefall": 1202,
-        "Genesungsfall": 40352,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3123,
-        "Zuwachs_Fallzahl": 1634,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1196,
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 334,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 465.5,
-        "Fallzahl_aktiv": 8311,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1838,
         "Krh_I_belegt": 455,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 429,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 3778,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.4,
+        "H_Inzidenz": 6.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2021"
@@ -24081,38 +24081,76 @@
         "Datum": "23.11.2021",
         "Fallzahl": 51258,
         "ObjectId": 627,
-        "Sterbefall": 1206,
-        "Genesungsfall": 41558,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3137,
-        "Zuwachs_Fallzahl": 1393,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1206,
         "BelegteBetten": null,
         "Inzidenz": 587.125974352527,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 141,
-        "Zeitraum": "16.11.2021 - 22.11.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 553,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 446.4,
-        "Fallzahl_aktiv": 8494,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1928,
         "Krh_I_belegt": 495,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 183,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": 3892,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.36,
-        "H_Zeitraum": "16.11.2021 - 22.11.2021",
-        "H_Datum": "23.11.2021",
+        "H_Inzidenz": 5.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.11.2022",
+        "Fallzahl": 53314,
+        "ObjectId": 628,
+        "Sterbefall": 1209,
+        "Genesungsfall": 42490,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3151,
+        "Zuwachs_Fallzahl": 2056,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 932,
+        "BelegteBetten": null,
+        "Inzidenz": 664.894572362513,
+        "Datum_neu": 1669248000000,
+        "F\u00e4lle_Meldedatum": 219,
+        "Zeitraum": "17.11.2021 - 23.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 471.6,
+        "Fallzahl_aktiv": 9615,
+        "Krh_N_belegt": 1943,
+        "Krh_I_belegt": 533,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1121,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3937,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.2,
+        "H_Zeitraum": "17.11.2021 - 23.11.2021",
+        "H_Datum": "24.11.2021",
+        "Datum_Bett": "23.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
