### PR TITLE
New data set: 2021-12-28T110103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-23T112503Z.json
+pjson/2021-12-28T110103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-27T121503Z.json pjson/2021-12-28T110103Z.json```:
```
--- pjson/2021-12-27T121503Z.json	2021-12-27 12:15:03.784961134 +0000
+++ pjson/2021-12-28T110103Z.json	2021-12-28 11:01:03.553297200 +0000
@@ -10602,7 +10602,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 300,
+        "F\u00e4lle_Meldedatum": 301,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -13528,7 +13528,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23066,7 +23066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 690,
+        "F\u00e4lle_Meldedatum": 691,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1040,
+        "F\u00e4lle_Meldedatum": 1039,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1100,
+        "F\u00e4lle_Meldedatum": 1101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1142,
+        "F\u00e4lle_Meldedatum": 1144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1567,
+        "F\u00e4lle_Meldedatum": 1568,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 936,
+        "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1484,
+        "F\u00e4lle_Meldedatum": 1485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1382,
+        "F\u00e4lle_Meldedatum": 1383,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1089,
+        "F\u00e4lle_Meldedatum": 1090,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1477,
+        "F\u00e4lle_Meldedatum": 1476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 769,
+        "F\u00e4lle_Meldedatum": 770,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 875,
+        "F\u00e4lle_Meldedatum": 878,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1327,
+        "F\u00e4lle_Meldedatum": 1330,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1112,
+        "F\u00e4lle_Meldedatum": 1116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 967,
+        "F\u00e4lle_Meldedatum": 969,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1249,
+        "F\u00e4lle_Meldedatum": 1252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -24662,9 +24662,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 865,
+        "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24700,9 +24700,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 904,
+        "F\u00e4lle_Meldedatum": 905,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 779,
+        "F\u00e4lle_Meldedatum": 781,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 476,
+        "F\u00e4lle_Meldedatum": 474,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1044,
+        "F\u00e4lle_Meldedatum": 1047,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 674,
+        "F\u00e4lle_Meldedatum": 676,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24964,15 +24964,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 860,
         "BelegteBetten": null,
-        "Inzidenz": 844.678328962966,
+        "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 761,
+        "F\u00e4lle_Meldedatum": 760,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 767.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1854,
-        "Krh_I_belegt": 588,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -24982,7 +24982,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.66,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.12.2021"
@@ -25002,15 +25002,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1158,
         "BelegteBetten": null,
-        "Inzidenz": 833.004059053845,
+        "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 532,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
-        "Inzidenz_RKI": 741.6,
+        "Hosp_Meldedatum": 21,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1745,
-        "Krh_I_belegt": 583,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25020,7 +25020,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.28,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.12.2021"
@@ -25040,15 +25040,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 621,
         "BelegteBetten": null,
-        "Inzidenz": 793.131937210388,
+        "Inzidenz": null,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 713.9,
+        "Hosp_Meldedatum": 11,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1591,
-        "Krh_I_belegt": 584,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25058,7 +25058,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.1,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.12.2021"
@@ -25078,15 +25078,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 208,
         "BelegteBetten": null,
-        "Inzidenz": 737.813858256403,
+        "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 627.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1580,
-        "Krh_I_belegt": 593,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25096,7 +25096,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.29,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.12.2021"
@@ -25116,15 +25116,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 918,
         "BelegteBetten": null,
-        "Inzidenz": 737.095441646611,
+        "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 567,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 41,
-        "Inzidenz_RKI": 655.5,
+        "Hosp_Meldedatum": 42,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1644,
-        "Krh_I_belegt": 598,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25134,7 +25134,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.16,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.12.2021"
@@ -25156,9 +25156,9 @@
         "BelegteBetten": null,
         "Inzidenz": 669.743884478609,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 934,
+        "F\u00e4lle_Meldedatum": 935,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 605,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1633,
@@ -25172,7 +25172,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.23,
+        "H_Inzidenz": 12.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.12.2021"
@@ -25183,34 +25183,34 @@
         "Datum": "22.12.2021",
         "Fallzahl": 79472,
         "ObjectId": 656,
