### PR TITLE
New data set: 2021-12-08T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-07T124104Z.json
+pjson/2021-12-08T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-07T124104Z.json pjson/2021-12-08T110203Z.json```:
```
--- pjson/2021-12-07T124104Z.json	2021-12-07 12:41:04.200865047 +0000
+++ pjson/2021-12-08T110203Z.json	2021-12-08 11:02:03.937861506 +0000
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 710,
+        "F\u00e4lle_Meldedatum": 712,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1228,
+        "F\u00e4lle_Meldedatum": 1227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 963,
+        "F\u00e4lle_Meldedatum": 964,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1023,
+        "F\u00e4lle_Meldedatum": 1029,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,9 +23674,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1075,
+        "F\u00e4lle_Meldedatum": 1082,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 488,
+        "F\u00e4lle_Meldedatum": 492,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1112,
+        "F\u00e4lle_Meldedatum": 1121,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1526,
+        "F\u00e4lle_Meldedatum": 1530,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 919,
+        "F\u00e4lle_Meldedatum": 920,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1056,
+        "F\u00e4lle_Meldedatum": 1060,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1451,
+        "F\u00e4lle_Meldedatum": 1455,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23978,9 +23978,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 897,
+        "F\u00e4lle_Meldedatum": 896,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24016,9 +24016,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 380,
+        "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1330,
+        "F\u00e4lle_Meldedatum": 1331,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24092,9 +24092,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1633,
+        "F\u00e4lle_Meldedatum": 1636,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24132,7 +24132,7 @@
         "Datum_neu": 1637712000000,
         "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24168,9 +24168,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1438,
+        "F\u00e4lle_Meldedatum": 1439,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24206,9 +24206,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1177,
+        "F\u00e4lle_Meldedatum": 1179,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24244,9 +24244,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 756,
+        "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 837,
+        "F\u00e4lle_Meldedatum": 845,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24356,15 +24356,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1512,
         "BelegteBetten": null,
-        "Inzidenz": 1200.83336326736,
+        "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1286,
+        "F\u00e4lle_Meldedatum": 1292,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 1038.8,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2116,
-        "Krh_I_belegt": 582,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24374,7 +24374,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.73,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2021"
@@ -24396,9 +24396,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1203.16821724918,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1089,
+        "F\u00e4lle_Meldedatum": 1093,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 1063.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2083,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 872,
+        "F\u00e4lle_Meldedatum": 878,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 1076.9,
@@ -24472,9 +24472,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1115.34178670211,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 987,
+        "F\u00e4lle_Meldedatum": 992,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1005.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2059,
@@ -24512,7 +24512,7 @@
         "Datum_neu": 1638576000000,
         "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 973,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24548,9 +24548,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 166,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 906.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24575,28 +24575,28 @@
         "Datum": "06.12.2021",
         "Fallzahl": 67676,
         "ObjectId": 640,
-        "Sterbefall": 1290,
-        "Genesungsfall": 54001,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3366,
-        "Zuwachs_Fallzahl": 1718,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 51,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1303,
         "BelegteBetten": null,
         "Inzidenz": 1026.1,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 749,
+        "F\u00e4lle_Meldedatum": 900,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 923.2,
-        "Fallzahl_aktiv": 12385,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
         "Krh_I_belegt": 582,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 409,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -24611,11 +24611,11 @@
     {
       "attributes": {
         "Datum": "07.12.2021",
-        "Fallzahl": 68691,
+        "Fallzahl": 69843,
         "ObjectId": 641,
         "Sterbefall": 1291,
         "Genesungsfall": 55612,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3435,
         "Zuwachs_Fallzahl": 1015,
         "Zuwachs_Sterbefall": 1,
@@ -24624,11 +24624,11 @@
         "BelegteBetten": null,
         "Inzidenz": 1016.73910700815,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 255,
-        "Zeitraum": "30.11.2021 - 06.12.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1164,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 798.4,
-        "Fallzahl_aktiv": 11788,
+        "Fallzahl_aktiv": 12940,
         "Krh_N_belegt": 2111,
         "Krh_I_belegt": 601,
         "Krh_I_frei": null,
@@ -24641,10 +24641,48 @@
         "Mutation": 0,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 6.48,
-        "H_Zeitraum": "30.11.2021 - 06.12.2021",
-        "H_Datum": "06.12.2021",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.12.2021",
+        "Fallzahl": 69947,
+        "ObjectId": 642,
+        "Sterbefall": 1291,
+        "Genesungsfall": 56776,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3519,
+        "Zuwachs_Fallzahl": 104,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 84,
+        "Zuwachs_Genesung": 1164,
+        "BelegteBetten": null,
+        "Inzidenz": 1025.18050217321,
+        "Datum_neu": 1638921600000,
+        "F\u00e4lle_Meldedatum": 104,
+        "Zeitraum": "01.12.2021 - 07.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 894.8,
+        "Fallzahl_aktiv": 11880,
+        "Krh_N_belegt": 2184,
+        "Krh_I_belegt": 593,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1060,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 0,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.56,
+        "H_Zeitraum": "01.12.2021 - 07.12.2021",
+        "H_Datum": "07.12.2021",
+        "Datum_Bett": "07.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
