### PR TITLE
New data set: 2021-12-27T121503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-23T112503Z.json
+pjson/2021-12-27T121503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-23T112503Z.json pjson/2021-12-27T121503Z.json```:
```
--- pjson/2021-12-23T112503Z.json	2021-12-23 11:25:04.115089770 +0000
+++ pjson/2021-12-27T121503Z.json	2021-12-27 12:15:03.784961134 +0000
@@ -10070,7 +10070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605744000000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -10640,7 +10640,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607040000000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -10830,7 +10830,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607472000000,
-        "F\u00e4lle_Meldedatum": 397,
+        "F\u00e4lle_Meldedatum": 398,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -11058,7 +11058,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607990400000,
-        "F\u00e4lle_Meldedatum": 421,
+        "F\u00e4lle_Meldedatum": 422,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -11210,7 +11210,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608336000000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -11248,7 +11248,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608422400000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -11476,7 +11476,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608940800000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -12692,7 +12692,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -13414,7 +13414,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13644,7 +13644,7 @@
         "Datum_neu": 1613865600000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14328,7 +14328,7 @@
         "Datum_neu": 1615420800000,
         "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15810,7 +15810,7 @@
         "Datum_neu": 1618790400000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21320,7 +21320,7 @@
         "Datum_neu": 1631318400000,
         "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21928,7 +21928,7 @@
         "Datum_neu": 1632700800000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22802,7 +22802,7 @@
         "Datum_neu": 1634688000000,
         "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23144,7 +23144,7 @@
         "Datum_neu": 1635465600000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23296,7 +23296,7 @@
         "Datum_neu": 1635811200000,
         "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23410,7 +23410,7 @@
         "Datum_neu": 1636070400000,
         "F\u00e4lle_Meldedatum": 543,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23610,7 +23610,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 497,
+        "F\u00e4lle_Meldedatum": 496,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1096,
+        "F\u00e4lle_Meldedatum": 1095,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24170,7 +24170,7 @@
         "Datum_neu": 1637798400000,
         "F\u00e4lle_Meldedatum": 1477,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24208,7 +24208,7 @@
         "Datum_neu": 1637884800000,
         "F\u00e4lle_Meldedatum": 1198,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 877,
+        "F\u00e4lle_Meldedatum": 875,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1326,
+        "F\u00e4lle_Meldedatum": 1327,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1111,
+        "F\u00e4lle_Meldedatum": 1112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1009,
+        "F\u00e4lle_Meldedatum": 1011,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 535,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 964,
+        "F\u00e4lle_Meldedatum": 967,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1248,
+        "F\u00e4lle_Meldedatum": 1249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 866,
+        "F\u00e4lle_Meldedatum": 865,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24700,9 +24700,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 899,
+        "F\u00e4lle_Meldedatum": 904,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 781,
+        "F\u00e4lle_Meldedatum": 779,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 478,
+        "F\u00e4lle_Meldedatum": 476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 853,
+        "F\u00e4lle_Meldedatum": 855,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24864,7 +24864,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1047,
+        "F\u00e4lle_Meldedatum": 1044,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24902,7 +24902,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24928,9 +24928,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 671,
+        "F\u00e4lle_Meldedatum": 674,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24940,7 +24940,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24968,7 +24968,7 @@
         "Datum_neu": 1639612800000,
         "F\u00e4lle_Meldedatum": 761,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 767.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1854,
@@ -24978,11 +24978,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.53,
+        "H_Inzidenz": 16.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.12.2021"
@@ -25004,9 +25004,9 @@
         "BelegteBetten": null,
         "Inzidenz": 833.004059053845,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 531,
+        "F\u00e4lle_Meldedatum": 532,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 741.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1745,
@@ -25020,7 +25020,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.07,
+        "H_Inzidenz": 15.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.12.2021"
@@ -25042,9 +25042,9 @@
         "BelegteBetten": null,
         "Inzidenz": 793.131937210388,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 192,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 713.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1591,
