### PR TITLE
New data set: 2021-12-10T113204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-09T110603Z.json
+pjson/2021-12-10T113204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-09T110603Z.json pjson/2021-12-10T113204Z.json```:
```
--- pjson/2021-12-09T110603Z.json	2021-12-09 11:06:04.127322100 +0000
+++ pjson/2021-12-10T113204Z.json	2021-12-10 11:32:04.167792146 +0000
@@ -22496,7 +22496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22572,7 +22572,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -23230,7 +23230,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 712,
+        "F\u00e4lle_Meldedatum": 713,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1230,
+        "F\u00e4lle_Meldedatum": 1231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 966,
+        "F\u00e4lle_Meldedatum": 967,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1030,
+        "F\u00e4lle_Meldedatum": 1033,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1083,
+        "F\u00e4lle_Meldedatum": 1088,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23712,9 +23712,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 493,
+        "F\u00e4lle_Meldedatum": 494,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1129,
+        "F\u00e4lle_Meldedatum": 1132,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1545,
+        "F\u00e4lle_Meldedatum": 1556,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23838,7 +23838,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23866,7 +23866,7 @@
         "Datum_neu": 1637107200000,
         "F\u00e4lle_Meldedatum": 924,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1061,
+        "F\u00e4lle_Meldedatum": 1068,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1456,
+        "F\u00e4lle_Meldedatum": 1458,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23952,7 +23952,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 896,
+        "F\u00e4lle_Meldedatum": 895,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 382,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1335,
+        "F\u00e4lle_Meldedatum": 1343,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24092,9 +24092,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1637,
+        "F\u00e4lle_Meldedatum": 1651,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24130,9 +24130,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1061,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24142,7 +24142,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24170,7 +24170,7 @@
         "Datum_neu": 1637798400000,
         "F\u00e4lle_Meldedatum": 1439,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24180,7 +24180,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1181,
+        "F\u00e4lle_Meldedatum": 1178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24218,7 +24218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24256,7 +24256,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24294,7 +24294,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 847,
+        "F\u00e4lle_Meldedatum": 848,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24332,7 +24332,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24358,9 +24358,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1295,
+        "F\u00e4lle_Meldedatum": 1300,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24370,7 +24370,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24394,11 +24394,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 936,
         "BelegteBetten": null,
-        "Inzidenz": 1203.16821724918,
+        "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1095,
+        "F\u00e4lle_Meldedatum": 1097,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24408,11 +24408,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.38,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.11.2021"
@@ -24434,23 +24434,23 @@
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 879,
+        "F\u00e4lle_Meldedatum": 881,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
-        "Inzidenz_RKI": 1076.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2074,
-        "Krh_I_belegt": 609,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.21,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.12.2021"
@@ -24474,17 +24474,17 @@
         "Datum_neu": 1638489600000,
         "F\u00e4lle_Meldedatum": 1001,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1005.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2059,
+        "Krh_N_belegt": 2074,
         "Krh_I_belegt": 597,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24510,19 +24510,19 @@
         "BelegteBetten": null,
         "Inzidenz": 1102.76949603075,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 518,
+        "F\u00e4lle_Meldedatum": 523,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 973,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2000,
+        "Krh_N_belegt": 2059,
         "Krh_I_belegt": 580,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24548,9 +24548,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1058.40727037609,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 168,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 906.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24560,7 +24560,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24586,19 +24586,19 @@
         "BelegteBetten": null,
         "Inzidenz": 1038.29160530191,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 931,
+        "F\u00e4lle_Meldedatum": 946,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": 923.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
-        "Krh_I_belegt": 582,
+        "Krh_I_belegt": 601,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24624,19 +24624,19 @@
         "BelegteBetten": null,
         "Inzidenz": 1048.16983368656,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1230,
+        "F\u00e4lle_Meldedatum": 1225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 798.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2111,
-        "Krh_I_belegt": 601,
+        "Krh_N_belegt": 211,
+        "Krh_I_belegt": 593,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24662,13 +24662,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1025.18050217321,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 771,
+        "F\u00e4lle_Meldedatum": 829,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": 894.8,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2184,
-        "Krh_I_belegt": 593,
+        "Krh_N_belegt": 2098,
+        "Krh_I_belegt": 575,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24689,26 +24689,64 @@
         "Datum": "09.12.2021",
         "Fallzahl": 71015,
         "ObjectId": 643,
-        "Sterbefall": 1301,
-        "Genesungsfall": 58130,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3619,
-        "Zuwachs_Fallzahl": 1068,
-        "Zuwachs_Sterbefall": 10,
-        "Zuwachs_Krankenhauseinweisung": 100,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1354,
         "BelegteBetten": null,
         "Inzidenz": 987.463630159129,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 241,
-        "Zeitraum": "02.12.2021 - 08.12.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 781,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 899.3,
-        "Fallzahl_aktiv": 11584,
-        "Krh_N_belegt": 2098,
-        "Krh_I_belegt": 575,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 2077,
+        "Krh_I_belegt": 567,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -296,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.93,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "08.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.12.2021",
+        "Fallzahl": 72011,
+        "ObjectId": 644,
+        "Sterbefall": 1337,
+        "Genesungsfall": 59304,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3687,
+        "Zuwachs_Fallzahl": 996,
+        "Zuwachs_Sterbefall": 36,
+        "Zuwachs_Krankenhauseinweisung": 68,
+        "Zuwachs_Genesung": 1174,
+        "BelegteBetten": null,
+        "Inzidenz": 987.284026006681,
+        "Datum_neu": 1639094400000,
+        "F\u00e4lle_Meldedatum": 287,
+        "Zeitraum": "03.12.2021 - 09.12.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 898.7,
+        "Fallzahl_aktiv": 11370,
+        "Krh_N_belegt": 2077,
+        "Krh_I_belegt": 567,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -214,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -24718,8 +24756,8 @@
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 9.93,
         "H_Zeitraum": "02.12.2021 - 08.12.2021",
-        "H_Datum": "08.12.2021",
-        "Datum_Bett": "08.12.2021"
+        "H_Datum": "09.12.2021",
+        "Datum_Bett": "09.12.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