-        "Sterbefall": 1412,
-        "Genesungsfall": 69427,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 3974,
-        "Zuwachs_Fallzahl": 979,
-        "Zuwachs_Sterbefall": 15,
-        "Zuwachs_Krankenhauseinweisung": 48,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 834,
         "BelegteBetten": null,
         "Inzidenz": 660.224864398865,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 416,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 568.8,
-        "Fallzahl_aktiv": 8633,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1553,
         "Krh_I_belegt": 575,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 130,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.14,
+        "H_Inzidenz": 11.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.12.2021"
@@ -25221,34 +25221,34 @@
         "Datum": "23.12.2021",
         "Fallzahl": 79939,
         "ObjectId": 657,
-        "Sterbefall": 1420,
-        "Genesungsfall": 70519,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4018,
-        "Zuwachs_Fallzahl": 467,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 44,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1092,
         "BelegteBetten": null,
         "Inzidenz": 623.046804842128,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 397,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 577.5,
-        "Fallzahl_aktiv": 8000,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1426,
         "Krh_I_belegt": 551,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -633,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.93,
+        "H_Inzidenz": 10.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.12.2021"
@@ -25260,7 +25260,7 @@
         "Fallzahl": 80410,
         "ObjectId": 658,
         "Sterbefall": null,
-        "Genesungsfall": 71295,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": 510.973813714573,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 516.5,
@@ -25286,7 +25286,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.12,
+        "H_Inzidenz": 10.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.12.2021"
@@ -25298,7 +25298,7 @@
         "Fallzahl": 80512,
         "ObjectId": 659,
         "Sterbefall": null,
-        "Genesungsfall": 71793,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25308,9 +25308,9 @@
         "BelegteBetten": null,
         "Inzidenz": 440.389381802507,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 89,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 458.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1175,
@@ -25324,7 +25324,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.2,
+        "H_Inzidenz": 8.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.12.2021"
@@ -25336,7 +25336,7 @@
         "Fallzahl": 80554,
         "ObjectId": 660,
         "Sterbefall": null,
-        "Genesungsfall": 71957,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25346,9 +25346,9 @@
         "BelegteBetten": null,
         "Inzidenz": 430.870361722763,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 457.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1184,
@@ -25362,7 +25362,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
+        "H_Inzidenz": 7.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.12.2021"
@@ -25375,7 +25375,7 @@
         "ObjectId": 661,
         "Sterbefall": 1431,
         "Genesungsfall": 72778,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4038,
         "Zuwachs_Fallzahl": 724,
         "Zuwachs_Sterbefall": 11,
@@ -25384,13 +25384,13 @@
         "BelegteBetten": null,
         "Inzidenz": 474.693774920076,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 20,
-        "Zeitraum": "20.12.2021 - 26.12.2021",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 505,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 463.5,
         "Fallzahl_aktiv": 6454,
-        "Krh_N_belegt": 1184,
-        "Krh_I_belegt": 523,
+        "Krh_N_belegt": 1239,
+        "Krh_I_belegt": 521,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -108,
         "Krh_I": null,
@@ -25398,13 +25398,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 13,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.14,
-        "H_Zeitraum": "20.12.2021 - 26.12.2021",
-        "H_Datum": "26.12.2021",
+        "H_Inzidenz": 7.72,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.12.2021",
+        "Fallzahl": 81370,
+        "ObjectId": 662,
+        "Sterbefall": 1432,
+        "Genesungsfall": 73800,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4053,
+        "Zuwachs_Fallzahl": 707,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 1022,
+        "BelegteBetten": null,
+        "Inzidenz": 475.951003987212,
+        "Datum_neu": 1640649600000,
+        "F\u00e4lle_Meldedatum": 120,
+        "Zeitraum": "21.12.2021 - 27.12.2021",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 399.8,
+        "Fallzahl_aktiv": 6138,
+        "Krh_N_belegt": 1239,
+        "Krh_I_belegt": 521,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -316,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 13,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.38,
+        "H_Zeitraum": "21.12.2021 - 27.12.2021",
+        "H_Datum": "27.12.2021",
+        "Datum_Bett": "27.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
