### PR TITLE
New data set: 2022-01-07T111503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-06T112406Z.json
+pjson/2022-01-07T111503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-06T112406Z.json pjson/2022-01-07T111503Z.json```:
```
--- pjson/2022-01-06T112406Z.json	2022-01-06 11:24:06.543152973 +0000
+++ pjson/2022-01-07T111503Z.json	2022-01-07 11:15:03.984140281 +0000
@@ -12236,7 +12236,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -19684,7 +19684,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627603200000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -19836,7 +19836,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627948800000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -20178,7 +20178,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1628726400000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -20406,7 +20406,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629244800000,
-        "F\u00e4lle_Meldedatum": 33,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -20748,7 +20748,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630022400000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21128,7 +21128,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21204,7 +21204,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631059200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21432,7 +21432,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21926,7 +21926,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632700800000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -22002,7 +22002,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22192,7 +22192,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22306,7 +22306,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22650,7 +22650,7 @@
         "Datum_neu": 1634342400000,
         "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22800,7 +22800,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 281,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 715,
+        "F\u00e4lle_Meldedatum": 714,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -23600,7 +23600,7 @@
         "Datum_neu": 1636502400000,
         "F\u00e4lle_Meldedatum": 978,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1104,
+        "F\u00e4lle_Meldedatum": 1101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1487,
+        "F\u00e4lle_Meldedatum": 1488,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1670,
+        "F\u00e4lle_Meldedatum": 1669,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1479,
+        "F\u00e4lle_Meldedatum": 1478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 770,
+        "F\u00e4lle_Meldedatum": 771,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 880,
+        "F\u00e4lle_Meldedatum": 881,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1123,
+        "F\u00e4lle_Meldedatum": 1122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 979,
+        "F\u00e4lle_Meldedatum": 980,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 866,
+        "F\u00e4lle_Meldedatum": 867,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 479,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1059,
+        "F\u00e4lle_Meldedatum": 1060,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 535,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 545,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
         "Hosp_Meldedatum": 45,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 936,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25232,7 +25232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 402,
+        "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25320,7 +25320,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -25434,7 +25434,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25472,7 +25472,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25496,15 +25496,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 776,
         "BelegteBetten": null,
-        "Inzidenz": 377.707532598154,
+        "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 404,
+        "F\u00e4lle_Meldedatum": 406,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 345,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1176,
-        "Krh_I_belegt": 484,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25514,7 +25514,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.12.2021"
@@ -25536,7 +25536,7 @@
         "BelegteBetten": null,
         "Inzidenz": 313.948058479112,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 324.7,
@@ -25552,7 +25552,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.22,
+        "H_Inzidenz": 7.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.12.2021"
@@ -25590,7 +25590,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.03,
+        "H_Inzidenz": 7.62,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.12.2021"
@@ -25628,7 +25628,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7,
+        "H_Inzidenz": 7.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.01.2022"
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": 358.130679981321,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 650,
+        "F\u00e4lle_Meldedatum": 651,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 354.4,
@@ -25666,7 +25666,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
+        "H_Inzidenz": 7.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2022"
@@ -25688,9 +25688,9 @@
         "BelegteBetten": null,
         "Inzidenz": 379.683178275082,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 525,
+        "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 263.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1137,
@@ -25700,11 +25700,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.72,
+        "H_Inzidenz": 6.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2022"
@@ -25726,9 +25726,9 @@
         "BelegteBetten": null,
         "Inzidenz": 395.308739538058,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 317,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 319.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1028,
@@ -25738,11 +25738,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 5.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2022"
@@ -25753,38 +25753,76 @@
         "Datum": "06.01.2022",
         "Fallzahl": 84571,
         "ObjectId": 671,
-        "Sterbefall": 1491,
-        "Genesungsfall": 78623,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4180,
-        "Zuwachs_Fallzahl": 356,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 408,
         "BelegteBetten": null,
         "Inzidenz": 398.541614282122,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 82,
-        "Zeitraum": "30.12.2021 - 05.01.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 294,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 352.4,
-        "Fallzahl_aktiv": 4457,
-        "Krh_N_belegt": 1028,
-        "Krh_I_belegt": 414,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 997,
+        "Krh_I_belegt": 397,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -58,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 47,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
-        "H_Zeitraum": "30.12.2021 - 05.01.2022",
-        "H_Datum": "05.01.2022",
+        "H_Inzidenz": 5.13,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.01.2022",
+        "Fallzahl": 84855,
+        "ObjectId": 672,
+        "Sterbefall": 1498,
+        "Genesungsfall": 78833,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4187,
+        "Zuwachs_Fallzahl": 284,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 210,
+        "BelegteBetten": null,
+        "Inzidenz": 380.940407342218,
+        "Datum_neu": 1641513600000,
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": "31.12.2021 - 06.01.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 342.3,
+        "Fallzahl_aktiv": 4524,
+        "Krh_N_belegt": 928,
+        "Krh_I_belegt": 383,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 67,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 67,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.19,
+        "H_Zeitraum": "31.12.2021 - 06.01.2022",
+        "H_Datum": "07.01.2022",
+        "Datum_Bett": "06.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