@@ -25054,11 +25054,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.77,
+        "H_Inzidenz": 14.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.12.2021"
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": 737.813858256403,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 627.8,
@@ -25096,7 +25096,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.93,
+        "H_Inzidenz": 13.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.12.2021"
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": 737.095441646611,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 543,
+        "F\u00e4lle_Meldedatum": 567,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": 655.5,
@@ -25134,7 +25134,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.61,
+        "H_Inzidenz": 13.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.12.2021"
@@ -25156,9 +25156,9 @@
         "BelegteBetten": null,
         "Inzidenz": 669.743884478609,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 878,
+        "F\u00e4lle_Meldedatum": 934,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 605,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1633,
@@ -25172,7 +25172,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.72,
+        "H_Inzidenz": 12.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.12.2021"
@@ -25194,9 +25194,9 @@
         "BelegteBetten": null,
         "Inzidenz": 660.224864398865,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 405,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 568.8,
         "Fallzahl_aktiv": 8633,
         "Krh_N_belegt": 1553,
@@ -25210,7 +25210,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.27,
+        "H_Inzidenz": 11.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.12.2021"
@@ -25223,7 +25223,7 @@
         "ObjectId": 657,
         "Sterbefall": 1420,
         "Genesungsfall": 70519,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4018,
         "Zuwachs_Fallzahl": 467,
         "Zuwachs_Sterbefall": 8,
@@ -25232,9 +25232,9 @@
         "BelegteBetten": null,
         "Inzidenz": 623.046804842128,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 137,
-        "Zeitraum": "16.12.2021 - 22.12.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 387,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 577.5,
         "Fallzahl_aktiv": 8000,
         "Krh_N_belegt": 1426,
@@ -25244,15 +25244,167 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 10,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.32,
-        "H_Zeitraum": "16.12.2021 - 22.12.2021",
-        "H_Datum": "23.12.2021",
+        "H_Inzidenz": 9.93,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.12.2021",
+        "Fallzahl": 80410,
+        "ObjectId": 658,
+        "Sterbefall": null,
+        "Genesungsfall": 71295,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 776,
+        "BelegteBetten": null,
+        "Inzidenz": 510.973813714573,
+        "Datum_neu": 1640304000000,
+        "F\u00e4lle_Meldedatum": 159,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 516.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1240,
+        "Krh_I_belegt": 543,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.12,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.12.2021",
+        "Fallzahl": 80512,
+        "ObjectId": 659,
+        "Sterbefall": null,
+        "Genesungsfall": 71793,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 498,
+        "BelegteBetten": null,
+        "Inzidenz": 440.389381802507,
+        "Datum_neu": 1640390400000,
+        "F\u00e4lle_Meldedatum": 89,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": 458.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1175,
+        "Krh_I_belegt": 529,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.2,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "24.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.12.2021",
+        "Fallzahl": 80554,
+        "ObjectId": 660,
+        "Sterbefall": null,
+        "Genesungsfall": 71957,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 164,
+        "BelegteBetten": null,
+        "Inzidenz": 430.870361722763,
+        "Datum_neu": 1640476800000,
+        "F\u00e4lle_Meldedatum": 91,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 457.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1184,
+        "Krh_I_belegt": 523,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.66,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.12.2021",
+        "Fallzahl": 80663,
+        "ObjectId": 661,
+        "Sterbefall": 1431,
+        "Genesungsfall": 72778,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4038,
+        "Zuwachs_Fallzahl": 724,
+        "Zuwachs_Sterbefall": 11,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 821,
+        "BelegteBetten": null,
+        "Inzidenz": 474.693774920076,
+        "Datum_neu": 1640563200000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": "20.12.2021 - 26.12.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 463.5,
+        "Fallzahl_aktiv": 6454,
+        "Krh_N_belegt": 1184,
+        "Krh_I_belegt": 523,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -108,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 13,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.14,
+        "H_Zeitraum": "20.12.2021 - 26.12.2021",
+        "H_Datum": "26.12.2021",
+        "Datum_Bett": "26.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
