### PR TITLE
New data set: 2021-11-25T110604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-24T121003Z.json
+pjson/2021-11-25T110604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-24T121003Z.json pjson/2021-11-25T110604Z.json```:
```
--- pjson/2021-11-24T121003Z.json	2021-11-24 12:10:03.976234927 +0000
+++ pjson/2021-11-25T110604Z.json	2021-11-25 11:06:04.799635407 +0000
@@ -22192,7 +22192,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22876,7 +22876,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 333,
+        "F\u00e4lle_Meldedatum": 334,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23028,7 +23028,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 469,
+        "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23066,7 +23066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23180,7 +23180,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23218,7 +23218,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635638400000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 495,
+        "F\u00e4lle_Meldedatum": 494,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 685,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 557,
+        "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 688,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 535,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1214,
+        "F\u00e4lle_Meldedatum": 1212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1023,
+        "F\u00e4lle_Meldedatum": 1021,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23648,7 +23648,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1055,
+        "F\u00e4lle_Meldedatum": 1054,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23686,7 +23686,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23724,7 +23724,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23762,7 +23762,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1089,
+        "F\u00e4lle_Meldedatum": 1091,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1513,
+        "F\u00e4lle_Meldedatum": 1521,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23862,15 +23862,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 545,
         "BelegteBetten": null,
-        "Inzidenz": 655.555156435217,
+        "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 910,
+        "F\u00e4lle_Meldedatum": 914,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 565.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1520,
-        "Krh_I_belegt": 357,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23878,9 +23878,9 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3546,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2021"
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": 593.052911383311,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 852,
+        "F\u00e4lle_Meldedatum": 1032,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 530.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1615,
@@ -23918,7 +23918,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3564,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.69,
+        "H_Inzidenz": 10.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2021"
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": 586.587161895183,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 379,
+        "F\u00e4lle_Meldedatum": 735,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 333.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1638,
@@ -23956,7 +23956,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3622,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.48,
+        "H_Inzidenz": 9.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2021"
@@ -23978,9 +23978,9 @@
         "BelegteBetten": null,
         "Inzidenz": 583.354287151119,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 627,
+        "F\u00e4lle_Meldedatum": 784,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 383.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1596,
@@ -23994,7 +23994,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
+        "H_Inzidenz": 8.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2021"
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": 592.154890621071,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 448.4,
@@ -24032,7 +24032,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.07,
+        "H_Inzidenz": 8.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2021"
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 334,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 465.5,
@@ -24066,11 +24066,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": 3778,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.85,
+        "H_Inzidenz": 7.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2021"
@@ -24092,9 +24092,9 @@
         "BelegteBetten": null,
         "Inzidenz": 587.125974352527,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 553,
+        "F\u00e4lle_Meldedatum": 642,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 446.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1928,
@@ -24108,7 +24108,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": 3892,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.87,
+        "H_Inzidenz": 6.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2021"
@@ -24116,40 +24116,78 @@
     },
     {
       "attributes": {
-        "Datum": "24.11.2021",
-        "Fallzahl": 53314,
+        "Datum": "25.11.2021",
+        "Fallzahl": 54857,
         "ObjectId": 628,
-        "Sterbefall": 1209,
-        "Genesungsfall": 42490,
+        "Sterbefall": 1217,
+        "Genesungsfall": 43517,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 3170,
+        "Zuwachs_Fallzahl": 1543,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 1027,
+        "BelegteBetten": null,
+        "Inzidenz": 783.253708825748,
+        "Datum_neu": 1637798400000,
+        "F\u00e4lle_Meldedatum": 177,
+        "Zeitraum": "18.11.2021 - 24.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 630.3,
+        "Fallzahl_aktiv": 10123,
+        "Krh_N_belegt": 1918,
+        "Krh_I_belegt": 534,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 508,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4094,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.47,
+        "H_Zeitraum": "18.11.2021 - 24.11.2022",
+        "H_Datum": "25.11.2021",
+        "Datum_Bett": "24.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.11.2022",
+        "Fallzahl": 53314,
+        "ObjectId": 629,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3151,
-        "Zuwachs_Fallzahl": 2056,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 932,
         "BelegteBetten": null,
         "Inzidenz": 664.894572362513,
-        "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 219,
-        "Zeitraum": "17.11.2021 - 23.11.2021",
-        "Hosp_Meldedatum": 0,
+        "Datum_neu": 1669248000000,
+        "F\u00e4lle_Meldedatum": 597,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 471.6,
-        "Fallzahl_aktiv": 9615,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1943,
         "Krh_I_belegt": 533,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1121,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": 3937,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.2,
-        "H_Zeitraum": "17.11.2021 - 23.11.2021",
-        "H_Datum": "24.11.2021",
-        "Datum_Bett": "23.11.2021"
+        "H_Inzidenz": 6.14,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.11.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
