### PR TITLE
New data set: 2021-12-13T113104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-10T143604Z.json
+pjson/2021-12-13T113104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-10T143903Z.json pjson/2021-12-13T113104Z.json```:
```
--- pjson/2021-12-10T143903Z.json	2021-12-10 14:39:03.222704590 +0000
+++ pjson/2021-12-13T113104Z.json	2021-12-13 11:31:04.454036671 +0000
@@ -19836,7 +19836,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627948800000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22074,7 +22074,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 50,
+        "Zuwachs_Genesung": 76,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633046400000,
@@ -22112,7 +22112,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 31,
+        "Zuwachs_Genesung": 47,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633132800000,
@@ -22150,7 +22150,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 17,
+        "Zuwachs_Genesung": 6,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633219200000,
@@ -22188,7 +22188,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 24,
+        "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
@@ -22226,7 +22226,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 62,
+        "Zuwachs_Genesung": 131,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633392000000,
@@ -22264,7 +22264,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 60,
+        "Zuwachs_Genesung": 89,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633478400000,
@@ -22302,7 +22302,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 61,
+        "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
@@ -22340,7 +22340,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 51,
+        "Zuwachs_Genesung": 79,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633651200000,
@@ -22378,7 +22378,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 31,
+        "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633737600000,
@@ -22416,7 +22416,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 9,
+        "Zuwachs_Genesung": 13,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633824000000,
@@ -22454,7 +22454,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 52,
+        "Zuwachs_Genesung": 80,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
@@ -22492,7 +22492,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 83,
+        "Zuwachs_Genesung": 147,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
@@ -22530,7 +22530,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 82,
+        "Zuwachs_Genesung": 120,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634083200000,
@@ -22568,7 +22568,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 74,
+        "Zuwachs_Genesung": 105,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
@@ -22606,7 +22606,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 75,
+        "Zuwachs_Genesung": 163,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634256000000,
@@ -22644,7 +22644,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 48,
+        "Zuwachs_Genesung": 18,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634342400000,
@@ -22682,13 +22682,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 7,
+        "Zuwachs_Genesung": 51,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634428800000,
         "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22720,13 +22720,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 54,
+        "Zuwachs_Genesung": 117,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634515200000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22758,13 +22758,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 124,
+        "Zuwachs_Genesung": 294,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634601600000,
         "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22796,13 +22796,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 88,
+        "Zuwachs_Genesung": 279,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
         "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22834,13 +22834,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 77,
+        "Zuwachs_Genesung": 230,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634774400000,
         "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22872,13 +22872,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 75,
+        "Zuwachs_Genesung": 333,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
         "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22910,13 +22910,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 39,
+        "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634947200000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22948,13 +22948,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 14,
+        "Zuwachs_Genesung": 93,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635033600000,
         "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22986,7 +22986,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 69,
+        "Zuwachs_Genesung": 214,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
@@ -23024,13 +23024,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 140,
+        "Zuwachs_Genesung": 472,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
         "F\u00e4lle_Meldedatum": 472,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23062,13 +23062,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 117,
+        "Zuwachs_Genesung": 358,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23100,13 +23100,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 99,
+        "Zuwachs_Genesung": 312,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
         "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23138,13 +23138,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 158,
+        "Zuwachs_Genesung": 228,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23176,7 +23176,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 14,
+        "Zuwachs_Genesung": 291,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
@@ -23214,7 +23214,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 52,
+        "Zuwachs_Genesung": 96,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635638400000,
@@ -23252,7 +23252,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 95,
+        "Zuwachs_Genesung": 496,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
@@ -23290,7 +23290,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 284,
+        "Zuwachs_Genesung": 690,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
@@ -23328,11 +23328,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 272,
+        "Zuwachs_Genesung": 555,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 555,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23366,7 +23366,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 229,
+        "Zuwachs_Genesung": 683,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
@@ -23404,7 +23404,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 327,
+        "Zuwachs_Genesung": 541,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
@@ -23442,13 +23442,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 51,
+        "Zuwachs_Genesung": 258,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
         "F\u00e4lle_Meldedatum": 258,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23480,13 +23480,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 92,
