### PR TITLE
New data set: 2021-12-23T112503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-22T111303Z.json
+pjson/2021-12-23T112503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-22T111303Z.json pjson/2021-12-23T112503Z.json```:
```
--- pjson/2021-12-22T111303Z.json	2021-12-22 11:13:04.068036184 +0000
+++ pjson/2021-12-23T112503Z.json	2021-12-23 11:25:04.115089770 +0000
@@ -23144,7 +23144,7 @@
         "Datum_neu": 1635465600000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1239,
+        "F\u00e4lle_Meldedatum": 1240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 934,
+        "F\u00e4lle_Meldedatum": 936,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1095,
+        "F\u00e4lle_Meldedatum": 1096,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1482,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 908,
+        "F\u00e4lle_Meldedatum": 907,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1668,
+        "F\u00e4lle_Meldedatum": 1667,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1087,
+        "F\u00e4lle_Meldedatum": 1089,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24246,7 +24246,7 @@
         "Datum_neu": 1637971200000,
         "F\u00e4lle_Meldedatum": 769,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1109,
+        "F\u00e4lle_Meldedatum": 1111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24434,9 +24434,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 893,
+        "F\u00e4lle_Meldedatum": 894,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24472,9 +24472,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1007,
+        "F\u00e4lle_Meldedatum": 1009,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 534,
+        "F\u00e4lle_Meldedatum": 535,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24522,7 +24522,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 962,
+        "F\u00e4lle_Meldedatum": 964,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -24624,9 +24624,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1245,
+        "F\u00e4lle_Meldedatum": 1248,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 864,
+        "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24702,7 +24702,7 @@
         "Datum_neu": 1639008000000,
         "F\u00e4lle_Meldedatum": 899,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 774,
+        "F\u00e4lle_Meldedatum": 781,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 479,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24814,9 +24814,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 839,
+        "F\u00e4lle_Meldedatum": 853,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24864,7 +24864,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1034,
+        "F\u00e4lle_Meldedatum": 1047,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24902,7 +24902,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24926,15 +24926,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1087,
         "BelegteBetten": null,
-        "Inzidenz": 863.716369122454,
+        "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 662,
+        "F\u00e4lle_Meldedatum": 671,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 757.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1907,
-        "Krh_I_belegt": 590,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24944,7 +24944,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.13,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.12.2021"
@@ -24966,9 +24966,9 @@
         "BelegteBetten": null,
         "Inzidenz": 844.678328962966,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 762,
+        "F\u00e4lle_Meldedatum": 761,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 767.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1854,
@@ -24982,7 +24982,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.59,
+        "H_Inzidenz": 15.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.12.2021"
@@ -25004,9 +25004,9 @@
         "BelegteBetten": null,
         "Inzidenz": 833.004059053845,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 520,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 741.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1745,
@@ -25016,11 +25016,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.11,
+        "H_Inzidenz": 14.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.12.2021"
@@ -25058,7 +25058,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.76,
+        "H_Inzidenz": 12.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.12.2021"
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": 737.813858256403,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 627.8,
@@ -25096,7 +25096,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.89,
+        "H_Inzidenz": 11.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.12.2021"
@@ -25118,9 +25118,9 @@
         "BelegteBetten": null,
         "Inzidenz": 737.095441646611,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 543,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 42,
+        "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": 655.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1644,
@@ -25130,11 +25130,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.6,
+        "H_Inzidenz": 11.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.12.2021"
@@ -25145,26 +25145,26 @@
         "Datum": "21.12.2021",
         "Fallzahl": 78493,
         "ObjectId": 655,
-        "Sterbefall": 1397,
-        "Genesungsfall": 68593,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3926,
-        "Zuwachs_Fallzahl": 752,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 55,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1213,
         "BelegteBetten": null,
         "Inzidenz": 669.743884478609,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 845,
+        "F\u00e4lle_Meldedatum": 878,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 605,
-        "Fallzahl_aktiv": 8503,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1633,
         "Krh_I_belegt": 587,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -465,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -25172,7 +25172,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.29,
+        "H_Inzidenz": 10.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.12.2021"
@@ -25185,7 +25185,7 @@
         "ObjectId": 656,
         "Sterbefall": 1412,
         "Genesungsfall": 69427,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 3974,
         "Zuwachs_Fallzahl": 979,
         "Zuwachs_Sterbefall": 15,
@@ -25194,9 +25194,9 @@
         "BelegteBetten": null,
         "Inzidenz": 660.224864398865,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 183,
-        "Zeitraum": "15.12.2021 - 21.12.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 405,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 568.8,
         "Fallzahl_aktiv": 8633,
         "Krh_N_belegt": 1553,
@@ -25206,15 +25206,53 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
-        "Mutation": 8,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.85,
-        "H_Zeitraum": "15.12.2021 - 21.12.2021",
-        "H_Datum": "22.12.2021",
+        "H_Inzidenz": 9.27,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.12.2021",
+        "Fallzahl": 79939,
+        "ObjectId": 657,
+        "Sterbefall": 1420,
+        "Genesungsfall": 70519,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4018,
+        "Zuwachs_Fallzahl": 467,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 44,
+        "Zuwachs_Genesung": 1092,
+        "BelegteBetten": null,
+        "Inzidenz": 623.046804842128,
+        "Datum_neu": 1640217600000,
+        "F\u00e4lle_Meldedatum": 137,
+        "Zeitraum": "16.12.2021 - 22.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 577.5,
+        "Fallzahl_aktiv": 8000,
+        "Krh_N_belegt": 1426,
+        "Krh_I_belegt": 551,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -633,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 10,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.32,
+        "H_Zeitraum": "16.12.2021 - 22.12.2021",
+        "H_Datum": "23.12.2021",
+        "Datum_Bett": "22.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
