### PR TITLE
New data set: 2021-11-26T121503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-25T112003Z.json
+pjson/2021-11-26T121503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-25T112003Z.json pjson/2021-11-26T121503Z.json```:
```
--- pjson/2021-11-25T112003Z.json	2021-11-25 11:20:03.859806104 +0000
+++ pjson/2021-11-26T121503Z.json	2021-11-26 12:15:04.113737508 +0000
@@ -9804,7 +9804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605139200000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -9956,7 +9956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605484800000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -10184,7 +10184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606003200000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -13262,7 +13262,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613001600000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -15656,7 +15656,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618444800000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22986,7 +22986,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 67,
+        "Zuwachs_Genesung": 69,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
@@ -23024,7 +23024,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 129,
+        "Zuwachs_Genesung": 140,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
@@ -23062,7 +23062,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 108,
+        "Zuwachs_Genesung": 117,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
@@ -23100,7 +23100,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 101,
+        "Zuwachs_Genesung": 99,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
@@ -23138,7 +23138,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 147,
+        "Zuwachs_Genesung": 158,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
@@ -23176,11 +23176,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 8,
+        "Zuwachs_Genesung": 14,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23214,7 +23214,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 45,
+        "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635638400000,
@@ -23252,7 +23252,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 158,
+        "Zuwachs_Genesung": 95,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
@@ -23290,7 +23290,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 285,
+        "Zuwachs_Genesung": 284,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
@@ -23328,11 +23328,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 268,
+        "Zuwachs_Genesung": 272,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23366,11 +23366,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 238,
+        "Zuwachs_Genesung": 229,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 685,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23404,11 +23404,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 326,
+        "Zuwachs_Genesung": 327,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23442,7 +23442,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 48,
+        "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
@@ -23458,7 +23458,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23480,7 +23480,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 97,
+        "Zuwachs_Genesung": 92,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
@@ -23518,13 +23518,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 338,
+        "Zuwachs_Genesung": 192,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
         "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23556,13 +23556,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 450,
+        "Zuwachs_Genesung": 444,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1212,
+        "F\u00e4lle_Meldedatum": 1211,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23572,7 +23572,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23594,11 +23594,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 348,
+        "Zuwachs_Genesung": 345,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 932,
+        "F\u00e4lle_Meldedatum": 930,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -23632,7 +23632,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 301,
+        "Zuwachs_Genesung": 302,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
@@ -23648,7 +23648,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23670,7 +23670,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 197,
+        "Zuwachs_Genesung": 215,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
@@ -23708,11 +23708,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 287,
+        "Zuwachs_Genesung": 288,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23724,7 +23724,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23746,11 +23746,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 98,
+        "Zuwachs_Genesung": 97,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 290,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23762,7 +23762,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23784,11 +23784,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 461,
+        "Zuwachs_Genesung": 463,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1091,
+        "F\u00e4lle_Meldedatum": 1090,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23822,7 +23822,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 660,
+        "Zuwachs_Genesung": 667,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
@@ -23838,7 +23838,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23860,11 +23860,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 545,
+        "Zuwachs_Genesung": 559,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 914,
+        "F\u00e4lle_Meldedatum": 916,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23876,7 +23876,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23898,27 +23898,27 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 653,
+        "Zuwachs_Genesung": 673,
         "BelegteBetten": null,
-        "Inzidenz": 593.052911383311,
+        "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1032,
+        "F\u00e4lle_Meldedatum": 1047,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 530.4,
+        "Hosp_Meldedatum": 28,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1615,
-        "Krh_I_belegt": 369,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 3564,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2021"
@@ -23936,27 +23936,27 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 513,
+        "Zuwachs_Genesung": 529,
         "BelegteBetten": null,
         "Inzidenz": 586.587161895183,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 735,
+        "F\u00e4lle_Meldedatum": 1028,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 333.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1638,
-        "Krh_I_belegt": 385,
+        "Krh_N_belegt": 1596,
+        "Krh_I_belegt": 471,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
-        "Mutation": 3622,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.56,
+        "H_Inzidenz": 11.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2021"
@@ -23974,27 +23974,27 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 308,
+        "Zuwachs_Genesung": 255,
         "BelegteBetten": null,
         "Inzidenz": 583.354287151119,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 784,
