### PR TITLE
New data set: 2021-12-10T143604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-09T110603Z.json
+pjson/2021-12-10T143604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-10T113204Z.json pjson/2021-12-10T143604Z.json```:
```
--- pjson/2021-12-10T113204Z.json	2021-12-10 11:32:04.167792146 +0000
+++ pjson/2021-12-10T143604Z.json	2021-12-10 14:36:04.194825729 +0000
@@ -24432,7 +24432,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1039,
         "BelegteBetten": null,
-        "Inzidenz": 1214.48327885341,
+        "Inzidenz": null,
         "Datum_neu": 1638403200000,
         "F\u00e4lle_Meldedatum": 881,
         "Zeitraum": null,
@@ -24477,7 +24477,7 @@
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1005.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2074,
+        "Krh_N_belegt": 2059,
         "Krh_I_belegt": 597,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -24488,7 +24488,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.3,
+        "H_Inzidenz": 13.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.12.2021"
@@ -24515,7 +24515,7 @@
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 973,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2059,
+        "Krh_N_belegt": 2000,
         "Krh_I_belegt": 580,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -24526,7 +24526,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.67,
+        "H_Inzidenz": 1395,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.12.2021"
@@ -24564,7 +24564,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.52,
+        "H_Inzidenz": 13.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2021"
@@ -24591,7 +24591,7 @@
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": 923.2,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2000,
+        "Krh_N_belegt": 2111,
         "Krh_I_belegt": 601,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -24602,7 +24602,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.35,
+        "H_Inzidenz": 13.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2021"
@@ -24629,7 +24629,7 @@
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 798.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 211,
+        "Krh_N_belegt": 2184,
         "Krh_I_belegt": 593,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -24640,7 +24640,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.57,
+        "H_Inzidenz": 14.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2021"
@@ -24678,7 +24678,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.78,
+        "H_Inzidenz": 13.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2021"
@@ -24689,13 +24689,13 @@
         "Datum": "09.12.2021",
         "Fallzahl": 71015,
         "ObjectId": 643,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1301,
+        "Genesungsfall": 58130,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 3619,
+        "Zuwachs_Fallzahl": 1068,
+        "Zuwachs_Sterbefall": 10,
+        "Zuwachs_Krankenhauseinweisung": 100,
         "Zuwachs_Genesung": 1354,
         "BelegteBetten": null,
         "Inzidenz": 987.463630159129,
@@ -24704,11 +24704,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 899.3,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 11584,
         "Krh_N_belegt": 2077,
         "Krh_I_belegt": 567,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": -296,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -24716,7 +24716,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.93,
+        "H_Inzidenz": 12.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2021"
@@ -24743,8 +24743,8 @@
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 898.7,
         "Fallzahl_aktiv": 11370,
-        "Krh_N_belegt": 2077,
-        "Krh_I_belegt": 567,
+        "Krh_N_belegt": 2011,
+        "Krh_I_belegt": 589,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -214,
         "Krh_I": null,
@@ -24754,9 +24754,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": 0,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.93,
-        "H_Zeitraum": "02.12.2021 - 08.12.2021",
-        "H_Datum": "09.12.2021",
+        "H_Inzidenz": 10.28,
+        "H_Zeitraum": "03.12.2021 - 09.12.2021",
+        "H_Datum": "10.12.2021",
         "Datum_Bett": "09.12.2021"
       }
     }
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
