### PR TITLE
New data set: 2021-12-14T112204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-13T113104Z.json
+pjson/2021-12-14T112204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-13T143603Z.json pjson/2021-12-14T112204Z.json```:
```
--- pjson/2021-12-13T143603Z.json	2021-12-13 14:36:03.640362691 +0000
+++ pjson/2021-12-14T112204Z.json	2021-12-14 11:22:04.184931385 +0000
@@ -22042,7 +22042,7 @@
         "Datum_neu": 1632960000000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22346,7 +22346,7 @@
         "Datum_neu": 1633651200000,
         "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22460,7 +22460,7 @@
         "Datum_neu": 1633910400000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22534,7 +22534,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634083200000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22650,7 +22650,7 @@
         "Datum_neu": 1634342400000,
         "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22688,7 +22688,7 @@
         "Datum_neu": 1634428800000,
         "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22726,7 +22726,7 @@
         "Datum_neu": 1634515200000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22764,7 +22764,7 @@
         "Datum_neu": 1634601600000,
         "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22802,7 +22802,7 @@
         "Datum_neu": 1634688000000,
         "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22840,7 +22840,7 @@
         "Datum_neu": 1634774400000,
         "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22878,7 +22878,7 @@
         "Datum_neu": 1634860800000,
         "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22916,7 +22916,7 @@
         "Datum_neu": 1634947200000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22954,7 +22954,7 @@
         "Datum_neu": 1635033600000,
         "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22992,7 +22992,7 @@
         "Datum_neu": 1635120000000,
         "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23030,7 +23030,7 @@
         "Datum_neu": 1635206400000,
         "F\u00e4lle_Meldedatum": 472,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23068,7 +23068,7 @@
         "Datum_neu": 1635292800000,
         "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23106,7 +23106,7 @@
         "Datum_neu": 1635379200000,
         "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23144,7 +23144,7 @@
         "Datum_neu": 1635465600000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 496,
+        "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -23446,7 +23446,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 258,
+        "F\u00e4lle_Meldedatum": 259,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -23486,7 +23486,7 @@
         "Datum_neu": 1636243200000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23524,7 +23524,7 @@
         "Datum_neu": 1636329600000,
         "F\u00e4lle_Meldedatum": 711,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1235,
+        "F\u00e4lle_Meldedatum": 1237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 969,
+        "F\u00e4lle_Meldedatum": 973,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1034,
+        "F\u00e4lle_Meldedatum": 1036,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1092,
+        "F\u00e4lle_Meldedatum": 1095,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 495,
+        "F\u00e4lle_Meldedatum": 496,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1134,
+        "F\u00e4lle_Meldedatum": 1138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1560,
+        "F\u00e4lle_Meldedatum": 1562,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -23902,9 +23902,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1080,
+        "F\u00e4lle_Meldedatum": 1086,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1457,
+        "F\u00e4lle_Meldedatum": 1470,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 897,
+        "F\u00e4lle_Meldedatum": 902,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 394,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1345,
+        "F\u00e4lle_Meldedatum": 1353,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24092,9 +24092,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1650,
+        "F\u00e4lle_Meldedatum": 1653,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1066,
+        "F\u00e4lle_Meldedatum": 1068,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24168,9 +24168,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1440,
+        "F\u00e4lle_Meldedatum": 1442,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1180,
+        "F\u00e4lle_Meldedatum": 1181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 279,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 849,
+        "F\u00e4lle_Meldedatum": 855,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1300,
+        "F\u00e4lle_Meldedatum": 1303,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -24398,7 +24398,7 @@
         "Datum_neu": 1638316800000,
         "F\u00e4lle_Meldedatum": 1097,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 881,
+        "F\u00e4lle_Meldedatum": 879,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -24470,15 +24470,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1439,
         "BelegteBetten": null,
-        "Inzidenz": 1115.34178670211,
+        "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1000,
+        "F\u00e4lle_Meldedatum": 1001,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 1005.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2059,
-        "Krh_I_belegt": 597,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24508,15 +24508,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 907,
         "BelegteBetten": null,
