### PR TITLE
New data set: 2021-12-21T111804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-20T111503Z.json
+pjson/2021-12-21T111804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-20T111503Z.json pjson/2021-12-21T111804Z.json```:
```
--- pjson/2021-12-20T111503Z.json	2021-12-20 11:15:03.948421695 +0000
+++ pjson/2021-12-21T111804Z.json	2021-12-21 11:18:04.255907746 +0000
@@ -12768,7 +12768,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611878400000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -22116,7 +22116,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22800,7 +22800,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 279,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 560,
+        "F\u00e4lle_Meldedatum": 561,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 711,
+        "F\u00e4lle_Meldedatum": 713,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 973,
+        "F\u00e4lle_Meldedatum": 975,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1098,
+        "F\u00e4lle_Meldedatum": 1099,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23826,9 +23826,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1567,
+        "F\u00e4lle_Meldedatum": 1568,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1093,
+        "F\u00e4lle_Meldedatum": 1094,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,9 +23940,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1478,
+        "F\u00e4lle_Meldedatum": 1480,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 905,
+        "F\u00e4lle_Meldedatum": 908,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1380,
+        "F\u00e4lle_Meldedatum": 1383,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1664,
+        "F\u00e4lle_Meldedatum": 1667,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24168,9 +24168,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1467,
+        "F\u00e4lle_Meldedatum": 1474,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1188,
+        "F\u00e4lle_Meldedatum": 1196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 770,
+        "F\u00e4lle_Meldedatum": 769,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 286,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 868,
+        "F\u00e4lle_Meldedatum": 874,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1312,
+        "F\u00e4lle_Meldedatum": 1322,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1097,
+        "F\u00e4lle_Meldedatum": 1102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 881,
+        "F\u00e4lle_Meldedatum": 892,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24472,9 +24472,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1002,
+        "F\u00e4lle_Meldedatum": 999,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 530,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 955,
+        "F\u00e4lle_Meldedatum": 956,
         "Zeitraum": null,
         "Hosp_Meldedatum": 45,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1229,
+        "F\u00e4lle_Meldedatum": 1231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 850,
+        "F\u00e4lle_Meldedatum": 851,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24776,9 +24776,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 479,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -24850,15 +24850,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 815,
         "BelegteBetten": null,
-        "Inzidenz": 938.072488235928,
+        "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 841,
+        "F\u00e4lle_Meldedatum": 842,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
-        "Inzidenz_RKI": 915.8,
+        "Hosp_Meldedatum": 24,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1989,
-        "Krh_I_belegt": 587,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24868,7 +24868,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.21,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2021"
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": 902.151657746327,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1027,
+        "F\u00e4lle_Meldedatum": 1026,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 797.5,
@@ -24906,7 +24906,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.43,
+        "H_Inzidenz": 14.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2021"
@@ -24928,9 +24928,9 @@
         "BelegteBetten": null,
         "Inzidenz": 863.716369122454,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 659,
+        "F\u00e4lle_Meldedatum": 661,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 757.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1907,
@@ -24940,11 +24940,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.72,
+        "H_Inzidenz": 13.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.12.2021"
@@ -24966,9 +24966,9 @@
         "BelegteBetten": null,
         "Inzidenz": 844.678328962966,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 756,
+        "F\u00e4lle_Meldedatum": 755,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 767.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1854,
@@ -24978,11 +24978,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.98,
+        "H_Inzidenz": 12.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.12.2021"
@@ -24993,34 +24993,34 @@
         "Datum": "17.12.2021",
         "Fallzahl": 76854,
         "ObjectId": 651,
-        "Sterbefall": 1381,
-        "Genesungsfall": 65633,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3818,
-        "Zuwachs_Fallzahl": 733,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1158,
         "BelegteBetten": null,
         "Inzidenz": 833.004059053845,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 510,
+        "F\u00e4lle_Meldedatum": 524,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 741.6,
-        "Fallzahl_aktiv": 9840,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1745,
         "Krh_I_belegt": 583,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -425,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.65,
+        "H_Inzidenz": 11.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.12.2021"
@@ -25032,7 +25032,7 @@
         "Fallzahl": 77085,
         "ObjectId": 652,
         "Sterbefall": null,
-        "Genesungsfall": 66254,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25042,9 +25042,9 @@
         "BelegteBetten": null,
         "Inzidenz": 793.131937210388,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 171,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 713.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1591,
@@ -25054,11 +25054,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.9,
+        "H_Inzidenz": 10.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.12.2021"
@@ -25070,7 +25070,7 @@
         "Fallzahl": 77178,
         "ObjectId": 653,
         "Sterbefall": null,
-        "Genesungsfall": 66462,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25080,9 +25080,9 @@
         "BelegteBetten": null,
         "Inzidenz": 737.813858256403,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 627.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1580,
@@ -25096,7 +25096,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.89,
+        "H_Inzidenz": 9.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.12.2021"
@@ -25107,38 +25107,76 @@
         "Datum": "20.12.2021",
         "Fallzahl": 77741,
         "ObjectId": 654,
-        "Sterbefall": 1393,
-        "Genesungsfall": 67380,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 3871,
-        "Zuwachs_Fallzahl": 887,
-        "Zuwachs_Sterbefall": 12,
-        "Zuwachs_Krankenhauseinweisung": 53,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 918,
         "BelegteBetten": null,
         "Inzidenz": 737.095441646611,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 52,
-        "Zeitraum": "13.12.2021 - 19.12.2021",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 420,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 655.5,
-        "Fallzahl_aktiv": 8968,
-        "Krh_N_belegt": 1580,
-        "Krh_I_belegt": 593,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1644,
+        "Krh_I_belegt": 598,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -43,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.3,
-        "H_Zeitraum": "13.12.2021 - 19.12.2021",
-        "H_Datum": "19.12.2021",
+        "H_Inzidenz": 8.73,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.12.2021",
+        "Fallzahl": 78493,
+        "ObjectId": 655,
+        "Sterbefall": 1397,
+        "Genesungsfall": 68593,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3926,
+        "Zuwachs_Fallzahl": 752,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 55,
+        "Zuwachs_Genesung": 1213,
+        "BelegteBetten": null,
+        "Inzidenz": 669.743884478609,
+        "Datum_neu": 1640044800000,
+        "F\u00e4lle_Meldedatum": 262,
+        "Zeitraum": "14.12.2021 - 20.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 605,
+        "Fallzahl_aktiv": 8503,
+        "Krh_N_belegt": 1644,
+        "Krh_I_belegt": 598,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -465,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.88,
+        "H_Zeitraum": "14.12.2021 - 20.12.2021",
+        "H_Datum": "20.12.2021",
+        "Datum_Bett": "20.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
