### PR TITLE
New data set: 2022-01-05T110905Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-04T110803Z.json
+pjson/2022-01-05T110905Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-04T110803Z.json pjson/2022-01-05T110905Z.json```:
```
--- pjson/2022-01-04T110803Z.json	2022-01-04 11:08:04.100260250 +0000
+++ pjson/2022-01-05T110905Z.json	2022-01-05 11:09:05.767704298 +0000
@@ -10642,7 +10642,7 @@
         "Datum_neu": 1607040000000,
         "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11820,7 +11820,7 @@
         "Datum_neu": 1609718400000,
         "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -17796,7 +17796,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -20786,7 +20786,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630108800000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22660,7 +22660,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22698,7 +22698,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22736,7 +22736,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22774,7 +22774,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22850,7 +22850,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 543,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 714,
+        "F\u00e4lle_Meldedatum": 715,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 976,
+        "F\u00e4lle_Meldedatum": 978,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23686,7 +23686,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23762,7 +23762,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1145,
+        "F\u00e4lle_Meldedatum": 1146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1098,
+        "F\u00e4lle_Meldedatum": 1101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1485,
+        "F\u00e4lle_Meldedatum": 1486,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 908,
+        "F\u00e4lle_Meldedatum": 907,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1669,
+        "F\u00e4lle_Meldedatum": 1670,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24104,7 +24104,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1478,
+        "F\u00e4lle_Meldedatum": 1479,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24180,7 +24180,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1335,
+        "F\u00e4lle_Meldedatum": 1336,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 897,
+        "F\u00e4lle_Meldedatum": 898,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 200,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 977,
+        "F\u00e4lle_Meldedatum": 979,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 903,
+        "F\u00e4lle_Meldedatum": 904,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 478,
+        "F\u00e4lle_Meldedatum": 479,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 767,
+        "F\u00e4lle_Meldedatum": 766,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 533,
+        "F\u00e4lle_Meldedatum": 534,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 548,
+        "F\u00e4lle_Meldedatum": 547,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 938,
+        "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25232,7 +25232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 403,
+        "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25420,15 +25420,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1022,
         "BelegteBetten": null,
-        "Inzidenz": 475.951003987212,
+        "Inzidenz": null,
         "Datum_neu": 1640649600000,
         "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 399.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1262,
-        "Krh_I_belegt": 517,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25438,7 +25438,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.91,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.12.2021"
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 326.7,
@@ -25476,7 +25476,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.94,
+        "H_Inzidenz": 8.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.12.2021"
@@ -25498,7 +25498,7 @@
         "BelegteBetten": null,
         "Inzidenz": 377.707532598154,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 399,
+        "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 345,
@@ -25514,7 +25514,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
+        "H_Inzidenz": 7.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.12.2021"
@@ -25536,7 +25536,7 @@
         "BelegteBetten": null,
         "Inzidenz": 313.948058479112,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 324.7,
@@ -25552,7 +25552,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.84,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.12.2021"
@@ -25574,7 +25574,7 @@
         "BelegteBetten": null,
         "Inzidenz": 281.798915190919,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 333,
@@ -25590,7 +25590,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.47,
+        "H_Inzidenz": 6.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.12.2021"
@@ -25612,7 +25612,7 @@
         "BelegteBetten": null,
         "Inzidenz": 262.401666726535,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 348.2,
@@ -25628,7 +25628,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.25,
+        "H_Inzidenz": 6.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.01.2022"
@@ -25639,34 +25639,34 @@
         "Datum": "03.01.2022",
         "Fallzahl": 82900,
         "ObjectId": 668,
-        "Sterbefall": 1470,
-        "Genesungsfall": 76868,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4122,
-        "Zuwachs_Fallzahl": 732,
-        "Zuwachs_Sterbefall": 18,
-        "Zuwachs_Krankenhauseinweisung": 44,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 512,
         "BelegteBetten": null,
         "Inzidenz": 358.130679981321,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 590,
+        "F\u00e4lle_Meldedatum": 643,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 354.4,
-        "Fallzahl_aktiv": 4562,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1091,
         "Krh_I_belegt": 443,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 202,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": 5.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2022"
@@ -25677,38 +25677,76 @@
         "Datum": "04.01.2022",
         "Fallzahl": 83653,
         "ObjectId": 669,
-        "Sterbefall": 1479,
-        "Genesungsfall": 77773,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4148,
-        "Zuwachs_Fallzahl": 753,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 905,
         "BelegteBetten": null,
         "Inzidenz": 379.683178275082,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 96,
-        "Zeitraum": "28.12.2021 - 03.01.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 502,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 263.6,
-        "Fallzahl_aktiv": 4401,
-        "Krh_N_belegt": 1091,
-        "Krh_I_belegt": 443,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1137,
+        "Krh_I_belegt": 446,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -161,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 30,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.2,
-        "H_Zeitraum": "28.12.2021 - 03.01.2022",
-        "H_Datum": "03.01.2022",
+        "H_Inzidenz": 4.93,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.01.2022",
+        "Fallzahl": 84215,
+        "ObjectId": 670,
+        "Sterbefall": 1485,
+        "Genesungsfall": 78215,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4160,
+        "Zuwachs_Fallzahl": 562,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 442,
+        "BelegteBetten": null,
+        "Inzidenz": 395.308739538058,
+        "Datum_neu": 1641340800000,
+        "F\u00e4lle_Meldedatum": 72,
+        "Zeitraum": "29.12.2021 - 04.01.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 319.7,
+        "Fallzahl_aktiv": 4515,
+        "Krh_N_belegt": 1137,
+        "Krh_I_belegt": 446,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 114,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 38,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.6,
+        "H_Zeitraum": "29.12.2021 - 04.01.2022",
+        "H_Datum": "04.01.2022",
+        "Datum_Bett": "04.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
