### PR TITLE
New data set: 2021-11-29T110904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-26T121503Z.json
+pjson/2021-11-29T110904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-26T121503Z.json pjson/2021-11-29T110904Z.json```:
```
--- pjson/2021-11-26T121503Z.json	2021-11-26 12:15:04.113737508 +0000
+++ pjson/2021-11-29T110904Z.json	2021-11-29 11:09:04.517968463 +0000
@@ -9994,7 +9994,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10298,7 +10298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -11590,7 +11590,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 574,
+        "F\u00e4lle_Meldedatum": 575,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -19532,7 +19532,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627257600000,
-        "F\u00e4lle_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -22876,7 +22876,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 334,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 494,
+        "F\u00e4lle_Meldedatum": 496,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 688,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 553,
+        "F\u00e4lle_Meldedatum": 552,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 536,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23458,7 +23458,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 692,
+        "F\u00e4lle_Meldedatum": 693,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23560,9 +23560,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1211,
+        "F\u00e4lle_Meldedatum": 1210,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23572,7 +23572,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 930,
+        "F\u00e4lle_Meldedatum": 931,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1021,
+        "F\u00e4lle_Meldedatum": 1019,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23648,7 +23648,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1054,
+        "F\u00e4lle_Meldedatum": 1055,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1090,
+        "F\u00e4lle_Meldedatum": 1093,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1521,
+        "F\u00e4lle_Meldedatum": 1519,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23864,9 +23864,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 916,
+        "F\u00e4lle_Meldedatum": 915,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23876,7 +23876,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1047,
+        "F\u00e4lle_Meldedatum": 1057,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -23938,25 +23938,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 529,
         "BelegteBetten": null,
-        "Inzidenz": 586.587161895183,
+        "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1028,
+        "F\u00e4lle_Meldedatum": 1256,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 333.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1596,
-        "Krh_I_belegt": 471,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.09,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2021"
@@ -23976,15 +23976,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 255,
         "BelegteBetten": null,
-        "Inzidenz": 583.354287151119,
+        "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 834,
+        "F\u00e4lle_Meldedatum": 824,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 383.1,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1700,
-        "Krh_I_belegt": 446,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -23994,7 +23994,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.45,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2021"
@@ -24014,15 +24014,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 226,
         "BelegteBetten": null,
-        "Inzidenz": 592.154890621071,
+        "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 165,
+        "F\u00e4lle_Meldedatum": 167,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 448.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1838,
-        "Krh_I_belegt": 455,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24032,7 +24032,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.01,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2021"
@@ -24054,13 +24054,13 @@
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 764,
+        "F\u00e4lle_Meldedatum": 932,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 465.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1928,
-        "Krh_I_belegt": 495,
+        "Krh_N_belegt": 1838,
+        "Krh_I_belegt": 455,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24070,7 +24070,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.66,
+        "H_Inzidenz": 10.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2021"
@@ -24092,13 +24092,13 @@
         "BelegteBetten": null,
         "Inzidenz": 587.125974352527,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 859,
+        "F\u00e4lle_Meldedatum": 1126,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 446.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1943,
-        "Krh_I_belegt": 533,
+        "Krh_N_belegt": 1928,
+        "Krh_I_belegt": 495,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24108,7 +24108,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.63,
+        "H_Inzidenz": 10.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2021"
@@ -24130,13 +24130,13 @@
         "BelegteBetten": null,
         "Inzidenz": 664.894572362513,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 816,
+        "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 471.6,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1918,
-        "Krh_I_belegt": 534,
+        "Krh_N_belegt": 1943,
+        "Krh_I_belegt": 533,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24146,7 +24146,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.31,
+        "H_Inzidenz": 10.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2021"
@@ -24168,23 +24168,23 @@
         "BelegteBetten": null,
         "Inzidenz": 783.253708825748,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1055,
+        "F\u00e4lle_Meldedatum": 1310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 630.3,
         "Fallzahl_aktiv": 10123,
-        "Krh_N_belegt": 1963,
-        "Krh_I_belegt": 548,
+        "Krh_N_belegt": 1918,
+        "Krh_I_belegt": 534,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 496,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.84,
+        "H_Inzidenz": 9.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2021"
@@ -24197,7 +24197,7 @@
         "ObjectId": 630,
         "Sterbefall": 1234,
         "Genesungsfall": 44545,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3191,
         "Zuwachs_Fallzahl": 2225,
         "Zuwachs_Sterbefall": 17,
@@ -24206,9 +24206,9 @@
         "BelegteBetten": null,
         "Inzidenz": 991.594525665433,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 200,
-        "Zeitraum": "19.11.2021 - 25.11.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 942,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 735.7,
         "Fallzahl_aktiv": 11303,
         "Krh_N_belegt": 1963,
@@ -24220,13 +24220,127 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4249,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.99,
-        "H_Zeitraum": "19.11.2021 - 25.11.2021",
-        "H_Datum": "25.11.2021",
+        "H_Inzidenz": 8.65,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.11.2021",
+        "Fallzahl": 58815,
+        "ObjectId": 631,
+        "Sterbefall": null,
+        "Genesungsfall": 45050,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 505,
+        "BelegteBetten": null,
+        "Inzidenz": 1110.49247458601,
+        "Datum_neu": 1637971200000,
+        "F\u00e4lle_Meldedatum": 658,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 894.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1958,
+        "Krh_I_belegt": 563,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.81,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.11.2021",
+        "Fallzahl": 58870,
+        "ObjectId": 632,
+        "Sterbefall": null,
+        "Genesungsfall": 45347,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 297,
+        "BelegteBetten": null,
+        "Inzidenz": 1075.2900607062,
+        "Datum_neu": 1638057600000,
+        "F\u00e4lle_Meldedatum": 210,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 846.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1970,
+        "Krh_I_belegt": 575,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.98,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.11.2021",
+        "Fallzahl": 59832,
+        "ObjectId": 633,
+        "Sterbefall": 1239,
+        "Genesungsfall": 46442,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3214,
+        "Zuwachs_Fallzahl": 2750,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 1095,
+        "BelegteBetten": null,
+        "Inzidenz": 1098.27939221955,
+        "Datum_neu": 1638144000000,
+        "F\u00e4lle_Meldedatum": 93,
+        "Zeitraum": "22.11.2021 - 28.11.2021",
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": 965.8,
+        "Fallzahl_aktiv": 12151,
+        "Krh_N_belegt": 1970,
+        "Krh_I_belegt": 575,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1650,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4336,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.48,
+        "H_Zeitraum": "22.11.2021 - 28.11.2021",
+        "H_Datum": "28.11.2021",
+        "Datum_Bett": "28.11.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
