### PR TITLE
New data set: 2021-12-22T111303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-21T111804Z.json
+pjson/2021-12-22T111303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-21T111804Z.json pjson/2021-12-22T111303Z.json```:
```
--- pjson/2021-12-21T111804Z.json	2021-12-21 11:18:04.255907746 +0000
+++ pjson/2021-12-22T111303Z.json	2021-12-22 11:13:04.068036184 +0000
@@ -13606,7 +13606,7 @@
         "Datum_neu": 1613779200000,
         "F\u00e4lle_Meldedatum": 21,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15240,7 +15240,7 @@
         "Datum_neu": 1617494400000,
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20634,7 +20634,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629763200000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 544,
+        "F\u00e4lle_Meldedatum": 543,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -23446,7 +23446,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636156800000,
-        "F\u00e4lle_Meldedatum": 259,
+        "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1237,
+        "F\u00e4lle_Meldedatum": 1239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1099,
+        "F\u00e4lle_Meldedatum": 1100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23714,7 +23714,7 @@
         "Datum_neu": 1636761600000,
         "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1568,
+        "F\u00e4lle_Meldedatum": 1567,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 933,
+        "F\u00e4lle_Meldedatum": 934,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1094,
+        "F\u00e4lle_Meldedatum": 1095,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1480,
+        "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1383,
+        "F\u00e4lle_Meldedatum": 1382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1667,
+        "F\u00e4lle_Meldedatum": 1668,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1086,
+        "F\u00e4lle_Meldedatum": 1087,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1474,
+        "F\u00e4lle_Meldedatum": 1477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1196,
+        "F\u00e4lle_Meldedatum": 1198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24320,9 +24320,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 874,
+        "F\u00e4lle_Meldedatum": 877,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1322,
+        "F\u00e4lle_Meldedatum": 1326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24370,7 +24370,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24434,9 +24434,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 892,
+        "F\u00e4lle_Meldedatum": 893,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 999,
+        "F\u00e4lle_Meldedatum": 1007,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 530,
+        "F\u00e4lle_Meldedatum": 534,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,9 +24586,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 956,
+        "F\u00e4lle_Meldedatum": 962,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 45,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24598,7 +24598,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24624,9 +24624,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1231,
+        "F\u00e4lle_Meldedatum": 1245,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24662,9 +24662,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 851,
+        "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24674,7 +24674,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24700,9 +24700,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 897,
+        "F\u00e4lle_Meldedatum": 899,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24712,7 +24712,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24738,9 +24738,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 771,
+        "F\u00e4lle_Meldedatum": 774,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 480,
+        "F\u00e4lle_Meldedatum": 479,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24788,7 +24788,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24816,7 +24816,7 @@
         "Datum_neu": 1639267200000,
         "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24826,7 +24826,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24852,9 +24852,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 842,
+        "F\u00e4lle_Meldedatum": 839,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24864,7 +24864,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24888,25 +24888,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1283,
         "BelegteBetten": null,
-        "Inzidenz": 902.151657746327,
+        "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1026,
+        "F\u00e4lle_Meldedatum": 1034,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 797.5,
+        "Hosp_Meldedatum": 20,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1970,
-        "Krh_I_belegt": 601,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.25,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2021"
@@ -24928,9 +24928,9 @@
         "BelegteBetten": null,
         "Inzidenz": 863.716369122454,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 661,
+        "F\u00e4lle_Meldedatum": 662,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 757.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1907,
@@ -24944,7 +24944,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.61,
+        "H_Inzidenz": 15.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.12.2021"
@@ -24966,9 +24966,9 @@
         "BelegteBetten": null,
         "Inzidenz": 844.678328962966,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 755,
+        "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 767.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1854,
@@ -24982,7 +24982,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.94,
+        "H_Inzidenz": 14.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.12.2021"
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": 833.004059053845,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 524,
+        "F\u00e4lle_Meldedatum": 520,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 741.6,
@@ -25016,11 +25016,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.68,
+        "H_Inzidenz": 13.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.12.2021"
@@ -25042,7 +25042,7 @@
         "BelegteBetten": null,
         "Inzidenz": 793.131937210388,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 192,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 713.9,
@@ -25058,7 +25058,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.13,
+        "H_Inzidenz": 11.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.12.2021"
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": 737.813858256403,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 627.8,
@@ -25096,7 +25096,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.12,
+        "H_Inzidenz": 10.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.12.2021"
@@ -25118,9 +25118,9 @@
         "BelegteBetten": null,
         "Inzidenz": 737.095441646611,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": 655.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1644,
@@ -25134,7 +25134,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.73,
+        "H_Inzidenz": 10.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.12.2021"
@@ -25147,7 +25147,7 @@
         "ObjectId": 655,
         "Sterbefall": 1397,
         "Genesungsfall": 68593,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3926,
         "Zuwachs_Fallzahl": 752,
         "Zuwachs_Sterbefall": 4,
@@ -25156,13 +25156,13 @@
         "BelegteBetten": null,
         "Inzidenz": 669.743884478609,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 262,
-        "Zeitraum": "14.12.2021 - 20.12.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 845,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 605,
         "Fallzahl_aktiv": 8503,
-        "Krh_N_belegt": 1644,
-        "Krh_I_belegt": 598,
+        "Krh_N_belegt": 1633,
+        "Krh_I_belegt": 587,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -465,
         "Krh_I": null,
@@ -25170,13 +25170,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
-        "H_Zeitraum": "14.12.2021 - 20.12.2021",
-        "H_Datum": "20.12.2021",
+        "H_Inzidenz": 9.29,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.12.2021",
+        "Fallzahl": 79472,
+        "ObjectId": 656,
+        "Sterbefall": 1412,
+        "Genesungsfall": 69427,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 3974,
+        "Zuwachs_Fallzahl": 979,
+        "Zuwachs_Sterbefall": 15,
+        "Zuwachs_Krankenhauseinweisung": 48,
+        "Zuwachs_Genesung": 834,
+        "BelegteBetten": null,
+        "Inzidenz": 660.224864398865,
+        "Datum_neu": 1640131200000,
+        "F\u00e4lle_Meldedatum": 183,
+        "Zeitraum": "15.12.2021 - 21.12.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 568.8,
+        "Fallzahl_aktiv": 8633,
+        "Krh_N_belegt": 1553,
+        "Krh_I_belegt": 575,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 130,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.85,
+        "H_Zeitraum": "15.12.2021 - 21.12.2021",
+        "H_Datum": "22.12.2021",
+        "Datum_Bett": "21.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
