### PR TITLE
New data set: 2021-12-06T111803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-03T111304Z.json
+pjson/2021-12-06T111803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-03T111304Z.json pjson/2021-12-06T111803Z.json```:
```
--- pjson/2021-12-03T111304Z.json	2021-12-03 11:13:04.561832032 +0000
+++ pjson/2021-12-06T111803Z.json	2021-12-06 11:18:03.980253409 +0000
@@ -22268,7 +22268,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633478400000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22990,7 +22990,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23104,7 +23104,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -23180,7 +23180,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 693,
+        "F\u00e4lle_Meldedatum": 691,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23382,7 +23382,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 539,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -23446,7 +23446,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 258,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 224,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 707,
+        "F\u00e4lle_Meldedatum": 709,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1222,
+        "F\u00e4lle_Meldedatum": 1227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 942,
+        "F\u00e4lle_Meldedatum": 956,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1020,
+        "F\u00e4lle_Meldedatum": 1024,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,9 +23674,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1069,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23712,9 +23712,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 488,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1100,
+        "F\u00e4lle_Meldedatum": 1106,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1519,
+        "F\u00e4lle_Meldedatum": 1523,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 915,
+        "F\u00e4lle_Meldedatum": 918,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1051,
+        "F\u00e4lle_Meldedatum": 1055,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1436,
+        "F\u00e4lle_Meldedatum": 1440,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23978,9 +23978,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 895,
+        "F\u00e4lle_Meldedatum": 897,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24016,9 +24016,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 373,
+        "F\u00e4lle_Meldedatum": 379,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1306,
+        "F\u00e4lle_Meldedatum": 1323,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24092,9 +24092,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1621,
+        "F\u00e4lle_Meldedatum": 1628,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24132,7 +24132,7 @@
         "Datum_neu": 1637712000000,
         "F\u00e4lle_Meldedatum": 1054,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24142,7 +24142,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24168,9 +24168,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1427,
+        "F\u00e4lle_Meldedatum": 1426,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24184,7 +24184,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.61,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2021"
@@ -24204,15 +24204,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1028,
         "BelegteBetten": null,
-        "Inzidenz": 991.594525665433,
+        "Inzidenz": null,
         "Datum_neu": 1637884800000,
         "F\u00e4lle_Meldedatum": 1172,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 735.7,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1963,
-        "Krh_I_belegt": 548,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24222,7 +24222,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.74,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2021"
@@ -24242,25 +24242,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 505,
         "BelegteBetten": null,
-        "Inzidenz": 1110.49247458601,
+        "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 758,
+        "F\u00e4lle_Meldedatum": 756,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 894.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1958,
-        "Krh_I_belegt": 563,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.91,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2021"
@@ -24280,15 +24280,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 297,
         "BelegteBetten": null,
-        "Inzidenz": 1075.2900607062,
+        "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 846.4,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1970,
-        "Krh_I_belegt": 575,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24298,7 +24298,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.31,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2021"
@@ -24322,7 +24322,7 @@
         "Datum_neu": 1638144000000,
         "F\u00e4lle_Meldedatum": 827,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 965.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2079,
@@ -24332,11 +24332,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.12,
+        "H_Inzidenz": 12.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2021"
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1200.83336326736,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1279,
+        "F\u00e4lle_Meldedatum": 1285,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1038.8,
@@ -24374,7 +24374,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.84,
+        "H_Inzidenz": 11.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2021"
@@ -24396,9 +24396,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1203.16821724918,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1077,
+        "F\u00e4lle_Meldedatum": 1086,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1063.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2083,
@@ -24412,7 +24412,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.41,
+        "H_Inzidenz": 10.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.11.2021"
@@ -24434,9 +24434,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 823,
+        "F\u00e4lle_Meldedatum": 868,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1076.9,
         "Fallzahl_aktiv": 13740,
         "Krh_N_belegt": 2074,
@@ -24446,11 +24446,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
+        "H_Inzidenz": 10.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.12.2021"
@@ -24463,7 +24463,7 @@
         "ObjectId": 637,
         "Sterbefall": 1284,
         "Genesungsfall": 51373,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3315,
         "Zuwachs_Fallzahl": 1034,
         "Zuwachs_Sterbefall": 10,
@@ -24472,26 +24472,140 @@
         "BelegteBetten": null,
         "Inzidenz": 1115.34178670211,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 188,
-        "Zeitraum": "26.11.2021 - 02.12.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 988,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1005.5,
         "Fallzahl_aktiv": 13301,
-        "Krh_N_belegt": 2074,
-        "Krh_I_belegt": 609,
+        "Krh_N_belegt": 2059,
+        "Krh_I_belegt": 597,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -439,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.9,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.12.2021",
+        "Fallzahl": null,
+        "ObjectId": 638,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638576000000,
+        "F\u00e4lle_Meldedatum": 510,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 973,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 2000,
+        "Krh_I_belegt": 580,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "03.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.12.2021",
+        "Fallzahl": null,
+        "ObjectId": 639,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638662400000,
+        "F\u00e4lle_Meldedatum": 149,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 906.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 2000,
+        "Krh_I_belegt": 582,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.12.2021",
+        "Fallzahl": 67676,
+        "ObjectId": 640,
+        "Sterbefall": 1290,
+        "Genesungsfall": 54001,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3366,
+        "Zuwachs_Fallzahl": 1718,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 51,
+        "Zuwachs_Genesung": 2628,
+        "BelegteBetten": null,
+        "Inzidenz": 1026.07852293545,
+        "Datum_neu": 1638748800000,
+        "F\u00e4lle_Meldedatum": 105,
+        "Zeitraum": "29.11.2021 - 05.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 923.2,
+        "Fallzahl_aktiv": 12385,
+        "Krh_N_belegt": 2000,
+        "Krh_I_belegt": 582,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -916,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": 0,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.87,
-        "H_Zeitraum": "26.11.2021 - 02.12.2021",
-        "H_Datum": "02.12.2021",
-        "Datum_Bett": "02.12.2021"
+        "H_Inzidenz": 7.59,
+        "H_Zeitraum": "29.11.2021 - 05.12.2021",
+        "H_Datum": "05.12.2021",
+        "Datum_Bett": "05.12.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