+        "Zuwachs_Genesung": 228,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23518,11 +23518,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 192,
+        "Zuwachs_Genesung": 711,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 713,
+        "F\u00e4lle_Meldedatum": 711,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23556,13 +23556,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 444,
+        "Zuwachs_Genesung": 1235,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1231,
+        "F\u00e4lle_Meldedatum": 1235,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23594,11 +23594,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 345,
+        "Zuwachs_Genesung": 969,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 967,
+        "F\u00e4lle_Meldedatum": 969,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23632,11 +23632,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 302,
+        "Zuwachs_Genesung": 1034,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1033,
+        "F\u00e4lle_Meldedatum": 1034,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23670,13 +23670,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 215,
+        "Zuwachs_Genesung": 1092,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1088,
+        "F\u00e4lle_Meldedatum": 1092,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23708,11 +23708,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 288,
+        "Zuwachs_Genesung": 495,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 494,
+        "F\u00e4lle_Meldedatum": 495,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23746,13 +23746,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 97,
+        "Zuwachs_Genesung": 293,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 294,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23784,13 +23784,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 463,
+        "Zuwachs_Genesung": 1134,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1132,
+        "F\u00e4lle_Meldedatum": 1134,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23822,13 +23822,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 667,
+        "Zuwachs_Genesung": 1560,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1556,
+        "F\u00e4lle_Meldedatum": 1560,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23860,11 +23860,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 559,
+        "Zuwachs_Genesung": 929,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 924,
+        "F\u00e4lle_Meldedatum": 929,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23898,11 +23898,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 673,
+        "Zuwachs_Genesung": 1080,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1068,
+        "F\u00e4lle_Meldedatum": 1080,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23936,11 +23936,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 529,
+        "Zuwachs_Genesung": 1457,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1458,
+        "F\u00e4lle_Meldedatum": 1457,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -23974,11 +23974,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 255,
+        "Zuwachs_Genesung": 897,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 895,
+        "F\u00e4lle_Meldedatum": 897,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24012,11 +24012,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 226,
+        "Zuwachs_Genesung": 390,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 390,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24050,11 +24050,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 669,
+        "Zuwachs_Genesung": 1345,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1343,
+        "F\u00e4lle_Meldedatum": 1345,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24066,7 +24066,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24088,13 +24088,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1211,
+        "Zuwachs_Genesung": 1650,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1651,
+        "F\u00e4lle_Meldedatum": 1650,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24126,11 +24126,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 952,
+        "Zuwachs_Genesung": 1066,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1066,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24164,11 +24164,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1021,
+        "Zuwachs_Genesung": 1440,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1439,
+        "F\u00e4lle_Meldedatum": 1440,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -24180,7 +24180,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24202,13 +24202,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1070,
+        "Zuwachs_Genesung": 1180,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1178,
+        "F\u00e4lle_Meldedatum": 1180,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24218,7 +24218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24240,7 +24240,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 484,
+        "Zuwachs_Genesung": 762,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
@@ -24278,11 +24278,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 292,
+        "Zuwachs_Genesung": 279,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24294,7 +24294,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9,
+        "SterbeF_Sterbedatum": 10,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24316,13 +24316,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1095,
+        "Zuwachs_Genesung": 849,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 848,
+        "F\u00e4lle_Meldedatum": 849,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24332,7 +24332,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 10,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24354,13 +24354,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1512,
+        "Zuwachs_Genesung": 1300,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
         "F\u00e4lle_Meldedatum": 1300,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24370,7 +24370,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24392,13 +24392,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 936,
+        "Zuwachs_Genesung": 1097,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
         "F\u00e4lle_Meldedatum": 1097,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24408,7 +24408,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24430,13 +24430,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1039,
+        "Zuwachs_Genesung": 881,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
         "F\u00e4lle_Meldedatum": 881,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24446,7 +24446,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24468,13 +24468,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1439,
+        "Zuwachs_Genesung": 1000,
         "BelegteBetten": null,
         "Inzidenz": 1115.34178670211,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1001,
+        "F\u00e4lle_Meldedatum": 1000,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1005.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2059,
@@ -24484,11 +24484,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.48,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.12.2021"
@@ -24506,11 +24506,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 907,
+        "Zuwachs_Genesung": 522,
         "BelegteBetten": null,
         "Inzidenz": 1102.76949603075,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 523,
+        "F\u00e4lle_Meldedatum": 522,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 973,
@@ -24522,11 +24522,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.12.2021"
@@ -24544,13 +24544,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 392,
+        "Zuwachs_Genesung": 193,
         "BelegteBetten": null,
         "Inzidenz": 1058.40727037609,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 906.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2000,
@@ -24560,11 +24560,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.73,
+        "H_Inzidenz": 15.06,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2021"
@@ -24582,13 +24582,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1303,
+        "Zuwachs_Genesung": 947,
         "BelegteBetten": null,
         "Inzidenz": 1038.29160530191,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 946,
