### PR TITLE
New data set: 2021-12-16T112004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-15T111904Z.json
+pjson/2021-12-16T112004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-15T111904Z.json pjson/2021-12-16T112004Z.json```:
```
--- pjson/2021-12-15T111904Z.json	2021-12-15 11:19:04.615570292 +0000
+++ pjson/2021-12-16T112004Z.json	2021-12-16 11:20:05.091386993 +0000
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 556,
+        "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 682,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1037,
+        "F\u00e4lle_Meldedatum": 1038,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1140,
+        "F\u00e4lle_Meldedatum": 1141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 932,
+        "F\u00e4lle_Meldedatum": 933,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23904,7 +23904,7 @@
         "Datum_neu": 1637193600000,
         "F\u00e4lle_Meldedatum": 1091,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1475,
+        "F\u00e4lle_Meldedatum": 1477,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 903,
+        "F\u00e4lle_Meldedatum": 904,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 396,
+        "F\u00e4lle_Meldedatum": 398,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1364,
+        "F\u00e4lle_Meldedatum": 1370,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1655,
+        "F\u00e4lle_Meldedatum": 1661,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1071,
+        "F\u00e4lle_Meldedatum": 1073,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24206,9 +24206,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1184,
+        "F\u00e4lle_Meldedatum": 1181,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 856,
+        "F\u00e4lle_Meldedatum": 857,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1306,
+        "F\u00e4lle_Meldedatum": 1309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1095,
+        "F\u00e4lle_Meldedatum": 1094,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -24436,7 +24436,7 @@
         "Datum_neu": 1638403200000,
         "F\u00e4lle_Meldedatum": 881,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24446,7 +24446,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24484,7 +24484,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 525,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24548,9 +24548,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24560,7 +24560,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24584,25 +24584,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1303,
         "BelegteBetten": null,
-        "Inzidenz": 1038.29160530191,
+        "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 953,
+        "F\u00e4lle_Meldedatum": 955,
         "Zeitraum": null,
         "Hosp_Meldedatum": 46,
-        "Inzidenz_RKI": 923.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2111,
-        "Krh_I_belegt": 601,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.64,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2021"
@@ -24624,13 +24624,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1048.16983368656,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1230,
+        "F\u00e4lle_Meldedatum": 1227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
-        "Inzidenz_RKI": 798.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2184,
-        "Krh_I_belegt": 593,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24640,7 +24640,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 17.28,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2021"
@@ -24662,9 +24662,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1025.18050217321,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 848,
+        "F\u00e4lle_Meldedatum": 849,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 41,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": 894.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2098,
@@ -24678,7 +24678,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.71,
+        "H_Inzidenz": 17.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2021"
@@ -24702,7 +24702,7 @@
         "Datum_neu": 1639008000000,
         "F\u00e4lle_Meldedatum": 902,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 899.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 2077,
@@ -24716,7 +24716,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.78,
+        "H_Inzidenz": 16.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2021"
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": 987.284026006681,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 766,
+        "F\u00e4lle_Meldedatum": 767,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 898.7,
@@ -24754,7 +24754,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.54,
+        "H_Inzidenz": 15.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2021"
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": 969.862423219225,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 477,
+        "F\u00e4lle_Meldedatum": 476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 876.4,
@@ -24792,7 +24792,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.16,
+        "H_Inzidenz": 13.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2021"
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": 956.571715938073,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 841,
@@ -24826,11 +24826,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.57,
+        "H_Inzidenz": 13.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2021"
@@ -24852,9 +24852,9 @@
         "BelegteBetten": null,
         "Inzidenz": 938.072488235928,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 820,
+        "F\u00e4lle_Meldedatum": 831,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 915.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1989,
@@ -24864,11 +24864,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.78,
+        "H_Inzidenz": 12.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2021"
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": 902.151657746327,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 851,
+        "F\u00e4lle_Meldedatum": 1008,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 797.5,
@@ -24906,7 +24906,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.69,
+        "H_Inzidenz": 10.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2021"
@@ -24917,38 +24917,76 @@
         "Datum": "15.12.2021",
         "Fallzahl": 75332,
         "ObjectId": 649,
-        "Sterbefall": 1374,
-        "Genesungsfall": 63615,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3785,
-        "Zuwachs_Fallzahl": 941,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1087,
         "BelegteBetten": null,
         "Inzidenz": 863.716369122454,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 217,
-        "Zeitraum": "08.12.2021 - 14.12.2021",
+        "F\u00e4lle_Meldedatum": 573,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 757.6,
-        "Fallzahl_aktiv": 10343,
-        "Krh_N_belegt": 1970,
-        "Krh_I_belegt": 601,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1907,
+        "Krh_I_belegt": 590,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -146,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.56,
-        "H_Zeitraum": "09.12.2021 - 15.12.2021",
-        "H_Datum": "14.12.2021",
+        "H_Inzidenz": 9.29,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "14.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.12.2021",
+        "Fallzahl": 76117,
+        "ObjectId": 650,
+        "Sterbefall": 1381,
+        "Genesungsfall": 64475,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3792,
+        "Zuwachs_Fallzahl": 785,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 860,
+        "BelegteBetten": null,
+        "Inzidenz": 844.678328962966,
+        "Datum_neu": 1639612800000,
+        "F\u00e4lle_Meldedatum": 236,
+        "Zeitraum": "09.12.2021 - 15.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 767.3,
+        "Fallzahl_aktiv": 10261,
+        "Krh_N_belegt": 1907,
+        "Krh_I_belegt": 590,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -82,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.69,
+        "H_Zeitraum": "10.12.2021 - 16.12.2021",
+        "H_Datum": "15.12.2021",
+        "Datum_Bett": "15.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
