### PR TITLE
New data set: 2021-12-08T111003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-08T110203Z.json
+pjson/2021-12-08T111003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-08T110203Z.json pjson/2021-12-08T111003Z.json```:
```
--- pjson/2021-12-08T110203Z.json	2021-12-08 11:02:03.937861506 +0000
+++ pjson/2021-12-08T111003Z.json	2021-12-08 11:10:04.194006919 +0000
@@ -24611,7 +24611,7 @@
     {
       "attributes": {
         "Datum": "07.12.2021",
-        "Fallzahl": 69843,
+        "Fallzahl": 68691,
         "ObjectId": 641,
         "Sterbefall": 1291,
         "Genesungsfall": 55612,
@@ -24628,7 +24628,7 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 798.4,
-        "Fallzahl_aktiv": 12940,
+        "Fallzahl_aktiv": 11788,
         "Krh_N_belegt": 2111,
         "Krh_I_belegt": 601,
         "Krh_I_frei": null,
@@ -24655,7 +24655,7 @@
         "Genesungsfall": 56776,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 3519,
-        "Zuwachs_Fallzahl": 104,
+        "Zuwachs_Fallzahl": 1256,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 84,
         "Zuwachs_Genesung": 1164,
@@ -24670,9 +24670,9 @@
         "Krh_N_belegt": 2184,
         "Krh_I_belegt": 593,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1060,
+        "Fallzahl_aktiv_Zuwachs": 92,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