+        "F\u00e4lle_Meldedatum": 947,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": 923.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2111,
@@ -24598,11 +24598,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.56,
+        "H_Inzidenz": 15.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2021"
@@ -24620,13 +24620,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1611,
+        "Zuwachs_Genesung": 1228,
         "BelegteBetten": null,
         "Inzidenz": 1048.16983368656,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1225,
+        "F\u00e4lle_Meldedatum": 1228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 798.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2184,
@@ -24636,11 +24636,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.1,
+        "H_Inzidenz": 15.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2021"
@@ -24658,11 +24658,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1164,
+        "Zuwachs_Genesung": 844,
         "BelegteBetten": null,
         "Inzidenz": 1025.18050217321,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 829,
+        "F\u00e4lle_Meldedatum": 844,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": 894.8,
@@ -24674,11 +24674,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.38,
+        "H_Inzidenz": 14.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2021"
@@ -24696,27 +24696,27 @@
         "Zuwachs_Fallzahl": 1068,
         "Zuwachs_Sterbefall": 10,
         "Zuwachs_Krankenhauseinweisung": 100,
-        "Zuwachs_Genesung": 1354,
+        "Zuwachs_Genesung": 898,
         "BelegteBetten": null,
         "Inzidenz": 987.463630159129,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 781,
+        "F\u00e4lle_Meldedatum": 898,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 899.3,
         "Fallzahl_aktiv": 11584,
         "Krh_N_belegt": 2077,
         "Krh_I_belegt": 567,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -296,
+        "Fallzahl_aktiv_Zuwachs": 160,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.03,
+        "H_Inzidenz": 13.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2021"
@@ -24728,36 +24728,150 @@
         "Fallzahl": 72011,
         "ObjectId": 644,
         "Sterbefall": 1337,
-        "Genesungsfall": 59304,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 59101,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3687,
         "Zuwachs_Fallzahl": 996,
         "Zuwachs_Sterbefall": 36,
         "Zuwachs_Krankenhauseinweisung": 68,
-        "Zuwachs_Genesung": 1174,
+        "Zuwachs_Genesung": 768,
         "BelegteBetten": null,
         "Inzidenz": 987.284026006681,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 287,
-        "Zeitraum": "03.12.2021 - 09.12.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 768,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 898.7,
-        "Fallzahl_aktiv": 11370,
+        "Fallzahl_aktiv": 11573,
         "Krh_N_belegt": 2011,
         "Krh_I_belegt": 589,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -214,
+        "Fallzahl_aktiv_Zuwachs": 192,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 12.69,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "09.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.12.2021",
+        "Fallzahl": 73047,
+        "ObjectId": 645,
+        "Sterbefall": null,
+        "Genesungsfall": 60146,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 448,
+        "BelegteBetten": null,
+        "Inzidenz": 969.862423219225,
+        "Datum_neu": 1639180800000,
+        "F\u00e4lle_Meldedatum": 448,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 876.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1908,
+        "Krh_I_belegt": 580,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 0,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.28,
-        "H_Zeitraum": "03.12.2021 - 09.12.2021",
-        "H_Datum": "10.12.2021",
-        "Datum_Bett": "09.12.2021"
+        "H_Inzidenz": 10.94,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "10.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.12.2021",
+        "Fallzahl": 73062,
+        "ObjectId": 646,
+        "Sterbefall": null,
+        "Genesungsfall": 60430,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 90,
+        "BelegteBetten": null,
+        "Inzidenz": 956.571715938073,
+        "Datum_neu": 1639267200000,
+        "F\u00e4lle_Meldedatum": 90,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 841,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1906,
+        "Krh_I_belegt": 578,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.16,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.12.2021",
+        "Fallzahl": 73310,
+        "ObjectId": 647,
+        "Sterbefall": 1366,
+        "Genesungsfall": 61245,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3757,
+        "Zuwachs_Fallzahl": 1299,
+        "Zuwachs_Sterbefall": 29,
+        "Zuwachs_Krankenhauseinweisung": 70,
+        "Zuwachs_Genesung": 95,
+        "BelegteBetten": null,
+        "Inzidenz": 938.072488235928,
+        "Datum_neu": 1639353600000,
+        "F\u00e4lle_Meldedatum": 95,
+        "Zeitraum": "06.12.2021 - 12.12.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 915.8,
+        "Fallzahl_aktiv": 10699,
+        "Krh_N_belegt": 1989,
+        "Krh_I_belegt": 587,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1175,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.92,
+        "H_Zeitraum": "07.12.2021 - 13.12.2021",
+        "H_Datum": "13.12.2021",
+        "Datum_Bett": "12.12.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
