### PR TITLE
New data set: 2021-11-24T121003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-24T113103Z.json
+pjson/2021-11-24T121003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-24T113103Z.json pjson/2021-11-24T121003Z.json```:
```
--- pjson/2021-11-24T113103Z.json	2021-11-24 11:31:04.007096839 +0000
+++ pjson/2021-11-24T121003Z.json	2021-11-24 12:10:03.976234927 +0000
@@ -24116,7 +24116,7 @@
     },
     {
       "attributes": {
-        "Datum": "24.11.2022",
+        "Datum": "24.11.2021",
         "Fallzahl": 53314,
         "ObjectId": 628,
         "Sterbefall": 1209,
@@ -24129,7 +24129,7 @@
         "Zuwachs_Genesung": 932,
         "BelegteBetten": null,
         "Inzidenz": 664.894572362513,
-        "Datum_neu": 1669248000000,
+        "Datum_neu": 1637712000000,
         "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": "17.11.2021 - 23.11.2021",
         "Hosp_Meldedatum": 0,
@@ -24149,7 +24149,7 @@
         "H_Inzidenz": 5.2,
         "H_Zeitraum": "17.11.2021 - 23.11.2021",
         "H_Datum": "24.11.2021",
-        "Datum_Bett": "23.11.2022"
+        "Datum_Bett": "23.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
