### PR TITLE
New data set: 2021-11-30T111004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-29T110904Z.json
+pjson/2021-11-30T111004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-29T110904Z.json pjson/2021-11-30T111004Z.json```:
```
--- pjson/2021-11-29T110904Z.json	2021-11-29 11:09:04.517968463 +0000
+++ pjson/2021-11-30T111004Z.json	2021-11-30 11:10:04.751709753 +0000
@@ -9994,7 +9994,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10298,7 +10298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 275,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10336,7 +10336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606348800000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13414,7 +13414,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -21470,7 +21470,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631664000000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 688,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 552,
+        "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 685,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23446,7 +23446,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 256,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 693,
+        "F\u00e4lle_Meldedatum": 691,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1210,
+        "F\u00e4lle_Meldedatum": 1211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1019,
+        "F\u00e4lle_Meldedatum": 1018,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1055,
+        "F\u00e4lle_Meldedatum": 1057,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 482,
+        "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1093,
+        "F\u00e4lle_Meldedatum": 1098,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1519,
+        "F\u00e4lle_Meldedatum": 1518,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23838,7 +23838,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 915,
+        "F\u00e4lle_Meldedatum": 916,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1057,
+        "F\u00e4lle_Meldedatum": 1048,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -23940,10 +23940,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1256,
+        "F\u00e4lle_Meldedatum": 1406,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 333.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -23978,10 +23978,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 824,
+        "F\u00e4lle_Meldedatum": 848,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 383.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -23990,7 +23990,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24016,10 +24016,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 167,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 448.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -24028,7 +24028,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 932,
+        "F\u00e4lle_Meldedatum": 955,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 465.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1838,
@@ -24066,11 +24066,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.8,
+        "H_Inzidenz": 11.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2021"
@@ -24092,9 +24092,9 @@
         "BelegteBetten": null,
         "Inzidenz": 587.125974352527,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1126,
+        "F\u00e4lle_Meldedatum": 1423,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 446.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1928,
@@ -24104,11 +24104,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.35,
+        "H_Inzidenz": 10.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2021"
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": 664.894572362513,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 1122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 471.6,
@@ -24146,7 +24146,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.13,
+        "H_Inzidenz": 10.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2021"
@@ -24157,34 +24157,34 @@
         "Datum": "25.11.2021",
         "Fallzahl": 54857,
         "ObjectId": 629,
-        "Sterbefall": 1217,
-        "Genesungsfall": 43517,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3170,
-        "Zuwachs_Fallzahl": 1543,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1039,
         "BelegteBetten": null,
         "Inzidenz": 783.253708825748,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1310,
+        "F\u00e4lle_Meldedatum": 1421,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 630.3,
-        "Fallzahl_aktiv": 10123,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1918,
         "Krh_I_belegt": 534,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 496,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.98,
+        "H_Inzidenz": 10.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2021"
@@ -24195,34 +24195,34 @@
         "Datum": "26.11.2021",
         "Fallzahl": 57082,
         "ObjectId": 630,
-        "Sterbefall": 1234,
-        "Genesungsfall": 44545,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3191,
-        "Zuwachs_Fallzahl": 2225,
-        "Zuwachs_Sterbefall": 17,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1028,
         "BelegteBetten": null,
         "Inzidenz": 991.594525665433,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 942,
+        "F\u00e4lle_Meldedatum": 1171,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 735.7,
-        "Fallzahl_aktiv": 11303,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1963,
         "Krh_I_belegt": 548,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1180,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.65,
+        "H_Inzidenz": 9.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2021"
@@ -24234,7 +24234,7 @@
         "Fallzahl": 58815,
         "ObjectId": 631,
         "Sterbefall": null,
-        "Genesungsfall": 45050,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -24244,9 +24244,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1110.49247458601,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 658,
+        "F\u00e4lle_Meldedatum": 755,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 894.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1958,
@@ -24256,11 +24256,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
+        "H_Inzidenz": 8.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2021"
@@ -24272,7 +24272,7 @@
         "Fallzahl": 58870,
         "ObjectId": 632,
         "Sterbefall": null,
-        "Genesungsfall": 45347,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -24282,9 +24282,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1075.2900607062,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 256,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 846.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1970,
@@ -24294,11 +24294,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
+        "H_Inzidenz": 8.04,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2021"
@@ -24309,37 +24309,75 @@
         "Datum": "29.11.2021",
         "Fallzahl": 59832,
         "ObjectId": 633,
-        "Sterbefall": 1239,
-        "Genesungsfall": 46442,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3214,
-        "Zuwachs_Fallzahl": 2750,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1095,
         "BelegteBetten": null,
         "Inzidenz": 1098.27939221955,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 93,
-        "Zeitraum": "22.11.2021 - 28.11.2021",
-        "Hosp_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 538,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 965.8,
-        "Fallzahl_aktiv": 12151,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1970,
         "Krh_I_belegt": 575,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1650,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.74,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "28.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.11.2021",
+        "Fallzahl": 61864,
+        "ObjectId": 634,
+        "Sterbefall": 1253,
+        "Genesungsfall": 47952,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3232,
+        "Zuwachs_Fallzahl": 2032,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 1510,
+        "BelegteBetten": null,
+        "Inzidenz": 1200.83336326736,
+        "Datum_neu": 1638230400000,
+        "F\u00e4lle_Meldedatum": 299,
+        "Zeitraum": "23.11.2021 - 29.11.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1038.8,
+        "Fallzahl_aktiv": 12659,
+        "Krh_N_belegt": 2116,
+        "Krh_I_belegt": 582,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 508,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4336,
+        "Mutation": 4437,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
-        "H_Zeitraum": "22.11.2021 - 28.11.2021",
-        "H_Datum": "28.11.2021",
-        "Datum_Bett": "28.11.2021"
+        "H_Inzidenz": 6.11,
+        "H_Zeitraum": "23.11.2021 - 29.11.2021",
+        "H_Datum": "29.11.2021",
+        "Datum_Bett": "29.11.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
