### PR TITLE
New data set: 2021-12-07T124104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-06T111803Z.json
+pjson/2021-12-07T124104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-06T125604Z.json pjson/2021-12-07T124104Z.json```:
```
--- pjson/2021-12-06T125604Z.json	2021-12-06 12:56:04.125110474 +0000
+++ pjson/2021-12-07T124104Z.json	2021-12-07 12:41:04.200865047 +0000
@@ -22724,7 +22724,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 555,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 682,
+        "F\u00e4lle_Meldedatum": 683,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23522,9 +23522,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 709,
+        "F\u00e4lle_Meldedatum": 710,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1227,
+        "F\u00e4lle_Meldedatum": 1228,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23598,9 +23598,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 956,
+        "F\u00e4lle_Meldedatum": 963,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1024,
+        "F\u00e4lle_Meldedatum": 1023,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,9 +23674,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1069,
+        "F\u00e4lle_Meldedatum": 1075,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1106,
+        "F\u00e4lle_Meldedatum": 1112,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1523,
+        "F\u00e4lle_Meldedatum": 1526,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 918,
+        "F\u00e4lle_Meldedatum": 919,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1055,
+        "F\u00e4lle_Meldedatum": 1056,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1440,
+        "F\u00e4lle_Meldedatum": 1451,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24016,9 +24016,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 379,
+        "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24050,13 +24050,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 661,
+        "Zuwachs_Genesung": 669,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1323,
+        "F\u00e4lle_Meldedatum": 1330,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24088,13 +24088,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1201,
+        "Zuwachs_Genesung": 1211,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1628,
+        "F\u00e4lle_Meldedatum": 1633,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24126,13 +24126,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 937,
+        "Zuwachs_Genesung": 952,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1054,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24164,13 +24164,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1039,
+        "Zuwachs_Genesung": 1021,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1426,
+        "F\u00e4lle_Meldedatum": 1438,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24202,13 +24202,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1028,
+        "Zuwachs_Genesung": 1070,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1172,
+        "F\u00e4lle_Meldedatum": 1177,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24240,7 +24240,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 505,
+        "Zuwachs_Genesung": 484,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
@@ -24278,13 +24278,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 297,
+        "Zuwachs_Genesung": 292,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 277,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24318,15 +24318,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1095,
         "BelegteBetten": null,
-        "Inzidenz": 1098.27939221955,
+        "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 827,
+        "F\u00e4lle_Meldedatum": 837,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 965.8,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2079,
-        "Krh_I_belegt": 567,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24336,7 +24336,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2021"
@@ -24354,13 +24354,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1510,
+        "Zuwachs_Genesung": 1512,
         "BelegteBetten": null,
         "Inzidenz": 1200.83336326736,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1285,
+        "F\u00e4lle_Meldedatum": 1286,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1038.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2116,
@@ -24392,13 +24392,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 943,
+        "Zuwachs_Genesung": 936,
         "BelegteBetten": null,
         "Inzidenz": 1203.16821724918,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1086,
+        "F\u00e4lle_Meldedatum": 1089,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1063.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2083,
@@ -24423,28 +24423,28 @@
         "Datum": "02.12.2021",
         "Fallzahl": 64924,
         "ObjectId": 636,
-        "Sterbefall": 1274,
-        "Genesungsfall": 49910,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3269,
-        "Zuwachs_Fallzahl": 1104,
-        "Zuwachs_Sterbefall": 11,
-        "Zuwachs_Krankenhauseinweisung": 19,
-        "Zuwachs_Genesung": 1015,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1039,
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 868,
+        "F\u00e4lle_Meldedatum": 872,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 1076.9,
-        "Fallzahl_aktiv": 13740,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2074,
         "Krh_I_belegt": 609,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 78,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
@@ -24461,30 +24461,30 @@
         "Datum": "03.12.2021",
         "Fallzahl": 65958,
         "ObjectId": 637,
-        "Sterbefall": 1284,
-        "Genesungsfall": 51373,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3315,
-        "Zuwachs_Fallzahl": 1034,
-        "Zuwachs_Sterbefall": 10,
-        "Zuwachs_Krankenhauseinweisung": 46,
-        "Zuwachs_Genesung": 1463,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1439,
         "BelegteBetten": null,
         "Inzidenz": 1115.34178670211,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 988,
+        "F\u00e4lle_Meldedatum": 987,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1005.5,
-        "Fallzahl_aktiv": 13301,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2059,
         "Krh_I_belegt": 597,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -439,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24506,13 +24506,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 907,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 510,
+        "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 973,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24544,11 +24544,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 392,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 906.6,
@@ -24577,36 +24577,74 @@
         "ObjectId": 640,
         "Sterbefall": 1290,
         "Genesungsfall": 54001,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3366,
         "Zuwachs_Fallzahl": 1718,
         "Zuwachs_Sterbefall": 6,
         "Zuwachs_Krankenhauseinweisung": 51,
-        "Zuwachs_Genesung": 2628,
+        "Zuwachs_Genesung": 1303,
         "BelegteBetten": null,
-        "Inzidenz": 1026.07852293545,
+        "Inzidenz": 1026.1,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 105,
-        "Zeitraum": "29.11.2021 - 05.12.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 749,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 923.2,
         "Fallzahl_aktiv": 12385,
         "Krh_N_belegt": 2000,
         "Krh_I_belegt": 582,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -916,
+        "Fallzahl_aktiv_Zuwachs": 409,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": 0,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 7.59,
-        "H_Zeitraum": "29.11.2021 - 05.12.2021",
-        "H_Datum": "05.12.2021",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.12.2021",
+        "Fallzahl": 68691,
+        "ObjectId": 641,
+        "Sterbefall": 1291,
+        "Genesungsfall": 55612,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3435,
+        "Zuwachs_Fallzahl": 1015,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 69,
+        "Zuwachs_Genesung": 1611,
+        "BelegteBetten": null,
+        "Inzidenz": 1016.73910700815,
+        "Datum_neu": 1638835200000,
+        "F\u00e4lle_Meldedatum": 255,
+        "Zeitraum": "30.11.2021 - 06.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 798.4,
+        "Fallzahl_aktiv": 11788,
+        "Krh_N_belegt": 2111,
+        "Krh_I_belegt": 601,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -597,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 0,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.48,
+        "H_Zeitraum": "30.11.2021 - 06.12.2021",
+        "H_Datum": "06.12.2021",
+        "Datum_Bett": "06.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
