### PR TITLE
New data set: 2021-12-09T110603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-08T111003Z.json
+pjson/2021-12-09T110603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-08T111003Z.json pjson/2021-12-09T110603Z.json```:
```
--- pjson/2021-12-08T111003Z.json	2021-12-08 11:10:04.194006919 +0000
+++ pjson/2021-12-09T110603Z.json	2021-12-09 11:06:04.127322100 +0000
@@ -23142,7 +23142,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23180,7 +23180,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 555,
+        "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 683,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1227,
+        "F\u00e4lle_Meldedatum": 1230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 964,
+        "F\u00e4lle_Meldedatum": 966,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1029,
+        "F\u00e4lle_Meldedatum": 1030,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1082,
+        "F\u00e4lle_Meldedatum": 1083,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23712,9 +23712,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 492,
+        "F\u00e4lle_Meldedatum": 493,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1121,
+        "F\u00e4lle_Meldedatum": 1129,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1530,
+        "F\u00e4lle_Meldedatum": 1545,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23864,9 +23864,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 920,
+        "F\u00e4lle_Meldedatum": 924,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1060,
+        "F\u00e4lle_Meldedatum": 1061,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1455,
+        "F\u00e4lle_Meldedatum": 1456,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 381,
+        "F\u00e4lle_Meldedatum": 382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1331,
+        "F\u00e4lle_Meldedatum": 1335,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24066,7 +24066,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24092,9 +24092,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1636,
+        "F\u00e4lle_Meldedatum": 1637,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24130,9 +24130,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1061,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24170,7 +24170,7 @@
         "Datum_neu": 1637798400000,
         "F\u00e4lle_Meldedatum": 1439,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24206,9 +24206,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1179,
+        "F\u00e4lle_Meldedatum": 1181,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24218,7 +24218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24256,7 +24256,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24284,7 +24284,7 @@
         "Datum_neu": 1638057600000,
         "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24294,7 +24294,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 845,
+        "F\u00e4lle_Meldedatum": 847,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24332,7 +24332,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24358,9 +24358,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1292,
+        "F\u00e4lle_Meldedatum": 1295,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24370,7 +24370,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24396,23 +24396,23 @@
         "BelegteBetten": null,
         "Inzidenz": 1203.16821724918,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1093,
+        "F\u00e4lle_Meldedatum": 1095,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
-        "Inzidenz_RKI": 1063.2,
+        "Hosp_Meldedatum": 24,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2083,
-        "Krh_I_belegt": 586,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.38,
+        "H_Inzidenz": 13.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.11.2021"
@@ -24434,9 +24434,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 878,
+        "F\u00e4lle_Meldedatum": 879,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 1076.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2074,
@@ -24450,7 +24450,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.11,
+        "H_Inzidenz": 13.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.12.2021"
@@ -24472,9 +24472,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1115.34178670211,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 992,
+        "F\u00e4lle_Meldedatum": 1001,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1005.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2059,
@@ -24488,7 +24488,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.9,
+        "H_Inzidenz": 12.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.12.2021"
@@ -24508,11 +24508,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 907,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 1102.76949603075,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 515,
+        "F\u00e4lle_Meldedatum": 518,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 973,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24526,7 +24526,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.87,
+        "H_Inzidenz": 12.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.12.2021"
@@ -24546,11 +24546,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 392,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 1058.40727037609,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 166,
+        "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 906.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24564,7 +24564,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.41,
+        "H_Inzidenz": 12.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2021"
@@ -24584,11 +24584,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1303,
         "BelegteBetten": null,
-        "Inzidenz": 1026.1,
+        "Inzidenz": 1038.29160530191,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 900,
+        "F\u00e4lle_Meldedatum": 931,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": 923.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24600,9 +24600,9 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 0,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
+        "H_Inzidenz": 12.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2021"
@@ -24613,34 +24613,34 @@
         "Datum": "07.12.2021",
         "Fallzahl": 68691,
         "ObjectId": 641,
-        "Sterbefall": 1291,
-        "Genesungsfall": 55612,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3435,
-        "Zuwachs_Fallzahl": 1015,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 69,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1611,
         "BelegteBetten": null,
-        "Inzidenz": 1016.73910700815,
+        "Inzidenz": 1048.16983368656,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1164,
+        "F\u00e4lle_Meldedatum": 1230,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 798.4,
-        "Fallzahl_aktiv": 11788,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2111,
         "Krh_I_belegt": 601,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -597,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 0,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
+        "H_Inzidenz": 12.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2021"
@@ -24651,38 +24651,76 @@
         "Datum": "08.12.2021",
         "Fallzahl": 69947,
         "ObjectId": 642,
-        "Sterbefall": 1291,
-        "Genesungsfall": 56776,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3519,
-        "Zuwachs_Fallzahl": 1256,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 84,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1164,
         "BelegteBetten": null,
         "Inzidenz": 1025.18050217321,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 104,
-        "Zeitraum": "01.12.2021 - 07.12.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 771,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 894.8,
-        "Fallzahl_aktiv": 11880,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2184,
         "Krh_I_belegt": 593,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 92,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 0,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.56,
-        "H_Zeitraum": "01.12.2021 - 07.12.2021",
-        "H_Datum": "07.12.2021",
+        "H_Inzidenz": 11.78,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.12.2021",
+        "Fallzahl": 71015,
+        "ObjectId": 643,
+        "Sterbefall": 1301,
+        "Genesungsfall": 58130,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3619,
+        "Zuwachs_Fallzahl": 1068,
+        "Zuwachs_Sterbefall": 10,
+        "Zuwachs_Krankenhauseinweisung": 100,
+        "Zuwachs_Genesung": 1354,
+        "BelegteBetten": null,
+        "Inzidenz": 987.463630159129,
+        "Datum_neu": 1639008000000,
+        "F\u00e4lle_Meldedatum": 241,
+        "Zeitraum": "02.12.2021 - 08.12.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 899.3,
+        "Fallzahl_aktiv": 11584,
+        "Krh_N_belegt": 2098,
+        "Krh_I_belegt": 575,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -296,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 0,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.93,
+        "H_Zeitraum": "02.12.2021 - 08.12.2021",
+        "H_Datum": "08.12.2021",
+        "Datum_Bett": "08.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