-        "Inzidenz": 1102.76949603075,
+        "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 522,
+        "F\u00e4lle_Meldedatum": 523,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 973,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2000,
-        "Krh_I_belegt": 580,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24564,7 +24564,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.06,
+        "H_Inzidenz": 15.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2021"
@@ -24586,9 +24586,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1038.29160530191,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 947,
+        "F\u00e4lle_Meldedatum": 951,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 44,
+        "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": 923.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2111,
@@ -24602,7 +24602,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.16,
+        "H_Inzidenz": 15.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2021"
@@ -24624,9 +24624,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1048.16983368656,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1228,
+        "F\u00e4lle_Meldedatum": 1227,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 798.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2184,
@@ -24640,7 +24640,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.73,
+        "H_Inzidenz": 16.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2021"
@@ -24662,9 +24662,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1025.18050217321,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 844,
+        "F\u00e4lle_Meldedatum": 846,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": 894.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2098,
@@ -24678,7 +24678,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.99,
+        "H_Inzidenz": 15.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2021"
@@ -24689,34 +24689,34 @@
         "Datum": "09.12.2021",
         "Fallzahl": 71015,
         "ObjectId": 643,
-        "Sterbefall": 1301,
-        "Genesungsfall": 58130,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3619,
-        "Zuwachs_Fallzahl": 1068,
-        "Zuwachs_Sterbefall": 10,
-        "Zuwachs_Krankenhauseinweisung": 100,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1354,
         "BelegteBetten": null,
         "Inzidenz": 987.463630159129,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 898,
+        "F\u00e4lle_Meldedatum": 901,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 899.3,
-        "Fallzahl_aktiv": 11584,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2077,
         "Krh_I_belegt": 567,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -296,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.93,
+        "H_Inzidenz": 14.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2021"
@@ -24727,34 +24727,34 @@
         "Datum": "10.12.2021",
         "Fallzahl": 72011,
         "ObjectId": 644,
-        "Sterbefall": 1337,
-        "Genesungsfall": 59101,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3687,
-        "Zuwachs_Fallzahl": 996,
-        "Zuwachs_Sterbefall": 36,
-        "Zuwachs_Krankenhauseinweisung": 68,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 971,
         "BelegteBetten": null,
         "Inzidenz": 987.284026006681,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 768,
+        "F\u00e4lle_Meldedatum": 767,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 898.7,
-        "Fallzahl_aktiv": 11573,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2011,
         "Krh_I_belegt": 589,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.69,
+        "H_Inzidenz": 13.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2021"
@@ -24766,7 +24766,7 @@
         "Fallzahl": 73047,
         "ObjectId": 645,
         "Sterbefall": null,
-        "Genesungsfall": 60146,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -24776,9 +24776,9 @@
         "BelegteBetten": null,
         "Inzidenz": 969.862423219225,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 475,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 876.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1908,
@@ -24792,7 +24792,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.94,
+        "H_Inzidenz": 11.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2021"
@@ -24804,7 +24804,7 @@
         "Fallzahl": 73062,
         "ObjectId": 646,
         "Sterbefall": null,
-        "Genesungsfall": 60430,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": 956.571715938073,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 841,
@@ -24826,11 +24826,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.16,
+        "H_Inzidenz": 11.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2021"
@@ -24841,37 +24841,75 @@
         "Datum": "13.12.2021",
         "Fallzahl": 73310,
         "ObjectId": 647,
-        "Sterbefall": 1366,
-        "Genesungsfall": 61245,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3757,
-        "Zuwachs_Fallzahl": 1299,
-        "Zuwachs_Sterbefall": 29,
-        "Zuwachs_Krankenhauseinweisung": 70,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 815,
         "BelegteBetten": null,
         "Inzidenz": 938.072488235928,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 95,
-        "Zeitraum": "06.12.2021 - 12.12.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 675,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 915.8,
-        "Fallzahl_aktiv": 10699,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1989,
+        "Krh_I_belegt": 587,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.25,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "12.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.12.2021",
+        "Fallzahl": 74391,
+        "ObjectId": 648,
+        "Sterbefall": 1374,
+        "Genesungsfall": 62528,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3776,
+        "Zuwachs_Fallzahl": 1081,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 1283,
+        "BelegteBetten": null,
+        "Inzidenz": 902.151657746327,
+        "Datum_neu": 1639440000000,
+        "F\u00e4lle_Meldedatum": 352,
+        "Zeitraum": "07.12.2021 - 13.12.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 797.5,
+        "Fallzahl_aktiv": 10489,
         "Krh_N_belegt": 1989,
         "Krh_I_belegt": 587,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 455,
+        "Fallzahl_aktiv_Zuwachs": -210,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": 1,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.92,
-        "H_Zeitraum": "07.12.2021 - 13.12.2021",
+        "H_Inzidenz": 7.72,
+        "H_Zeitraum": "08.12.2021 - 14.12.2021",
         "H_Datum": "13.12.2021",
-        "Datum_Bett": "12.12.2021"
+        "Datum_Bett": "13.12.2021"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