+        "F\u00e4lle_Meldedatum": 834,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 383.1,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1596,
-        "Krh_I_belegt": 471,
+        "Krh_N_belegt": 1700,
+        "Krh_I_belegt": 446,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.82,
+        "H_Inzidenz": 10.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2021"
@@ -24016,13 +24016,13 @@
         "BelegteBetten": null,
         "Inzidenz": 592.154890621071,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 165,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 448.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1700,
-        "Krh_I_belegt": 446,
+        "Krh_N_belegt": 1838,
+        "Krh_I_belegt": 455,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24032,7 +24032,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.13,
+        "H_Inzidenz": 10.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2021"
@@ -24050,17 +24050,17 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1196,
+        "Zuwachs_Genesung": 661,
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 764,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 465.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1838,
-        "Krh_I_belegt": 455,
+        "Krh_N_belegt": 1928,
+        "Krh_I_belegt": 495,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24068,9 +24068,9 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 3778,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.84,
+        "H_Inzidenz": 9.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2021"
@@ -24088,27 +24088,27 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1206,
+        "Zuwachs_Genesung": 1201,
         "BelegteBetten": null,
         "Inzidenz": 587.125974352527,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 642,
+        "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 446.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1928,
-        "Krh_I_belegt": 495,
+        "Krh_N_belegt": 1943,
+        "Krh_I_belegt": 533,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 3892,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.7,
+        "H_Inzidenz": 8.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2021"
@@ -24126,17 +24126,17 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 932,
+        "Zuwachs_Genesung": 937,
         "BelegteBetten": null,
         "Inzidenz": 664.894572362513,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 597,
+        "F\u00e4lle_Meldedatum": 816,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 471.6,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1943,
-        "Krh_I_belegt": 533,
+        "Krh_N_belegt": 1918,
+        "Krh_I_belegt": 534,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24144,9 +24144,9 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 3937,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.14,
+        "H_Inzidenz": 8.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2021"
@@ -24159,36 +24159,74 @@
         "ObjectId": 629,
         "Sterbefall": 1217,
         "Genesungsfall": 43517,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3170,
         "Zuwachs_Fallzahl": 1543,
         "Zuwachs_Sterbefall": 8,
         "Zuwachs_Krankenhauseinweisung": 19,
-        "Zuwachs_Genesung": 1027,
+        "Zuwachs_Genesung": 1039,
         "BelegteBetten": null,
         "Inzidenz": 783.253708825748,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 177,
-        "Zeitraum": "18.11.2021 - 24.11.2021",
+        "F\u00e4lle_Meldedatum": 1055,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 630.3,
         "Fallzahl_aktiv": 10123,
-        "Krh_N_belegt": 1918,
-        "Krh_I_belegt": 534,
+        "Krh_N_belegt": 1963,
+        "Krh_I_belegt": 548,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 508,
+        "Fallzahl_aktiv_Zuwachs": 496,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4094,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.47,
-        "H_Zeitraum": "18.11.2021 - 24.11.2021",
-        "H_Datum": "25.11.2021",
+        "H_Inzidenz": 7.84,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.11.2021",
+        "Fallzahl": 57082,
+        "ObjectId": 630,
+        "Sterbefall": 1234,
+        "Genesungsfall": 44545,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3191,
+        "Zuwachs_Fallzahl": 2225,
+        "Zuwachs_Sterbefall": 17,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 1028,
+        "BelegteBetten": null,
+        "Inzidenz": 991.594525665433,
+        "Datum_neu": 1637884800000,
+        "F\u00e4lle_Meldedatum": 200,
+        "Zeitraum": "19.11.2021 - 25.11.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 735.7,
+        "Fallzahl_aktiv": 11303,
+        "Krh_N_belegt": 1963,
+        "Krh_I_belegt": 548,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1180,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4249,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.99,
+        "H_Zeitraum": "19.11.2021 - 25.11.2021",
+        "H_Datum": "25.11.2021",
+        "Datum_Bett": "25.11.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
