### PR TITLE
New data set: 2021-12-02T083904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-01T112304Z.json
+pjson/2021-12-02T083904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-01T112304Z.json pjson/2021-12-02T083904Z.json```:
```
--- pjson/2021-12-01T112304Z.json	2021-12-01 11:23:04.260395274 +0000
+++ pjson/2021-12-02T083904Z.json	2021-12-02 08:39:04.574980824 +0000
@@ -24410,7 +24410,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4614,
+        "Mutation": 0,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 5.32,
         "H_Zeitraum": "24.11.2021 - 30.11.2021",
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
