### PR TITLE
New data set: 2021-12-06T125604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-06T111803Z.json
+pjson/2021-12-06T125604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-06T111803Z.json pjson/2021-12-06T125604Z.json```:
```
--- pjson/2021-12-06T111803Z.json	2021-12-06 11:18:03.980253409 +0000
+++ pjson/2021-12-06T125604Z.json	2021-12-06 12:56:04.125110474 +0000
@@ -24497,7 +24497,7 @@
     {
       "attributes": {
         "Datum": "04.12.2021",
-        "Fallzahl": null,
+        "Fallzahl": 66053,
         "ObjectId": 638,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -24535,7 +24535,7 @@
     {
       "attributes": {
         "Datum": "05.12.2021",
-        "Fallzahl": null,
+        "Fallzahl": 66923,
         "ObjectId": 639,
         "Sterbefall": null,
         "Genesungsfall": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
