### PR TITLE
New data set: 2021-12-15T111904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-14T112204Z.json
+pjson/2021-12-15T111904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-14T112204Z.json pjson/2021-12-15T111904Z.json```:
```
--- pjson/2021-12-14T112204Z.json	2021-12-14 11:22:04.184931385 +0000
+++ pjson/2021-12-15T111904Z.json	2021-12-15 11:19:04.615570292 +0000
@@ -21016,7 +21016,7 @@
         "Datum_neu": 1630627200000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22080,7 +22080,7 @@
         "Datum_neu": 1633046400000,
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 690,
+        "F\u00e4lle_Meldedatum": 691,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 555,
+        "F\u00e4lle_Meldedatum": 556,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1036,
+        "F\u00e4lle_Meldedatum": 1037,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1095,
+        "F\u00e4lle_Meldedatum": 1096,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 496,
+        "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1138,
+        "F\u00e4lle_Meldedatum": 1140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1562,
+        "F\u00e4lle_Meldedatum": 1564,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 929,
+        "F\u00e4lle_Meldedatum": 932,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1086,
+        "F\u00e4lle_Meldedatum": 1091,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1470,
+        "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 902,
+        "F\u00e4lle_Meldedatum": 903,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 394,
+        "F\u00e4lle_Meldedatum": 396,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1353,
+        "F\u00e4lle_Meldedatum": 1364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1653,
+        "F\u00e4lle_Meldedatum": 1655,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1068,
+        "F\u00e4lle_Meldedatum": 1071,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1442,
+        "F\u00e4lle_Meldedatum": 1447,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1181,
+        "F\u00e4lle_Meldedatum": 1184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 762,
+        "F\u00e4lle_Meldedatum": 763,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 855,
+        "F\u00e4lle_Meldedatum": 856,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1303,
+        "F\u00e4lle_Meldedatum": 1306,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1097,
+        "F\u00e4lle_Meldedatum": 1095,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 879,
+        "F\u00e4lle_Meldedatum": 881,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 523,
+        "F\u00e4lle_Meldedatum": 525,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24546,15 +24546,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 392,
         "BelegteBetten": null,
-        "Inzidenz": 1058.40727037609,
+        "Inzidenz": null,
         "Datum_neu": 1638662400000,
         "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 906.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2000,
-        "Krh_I_belegt": 582,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24564,7 +24564,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.5,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2021"
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1038.29160530191,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 951,
+        "F\u00e4lle_Meldedatum": 953,
         "Zeitraum": null,
         "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": 923.2,
@@ -24602,7 +24602,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.6,
+        "H_Inzidenz": 16.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2021"
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1048.16983368656,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1227,
+        "F\u00e4lle_Meldedatum": 1230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 798.4,
@@ -24640,7 +24640,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.15,
+        "H_Inzidenz": 17.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2021"
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1025.18050217321,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 846,
+        "F\u00e4lle_Meldedatum": 848,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": 894.8,
@@ -24678,7 +24678,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.46,
+        "H_Inzidenz": 16.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2021"
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": 987.463630159129,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 901,
+        "F\u00e4lle_Meldedatum": 902,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 899.3,
@@ -24716,7 +24716,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.52,
+        "H_Inzidenz": 15.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2021"
@@ -24738,9 +24738,9 @@
         "BelegteBetten": null,
         "Inzidenz": 987.284026006681,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 767,
+        "F\u00e4lle_Meldedatum": 766,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 898.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2011,
@@ -24754,7 +24754,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.36,
+        "H_Inzidenz": 14.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2021"
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": 969.862423219225,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 475,
+        "F\u00e4lle_Meldedatum": 477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 876.4,
@@ -24792,7 +24792,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.71,
+        "H_Inzidenz": 13.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2021"
@@ -24814,9 +24814,9 @@
         "BelegteBetten": null,
         "Inzidenz": 956.571715938073,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 841,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1906,
@@ -24830,7 +24830,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.12,
+        "H_Inzidenz": 12.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2021"
@@ -24852,9 +24852,9 @@
         "BelegteBetten": null,
         "Inzidenz": 938.072488235928,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 675,
+        "F\u00e4lle_Meldedatum": 820,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 915.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1989,
@@ -24868,7 +24868,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.25,
+        "H_Inzidenz": 11.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2021"
@@ -24879,38 +24879,76 @@
         "Datum": "14.12.2021",
         "Fallzahl": 74391,
         "ObjectId": 648,
-        "Sterbefall": 1374,
-        "Genesungsfall": 62528,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3776,
-        "Zuwachs_Fallzahl": 1081,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1283,
         "BelegteBetten": null,
         "Inzidenz": 902.151657746327,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 352,
-        "Zeitraum": "07.12.2021 - 13.12.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 851,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 797.5,
-        "Fallzahl_aktiv": 10489,
-        "Krh_N_belegt": 1989,
-        "Krh_I_belegt": 587,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1970,
+        "Krh_I_belegt": 601,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -210,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
-        "H_Zeitraum": "08.12.2021 - 14.12.2021",
-        "H_Datum": "13.12.2021",
+        "H_Inzidenz": 9.69,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.12.2021",
+        "Fallzahl": 75332,
+        "ObjectId": 649,
+        "Sterbefall": 1374,
+        "Genesungsfall": 63615,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3785,
+        "Zuwachs_Fallzahl": 941,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 1087,
+        "BelegteBetten": null,
+        "Inzidenz": 863.716369122454,
+        "Datum_neu": 1639526400000,
+        "F\u00e4lle_Meldedatum": 217,
+        "Zeitraum": "08.12.2021 - 14.12.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 757.6,
+        "Fallzahl_aktiv": 10343,
+        "Krh_N_belegt": 1970,
+        "Krh_I_belegt": 601,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -146,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.56,
+        "H_Zeitraum": "09.12.2021 - 15.12.2021",
+        "H_Datum": "14.12.2021",
+        "Datum_Bett": "14.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
