### PR TITLE
New data set: 2021-12-29T113103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-28T110103Z.json
+pjson/2021-12-29T113103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-28T110103Z.json pjson/2021-12-29T113103Z.json```:
```
--- pjson/2021-12-28T110103Z.json	2021-12-28 11:01:03.553297200 +0000
+++ pjson/2021-12-29T113103Z.json	2021-12-29 11:31:03.642155186 +0000
@@ -10602,7 +10602,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606953600000,
-        "F\u00e4lle_Meldedatum": 301,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -10868,7 +10868,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 463,
+        "F\u00e4lle_Meldedatum": 462,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -10906,7 +10906,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607644800000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23066,7 +23066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23142,7 +23142,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 713,
+        "F\u00e4lle_Meldedatum": 714,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1095,
+        "F\u00e4lle_Meldedatum": 1097,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1383,
+        "F\u00e4lle_Meldedatum": 1384,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1090,
+        "F\u00e4lle_Meldedatum": 1091,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24218,7 +24218,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1330,
+        "F\u00e4lle_Meldedatum": 1333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1116,
+        "F\u00e4lle_Meldedatum": 1119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 894,
+        "F\u00e4lle_Meldedatum": 895,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1011,
+        "F\u00e4lle_Meldedatum": 1013,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 536,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 969,
+        "F\u00e4lle_Meldedatum": 977,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 864,
+        "F\u00e4lle_Meldedatum": 865,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 905,
+        "F\u00e4lle_Meldedatum": 903,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 474,
+        "F\u00e4lle_Meldedatum": 475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1047,
+        "F\u00e4lle_Meldedatum": 1049,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 676,
+        "F\u00e4lle_Meldedatum": 681,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 760,
+        "F\u00e4lle_Meldedatum": 761,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -24978,7 +24978,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25042,7 +25042,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 201,
+        "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25092,7 +25092,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 547,
         "Zeitraum": null,
         "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
@@ -25130,7 +25130,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25154,15 +25154,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1213,
         "BelegteBetten": null,
-        "Inzidenz": 669.743884478609,
+        "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 935,
+        "F\u00e4lle_Meldedatum": 936,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
-        "Inzidenz_RKI": 605,
+        "Hosp_Meldedatum": 33,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1633,
-        "Krh_I_belegt": 587,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25172,7 +25172,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.77,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.12.2021"
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": 660.224864398865,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 568.8,
@@ -25232,9 +25232,9 @@
         "BelegteBetten": null,
         "Inzidenz": 623.046804842128,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 397,
+        "F\u00e4lle_Meldedatum": 398,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 577.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1426,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": 510.973813714573,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 516.5,
@@ -25308,7 +25308,7 @@
         "BelegteBetten": null,
         "Inzidenz": 440.389381802507,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 458.1,
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": 430.870361722763,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 457.5,
@@ -25373,26 +25373,26 @@
         "Datum": "27.12.2021",
         "Fallzahl": 80663,
         "ObjectId": 661,
-        "Sterbefall": 1431,
-        "Genesungsfall": 72778,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4038,
-        "Zuwachs_Fallzahl": 724,
-        "Zuwachs_Sterbefall": 11,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 821,
         "BelegteBetten": null,
         "Inzidenz": 474.693774920076,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 505,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 463.5,
-        "Fallzahl_aktiv": 6454,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1239,
         "Krh_I_belegt": 521,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -108,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -25411,38 +25411,76 @@
         "Datum": "28.12.2021",
         "Fallzahl": 81370,
         "ObjectId": 662,
-        "Sterbefall": 1432,
-        "Genesungsfall": 73800,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4053,
-        "Zuwachs_Fallzahl": 707,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1022,
         "BelegteBetten": null,
         "Inzidenz": 475.951003987212,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 120,
-        "Zeitraum": "21.12.2021 - 27.12.2021",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 467,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 399.8,
-        "Fallzahl_aktiv": 6138,
-        "Krh_N_belegt": 1239,
-        "Krh_I_belegt": 521,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1262,
+        "Krh_I_belegt": 517,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -316,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 13,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 6.38,
-        "H_Zeitraum": "21.12.2021 - 27.12.2021",
-        "H_Datum": "27.12.2021",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.12.2021",
+        "Fallzahl": 81838,
+        "ObjectId": 663,
+        "Sterbefall": 1437,
+        "Genesungsfall": 74479,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4066,
+        "Zuwachs_Fallzahl": 468,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 679,
+        "BelegteBetten": null,
+        "Inzidenz": 399.978447501706,
+        "Datum_neu": 1640736000000,
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": "22.12.2021 - 28.12.2021",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 326.7,
+        "Fallzahl_aktiv": 5922,
+        "Krh_N_belegt": 1262,
+        "Krh_I_belegt": 517,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -216,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 15,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.38,
+        "H_Zeitraum": "21.12.2021 - 27.12.2021",
+        "H_Datum": "28.12.2021",
+        "Datum_Bett": "28.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
