### PR TITLE
New data set: 2021-12-20T111503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-17T113803Z.json
+pjson/2021-12-20T111503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-17T113803Z.json pjson/2021-12-20T111503Z.json```:
```
--- pjson/2021-12-17T113803Z.json	2021-12-17 11:38:03.281894728 +0000
+++ pjson/2021-12-20T111503Z.json	2021-12-20 11:15:03.948421695 +0000
@@ -10868,7 +10868,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 462,
+        "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -11172,7 +11172,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608249600000,
-        "F\u00e4lle_Meldedatum": 445,
+        "F\u00e4lle_Meldedatum": 446,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -20294,7 +20294,7 @@
         "Datum_neu": 1628985600000,
         "F\u00e4lle_Meldedatum": 1,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22116,7 +22116,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22496,7 +22496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -23066,7 +23066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 495,
+        "F\u00e4lle_Meldedatum": 498,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 558,
+        "F\u00e4lle_Meldedatum": 560,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 543,
+        "F\u00e4lle_Meldedatum": 544,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1097,
+        "F\u00e4lle_Meldedatum": 1098,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23714,7 +23714,7 @@
         "Datum_neu": 1636761600000,
         "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23788,9 +23788,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1141,
+        "F\u00e4lle_Meldedatum": 1142,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1563,
+        "F\u00e4lle_Meldedatum": 1567,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1091,
+        "F\u00e4lle_Meldedatum": 1093,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1477,
+        "F\u00e4lle_Meldedatum": 1478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -24054,9 +24054,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1378,
+        "F\u00e4lle_Meldedatum": 1380,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1082,
+        "F\u00e4lle_Meldedatum": 1086,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24168,9 +24168,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1451,
+        "F\u00e4lle_Meldedatum": 1467,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24206,9 +24206,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1181,
+        "F\u00e4lle_Meldedatum": 1188,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 767,
+        "F\u00e4lle_Meldedatum": 770,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24282,9 +24282,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 283,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24294,7 +24294,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 863,
+        "F\u00e4lle_Meldedatum": 868,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24358,9 +24358,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1305,
+        "F\u00e4lle_Meldedatum": 1312,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24396,9 +24396,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1098,
+        "F\u00e4lle_Meldedatum": 1097,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24436,7 +24436,7 @@
         "Datum_neu": 1638403200000,
         "F\u00e4lle_Meldedatum": 881,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1001,
+        "F\u00e4lle_Meldedatum": 1002,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -24484,7 +24484,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 12,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,9 +24586,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 956,
+        "F\u00e4lle_Meldedatum": 955,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 46,
+        "Hosp_Meldedatum": 45,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24598,7 +24598,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24624,9 +24624,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1228,
+        "F\u00e4lle_Meldedatum": 1229,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 849,
+        "F\u00e4lle_Meldedatum": 850,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 898,
+        "F\u00e4lle_Meldedatum": 897,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24736,25 +24736,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 971,
         "BelegteBetten": null,
-        "Inzidenz": 987.284026006681,
+        "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 770,
+        "F\u00e4lle_Meldedatum": 771,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
-        "Inzidenz_RKI": 898.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 2011,
-        "Krh_I_belegt": 589,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.17,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2021"
@@ -24774,15 +24774,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1045,
         "BelegteBetten": null,
-        "Inzidenz": 969.862423219225,
+        "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 478,
+        "F\u00e4lle_Meldedatum": 479,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 876.4,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1908,
-        "Krh_I_belegt": 580,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24792,7 +24792,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.04,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2021"
@@ -24812,15 +24812,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 284,
         "BelegteBetten": null,
-        "Inzidenz": 956.571715938073,
+        "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 841,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1906,
-        "Krh_I_belegt": 578,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24830,7 +24830,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.64,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2021"
@@ -24852,9 +24852,9 @@
         "BelegteBetten": null,
         "Inzidenz": 938.072488235928,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 839,
