### PR TITLE
New data set: 2021-12-30T110503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2021-12-29T113103Z.json
+pjson/2021-12-30T110503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2021-12-29T113103Z.json pjson/2021-12-30T110503Z.json```:
```
--- pjson/2021-12-29T113103Z.json	2021-12-29 11:31:03.642155186 +0000
+++ pjson/2021-12-30T110503Z.json	2021-12-30 11:05:04.103201654 +0000
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 561,
+        "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1144,
+        "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1568,
+        "F\u00e4lle_Meldedatum": 1569,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 907,
+        "F\u00e4lle_Meldedatum": 908,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1384,
+        "F\u00e4lle_Meldedatum": 1385,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1667,
+        "F\u00e4lle_Meldedatum": 1668,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1091,
+        "F\u00e4lle_Meldedatum": 1092,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1198,
+        "F\u00e4lle_Meldedatum": 1199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 878,
+        "F\u00e4lle_Meldedatum": 879,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1119,
+        "F\u00e4lle_Meldedatum": 1120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 895,
+        "F\u00e4lle_Meldedatum": 896,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1013,
+        "F\u00e4lle_Meldedatum": 1014,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 538,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24598,7 +24598,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 9,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1252,
+        "F\u00e4lle_Meldedatum": 1253,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -24636,7 +24636,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24674,7 +24674,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24712,7 +24712,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 781,
+        "F\u00e4lle_Meldedatum": 783,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24750,7 +24750,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 475,
+        "F\u00e4lle_Meldedatum": 477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24788,7 +24788,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24816,7 +24816,7 @@
         "Datum_neu": 1639267200000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 855,
+        "F\u00e4lle_Meldedatum": 857,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1049,
+        "F\u00e4lle_Meldedatum": 1053,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 681,
+        "F\u00e4lle_Meldedatum": 682,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24940,7 +24940,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24978,7 +24978,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 536,
+        "F\u00e4lle_Meldedatum": 534,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25016,7 +25016,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25042,7 +25042,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -25092,7 +25092,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25118,9 +25118,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 547,
+        "F\u00e4lle_Meldedatum": 549,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 42,
+        "Hosp_Meldedatum": 43,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25168,7 +25168,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": 660.224864398865,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 568.8,
@@ -25210,7 +25210,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.93,
+        "H_Inzidenz": 13.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.12.2021"
@@ -25232,9 +25232,9 @@
         "BelegteBetten": null,
         "Inzidenz": 623.046804842128,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 398,
+        "F\u00e4lle_Meldedatum": 400,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 577.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1426,
@@ -25244,11 +25244,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.85,
+        "H_Inzidenz": 12.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.12.2021"
@@ -25286,7 +25286,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.18,
+        "H_Inzidenz": 11.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.12.2021"
@@ -25308,7 +25308,7 @@
         "BelegteBetten": null,
         "Inzidenz": 440.389381802507,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 458.1,
@@ -25324,7 +25324,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.36,
+        "H_Inzidenz": 9.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.12.2021"
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": 430.870361722763,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 457.5,
@@ -25362,7 +25362,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.99,
+        "H_Inzidenz": 9.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.12.2021"
@@ -25384,9 +25384,9 @@
         "BelegteBetten": null,
         "Inzidenz": 474.693774920076,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 463.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1239,
@@ -25400,7 +25400,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
+        "H_Inzidenz": 9.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.12.2021"
@@ -25422,9 +25422,9 @@
         "BelegteBetten": null,
         "Inzidenz": 475.951003987212,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 467,
+        "F\u00e4lle_Meldedatum": 479,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 399.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1262,
@@ -25438,7 +25438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": 8.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.12.2021"
@@ -25449,38 +25449,76 @@
         "Datum": "29.12.2021",
         "Fallzahl": 81838,
         "ObjectId": 663,
-        "Sterbefall": 1437,
-        "Genesungsfall": 74479,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4066,
-        "Zuwachs_Fallzahl": 468,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 679,
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 39,
-        "Zeitraum": "22.12.2021 - 28.12.2021",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 274,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 326.7,
-        "Fallzahl_aktiv": 5922,
-        "Krh_N_belegt": 1262,
-        "Krh_I_belegt": 517,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1219,
+        "Krh_I_belegt": 497,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -216,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 15,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
-        "H_Zeitraum": "21.12.2021 - 27.12.2021",
-        "H_Datum": "28.12.2021",
+        "H_Inzidenz": 5.42,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.12.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.12.2021",
+        "Fallzahl": 82168,
+        "ObjectId": 664,
+        "Sterbefall": 1452,
+        "Genesungsfall": 75255,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4078,
+        "Zuwachs_Fallzahl": 330,
+        "Zuwachs_Sterbefall": 15,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 776,
+        "BelegteBetten": null,
+        "Inzidenz": 377.707532598154,
+        "Datum_neu": 1640822400000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "23.12.2021 - 29.12.2021",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 345,
+        "Fallzahl_aktiv": 5461,
+        "Krh_N_belegt": 1219,
+        "Krh_I_belegt": 497,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -461,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 17,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.76,
+        "H_Zeitraum": "23.12.2021 - 29.12.2021",
+        "H_Datum": "29.12.2021",
+        "Datum_Bett": "29.12.2021"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
