### PR TITLE
New data set: 2022-01-04T110803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-03T113403Z.json
+pjson/2022-01-04T110803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-03T113403Z.json pjson/2022-01-04T110803Z.json```:
```
--- pjson/2022-01-03T113403Z.json	2022-01-03 11:34:03.941776547 +0000
+++ pjson/2022-01-04T110803Z.json	2022-01-04 11:08:04.100260250 +0000
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 543,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1101,
+        "F\u00e4lle_Meldedatum": 1102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1097,
+        "F\u00e4lle_Meldedatum": 1098,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1093,
+        "F\u00e4lle_Meldedatum": 1091,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1477,
+        "F\u00e4lle_Meldedatum": 1478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 879,
+        "F\u00e4lle_Meldedatum": 880,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1333,
+        "F\u00e4lle_Meldedatum": 1335,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1123,
+        "F\u00e4lle_Meldedatum": 1122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24598,7 +24598,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 11,
+        "SterbeF_Sterbedatum": 10,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1255,
+        "F\u00e4lle_Meldedatum": 1256,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 477,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 858,
+        "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1055,
+        "F\u00e4lle_Meldedatum": 1057,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 765,
+        "F\u00e4lle_Meldedatum": 767,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 535,
+        "F\u00e4lle_Meldedatum": 533,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25042,9 +25042,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 552,
+        "F\u00e4lle_Meldedatum": 548,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 938,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25168,7 +25168,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25194,9 +25194,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 431,
+        "F\u00e4lle_Meldedatum": 432,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25234,7 +25234,7 @@
         "Datum_neu": 1640217600000,
         "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25308,7 +25308,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -25382,25 +25382,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 821,
         "BelegteBetten": null,
-        "Inzidenz": 474.693774920076,
+        "Inzidenz": null,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
-        "Inzidenz_RKI": 463.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1239,
-        "Krh_I_belegt": 521,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.33,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.12.2021"
@@ -25422,9 +25422,9 @@
         "BelegteBetten": null,
         "Inzidenz": 475.951003987212,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 399.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1262,
@@ -25438,7 +25438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.49,
+        "H_Inzidenz": 9.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.12.2021"
@@ -25462,7 +25462,7 @@
         "Datum_neu": 1640736000000,
         "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 326.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1219,
@@ -25476,7 +25476,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
+        "H_Inzidenz": 7.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.12.2021"
@@ -25487,34 +25487,34 @@
         "Datum": "30.12.2021",
         "Fallzahl": 82168,
         "ObjectId": 664,
-        "Sterbefall": 1452,
-        "Genesungsfall": 75255,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4078,
-        "Zuwachs_Fallzahl": 330,
-        "Zuwachs_Sterbefall": 15,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 776,
         "BelegteBetten": null,
         "Inzidenz": 377.707532598154,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 399,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 345,
-        "Fallzahl_aktiv": 5461,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1176,
         "Krh_I_belegt": 484,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -461,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.04,
+        "H_Inzidenz": 6.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.12.2021"
@@ -25526,7 +25526,7 @@
         "Fallzahl": 82679,
         "ObjectId": 665,
         "Sterbefall": null,
-        "Genesungsfall": 75942,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25536,9 +25536,9 @@
         "BelegteBetten": null,
         "Inzidenz": 313.948058479112,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 324.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1082,
@@ -25548,11 +25548,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.18,
+        "H_Inzidenz": 5.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.12.2021"
@@ -25564,7 +25564,7 @@
         "Fallzahl": 82811,
         "ObjectId": 666,
         "Sterbefall": null,
-        "Genesungsfall": 76172,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25574,9 +25574,9 @@
         "BelegteBetten": null,
         "Inzidenz": 281.798915190919,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 333,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1030,
@@ -25586,11 +25586,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 5.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.12.2021"
@@ -25602,7 +25602,7 @@
         "Fallzahl": 82822,
         "ObjectId": 667,
         "Sterbefall": null,
-        "Genesungsfall": 76356,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -25612,9 +25612,9 @@
         "BelegteBetten": null,
         "Inzidenz": 262.401666726535,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 348.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1042,
@@ -25624,11 +25624,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.61,
+        "H_Inzidenz": 5.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.01.2022"
@@ -25641,7 +25641,7 @@
         "ObjectId": 668,
         "Sterbefall": 1470,
         "Genesungsfall": 76868,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4122,
         "Zuwachs_Fallzahl": 732,
         "Zuwachs_Sterbefall": 18,
@@ -25650,13 +25650,13 @@
         "BelegteBetten": null,
         "Inzidenz": 358.130679981321,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 19,
-        "Zeitraum": "27.12.2021 - 02.01.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 590,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 354.4,
         "Fallzahl_aktiv": 4562,
-        "Krh_N_belegt": 1042,
-        "Krh_I_belegt": 442,
+        "Krh_N_belegt": 1091,
+        "Krh_I_belegt": 443,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 202,
         "Krh_I": null,
@@ -25664,13 +25664,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 26,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.94,
-        "H_Zeitraum": "27.12.2021 - 02.01.2022",
-        "H_Datum": "02.01.2022",
+        "H_Inzidenz": 4.68,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.01.2022",
+        "Fallzahl": 83653,
+        "ObjectId": 669,
+        "Sterbefall": 1479,
+        "Genesungsfall": 77773,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4148,
+        "Zuwachs_Fallzahl": 753,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 26,
+        "Zuwachs_Genesung": 905,
+        "BelegteBetten": null,
+        "Inzidenz": 379.683178275082,
+        "Datum_neu": 1641254400000,
+        "F\u00e4lle_Meldedatum": 96,
+        "Zeitraum": "28.12.2021 - 03.01.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 263.6,
+        "Fallzahl_aktiv": 4401,
+        "Krh_N_belegt": 1091,
+        "Krh_I_belegt": 443,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -161,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 30,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.2,
+        "H_Zeitraum": "28.12.2021 - 03.01.2022",
+        "H_Datum": "03.01.2022",
+        "Datum_Bett": "03.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