+        "F\u00e4lle_Meldedatum": 841,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 915.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1989,
@@ -24868,7 +24868,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.75,
+        "H_Inzidenz": 15.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2021"
@@ -24890,9 +24890,9 @@
         "BelegteBetten": null,
         "Inzidenz": 902.151657746327,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1023,
+        "F\u00e4lle_Meldedatum": 1027,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 797.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1970,
@@ -24902,11 +24902,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.61,
+        "H_Inzidenz": 13.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2021"
@@ -24928,9 +24928,9 @@
         "BelegteBetten": null,
         "Inzidenz": 863.716369122454,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 657,
+        "F\u00e4lle_Meldedatum": 659,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 757.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1907,
@@ -24940,11 +24940,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.43,
+        "H_Inzidenz": 12.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.12.2021"
@@ -24966,9 +24966,9 @@
         "BelegteBetten": null,
         "Inzidenz": 844.678328962966,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 726,
+        "F\u00e4lle_Meldedatum": 756,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 767.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1854,
@@ -24982,7 +24982,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.34,
+        "H_Inzidenz": 11.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.12.2021"
@@ -24995,7 +24995,7 @@
         "ObjectId": 651,
         "Sterbefall": 1381,
         "Genesungsfall": 65633,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3818,
         "Zuwachs_Fallzahl": 733,
         "Zuwachs_Sterbefall": 0,
@@ -25004,13 +25004,13 @@
         "BelegteBetten": null,
         "Inzidenz": 833.004059053845,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 91,
-        "Zeitraum": "10.12.2021 - 16.12.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 510,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 741.6,
         "Fallzahl_aktiv": 9840,
-        "Krh_N_belegt": 1854,
-        "Krh_I_belegt": 588,
+        "Krh_N_belegt": 1745,
+        "Krh_I_belegt": 583,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -425,
         "Krh_I": null,
@@ -25018,13 +25018,127 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.79,
-        "H_Zeitraum": "10.12.2021 - 16.12.2021",
-        "H_Datum": "16.12.2021",
+        "H_Inzidenz": 10.65,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.12.2021",
+        "Fallzahl": 77085,
+        "ObjectId": 652,
+        "Sterbefall": null,
+        "Genesungsfall": 66254,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 621,
+        "BelegteBetten": null,
+        "Inzidenz": 793.131937210388,
+        "Datum_neu": 1639785600000,
+        "F\u00e4lle_Meldedatum": 171,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 713.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1591,
+        "Krh_I_belegt": 584,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.9,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.12.2021",
+        "Fallzahl": 77178,
+        "ObjectId": 653,
+        "Sterbefall": null,
+        "Genesungsfall": 66462,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 208,
+        "BelegteBetten": null,
+        "Inzidenz": 737.813858256403,
+        "Datum_neu": 1639872000000,
+        "F\u00e4lle_Meldedatum": 140,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 627.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1580,
+        "Krh_I_belegt": 593,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.89,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.12.2021",
+        "Fallzahl": 77741,
+        "ObjectId": 654,
+        "Sterbefall": 1393,
+        "Genesungsfall": 67380,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3871,
+        "Zuwachs_Fallzahl": 887,
+        "Zuwachs_Sterbefall": 12,
+        "Zuwachs_Krankenhauseinweisung": 53,
+        "Zuwachs_Genesung": 918,
+        "BelegteBetten": null,
+        "Inzidenz": 737.095441646611,
+        "Datum_neu": 1639958400000,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": "13.12.2021 - 19.12.2021",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 655.5,
+        "Fallzahl_aktiv": 8968,
+        "Krh_N_belegt": 1580,
+        "Krh_I_belegt": 593,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -43,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.3,
+        "H_Zeitraum": "13.12.2021 - 19.12.2021",
+        "H_Datum": "19.12.2021",
+        "Datum_Bett": "19.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
