### PR TITLE
New data set: 2021-12-01T112304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-11-30T111004Z.json
+pjson/2021-12-01T112304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-11-30T111004Z.json pjson/2021-12-01T112304Z.json```:
```
--- pjson/2021-11-30T111004Z.json	2021-11-30 11:10:04.751709753 +0000
+++ pjson/2021-12-01T112304Z.json	2021-12-01 11:23:04.260395274 +0000
@@ -10374,7 +10374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -10754,7 +10754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 384,
+        "F\u00e4lle_Meldedatum": 385,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -12730,7 +12730,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611792000000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22572,7 +22572,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23142,7 +23142,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23256,9 +23256,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 496,
+        "F\u00e4lle_Meldedatum": 495,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 691,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23372,7 +23372,7 @@
         "Datum_neu": 1635984000000,
         "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1211,
+        "F\u00e4lle_Meldedatum": 1213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1018,
+        "F\u00e4lle_Meldedatum": 1017,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1057,
+        "F\u00e4lle_Meldedatum": 1058,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23762,7 +23762,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23790,7 +23790,7 @@
         "Datum_neu": 1636934400000,
         "F\u00e4lle_Meldedatum": 1098,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23800,7 +23800,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1518,
+        "F\u00e4lle_Meldedatum": 1517,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1048,
+        "F\u00e4lle_Meldedatum": 1045,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1406,
+        "F\u00e4lle_Meldedatum": 1425,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23952,7 +23952,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23978,9 +23978,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 848,
+        "F\u00e4lle_Meldedatum": 858,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23990,7 +23990,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -24028,7 +24028,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24052,15 +24052,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 661,
         "BelegteBetten": null,
-        "Inzidenz": 547.433456661518,
+        "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 955,
+        "F\u00e4lle_Meldedatum": 1357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 465.5,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1838,
-        "Krh_I_belegt": 455,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24070,7 +24070,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2021"
@@ -24090,15 +24090,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1201,
         "BelegteBetten": null,
-        "Inzidenz": 587.125974352527,
+        "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1423,
+        "F\u00e4lle_Meldedatum": 1622,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 446.4,
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1928,
-        "Krh_I_belegt": 495,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24108,7 +24108,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.97,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2021"
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": 664.894572362513,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1122,
+        "F\u00e4lle_Meldedatum": 1072,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 471.6,
@@ -24146,7 +24146,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.77,
+        "H_Inzidenz": 11.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2021"
@@ -24168,9 +24168,9 @@
         "BelegteBetten": null,
         "Inzidenz": 783.253708825748,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1421,
+        "F\u00e4lle_Meldedatum": 1417,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 630.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1918,
@@ -24184,7 +24184,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.72,
+        "H_Inzidenz": 11.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2021"
@@ -24206,9 +24206,9 @@
         "BelegteBetten": null,
         "Inzidenz": 991.594525665433,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1171,
+        "F\u00e4lle_Meldedatum": 1169,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 735.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1963,
@@ -24222,7 +24222,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.37,
+        "H_Inzidenz": 10.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2021"
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1110.49247458601,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 755,
+        "F\u00e4lle_Meldedatum": 754,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 894.8,
@@ -24256,11 +24256,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.63,
+        "H_Inzidenz": 9.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2021"
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1075.2900607062,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 256,
+        "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 846.4,
@@ -24298,7 +24298,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.04,
+        "H_Inzidenz": 8.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2021"
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1098.27939221955,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 538,
+        "F\u00e4lle_Meldedatum": 799,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 965.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1970,
@@ -24332,11 +24332,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
+        "H_Inzidenz": 8.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2021"
@@ -24349,7 +24349,7 @@
         "ObjectId": 634,
         "Sterbefall": 1253,
         "Genesungsfall": 47952,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3232,
         "Zuwachs_Fallzahl": 2032,
         "Zuwachs_Sterbefall": 14,
@@ -24358,9 +24358,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1200.83336326736,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 299,
-        "Zeitraum": "23.11.2021 - 29.11.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1217,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1038.8,
         "Fallzahl_aktiv": 12659,
         "Krh_N_belegt": 2116,
@@ -24372,13 +24372,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4437,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.11,
-        "H_Zeitraum": "23.11.2021 - 29.11.2021",
-        "H_Datum": "29.11.2021",
+        "H_Inzidenz": 7.2,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.12.2021",
+        "Fallzahl": 63820,
+        "ObjectId": 635,
+        "Sterbefall": 1263,
+        "Genesungsfall": 48895,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3250,
+        "Zuwachs_Fallzahl": 1956,
+        "Zuwachs_Sterbefall": 10,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 943,
+        "BelegteBetten": null,
+        "Inzidenz": 1203.16821724918,
+        "Datum_neu": 1638316800000,
+        "F\u00e4lle_Meldedatum": 165,
+        "Zeitraum": "24.11.2021 - 30.11.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1063.2,
+        "Fallzahl_aktiv": 13662,
+        "Krh_N_belegt": 2083,
+        "Krh_I_belegt": 586,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1003,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4614,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.32,
+        "H_Zeitraum": "24.11.2021 - 30.11.2021",
+        "H_Datum": "01.12.2021",
+        "Datum_Bett": "30.11.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
