### PR TITLE
New data set: 2021-12-13T121504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-13T113104Z.json
+pjson/2021-12-13T121504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-13T113104Z.json pjson/2021-12-13T121504Z.json```:
```
--- pjson/2021-12-13T113104Z.json	2021-12-13 11:31:04.454036671 +0000
+++ pjson/2021-12-13T121504Z.json	2021-12-13 12:15:05.258598349 +0000
@@ -24772,7 +24772,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 448,
+        "Zuwachs_Genesung": 1045,
         "BelegteBetten": null,
         "Inzidenz": 969.862423219225,
         "Datum_neu": 1639180800000,
@@ -24810,7 +24810,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 90,
+        "Zuwachs_Genesung": 284,
         "BelegteBetten": null,
         "Inzidenz": 956.571715938073,
         "Datum_neu": 1639267200000,
@@ -24848,7 +24848,7 @@
         "Zuwachs_Fallzahl": 1299,
         "Zuwachs_Sterbefall": 29,
         "Zuwachs_Krankenhauseinweisung": 70,
-        "Zuwachs_Genesung": 95,
+        "Zuwachs_Genesung": 815,
         "BelegteBetten": null,
         "Inzidenz": 938.072488235928,
         "Datum_neu": 1639353600000,
@@ -24860,7 +24860,7 @@
         "Krh_N_belegt": 1989,
         "Krh_I_belegt": 587,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1175,
+        "Fallzahl_aktiv_Zuwachs": 455,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
