### PR TITLE
New data set: 2021-12-02T111404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-01T112304Z.json
+pjson/2021-12-02T111404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-02T083904Z.json pjson/2021-12-02T111404Z.json```:
```
--- pjson/2021-12-02T083904Z.json	2021-12-02 08:39:04.574980824 +0000
+++ pjson/2021-12-02T111404Z.json	2021-12-02 11:14:04.229150396 +0000
@@ -7334,7 +7334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1599523200000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -20862,7 +20862,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630281600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22496,7 +22496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -23028,7 +23028,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 470,
+        "F\u00e4lle_Meldedatum": 471,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 495,
+        "F\u00e4lle_Meldedatum": 496,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 682,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23408,9 +23408,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 539,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 692,
+        "F\u00e4lle_Meldedatum": 697,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1213,
+        "F\u00e4lle_Meldedatum": 1214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23572,7 +23572,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23598,9 +23598,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 931,
+        "F\u00e4lle_Meldedatum": 932,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1017,
+        "F\u00e4lle_Meldedatum": 1019,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1058,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23714,7 +23714,7 @@
         "Datum_neu": 1636761600000,
         "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1098,
+        "F\u00e4lle_Meldedatum": 1099,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23864,9 +23864,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 916,
+        "F\u00e4lle_Meldedatum": 917,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1045,
+        "F\u00e4lle_Meldedatum": 1047,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1425,
+        "F\u00e4lle_Meldedatum": 1430,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23952,7 +23952,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9,
+        "SterbeF_Sterbedatum": 10,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 858,
+        "F\u00e4lle_Meldedatum": 895,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23990,7 +23990,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 315,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -24028,7 +24028,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1357,
+        "F\u00e4lle_Meldedatum": 1302,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24066,7 +24066,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1622,
+        "F\u00e4lle_Meldedatum": 1619,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24128,25 +24128,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 937,
         "BelegteBetten": null,
-        "Inzidenz": 664.894572362513,
+        "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1072,
+        "F\u00e4lle_Meldedatum": 1053,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 471.6,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1943,
-        "Krh_I_belegt": 533,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.51,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2021"
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": 783.253708825748,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1417,
+        "F\u00e4lle_Meldedatum": 1422,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 630.3,
@@ -24180,11 +24180,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.41,
+        "H_Inzidenz": 12.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2021"
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": 991.594525665433,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1169,
+        "F\u00e4lle_Meldedatum": 1168,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 735.7,
@@ -24222,7 +24222,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.13,
+        "H_Inzidenz": 10.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2021"
@@ -24244,9 +24244,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1110.49247458601,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 754,
+        "F\u00e4lle_Meldedatum": 757,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 894.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1958,
@@ -24260,7 +24260,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.34,
+        "H_Inzidenz": 10.06,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2021"
@@ -24282,9 +24282,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1075.2900607062,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 271,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 846.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1970,
@@ -24298,7 +24298,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.75,
+        "H_Inzidenz": 9.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2021"
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1098.27939221955,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 799,
+        "F\u00e4lle_Meldedatum": 821,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 965.8,
@@ -24336,7 +24336,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.45,
+        "H_Inzidenz": 9.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2021"
@@ -24347,34 +24347,34 @@
         "Datum": "30.11.2021",
         "Fallzahl": 61864,
         "ObjectId": 634,
-        "Sterbefall": 1253,
-        "Genesungsfall": 47952,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3232,
-        "Zuwachs_Fallzahl": 2032,
-        "Zuwachs_Sterbefall": 14,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1510,
         "BelegteBetten": null,
         "Inzidenz": 1200.83336326736,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1217,
+        "F\u00e4lle_Meldedatum": 1269,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1038.8,
-        "Fallzahl_aktiv": 12659,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2116,
         "Krh_I_belegt": 582,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 508,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.2,
+        "H_Inzidenz": 7.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2021"
@@ -24387,7 +24387,7 @@
         "ObjectId": 635,
         "Sterbefall": 1263,
         "Genesungsfall": 48895,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3250,
         "Zuwachs_Fallzahl": 1956,
         "Zuwachs_Sterbefall": 10,
@@ -24396,9 +24396,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1203.16821724918,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 165,
-        "Zeitraum": "24.11.2021 - 30.11.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1053,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1063.2,
         "Fallzahl_aktiv": 13662,
         "Krh_N_belegt": 2083,
@@ -24408,14 +24408,52 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.12.2021",
+        "Fallzahl": 64924,
+        "ObjectId": 636,
+        "Sterbefall": 1274,
+        "Genesungsfall": 49910,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3269,
+        "Zuwachs_Fallzahl": 1104,
+        "Zuwachs_Sterbefall": 11,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 1015,
+        "BelegteBetten": null,
+        "Inzidenz": 1214.48327885341,
+        "Datum_neu": 1638403200000,
+        "F\u00e4lle_Meldedatum": 90,
+        "Zeitraum": "25.11.2021 - 01.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1076.9,
+        "Fallzahl_aktiv": 13740,
+        "Krh_N_belegt": 2083,
+        "Krh_I_belegt": 586,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 78,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": 0,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
-        "H_Zeitraum": "24.11.2021 - 30.11.2021",
+        "H_Inzidenz": 5.25,
+        "H_Zeitraum": "25.11.2021 - 01.12.2021",
         "H_Datum": "01.12.2021",
-        "Datum_Bett": "30.11.2021"
+        "Datum_Bett": "01.12.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
