### PR TITLE
New data set: 2022-01-10T111804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-07T111503Z.json
+pjson/2022-01-10T111804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-07T111503Z.json pjson/2022-01-10T111804Z.json```:
```
--- pjson/2022-01-07T111503Z.json	2022-01-07 11:15:03.984140281 +0000
+++ pjson/2022-01-10T111804Z.json	2022-01-10 11:18:04.386176087 +0000
@@ -11362,7 +11362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 446,
+        "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -11932,9 +11932,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 265,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12236,7 +12236,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -12426,7 +12426,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -15314,7 +15314,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -19684,7 +19684,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627603200000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -19836,7 +19836,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627948800000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -20178,7 +20178,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1628726400000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -20406,7 +20406,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629244800000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -20748,7 +20748,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630022400000,
-        "F\u00e4lle_Meldedatum": 28,
+        "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21128,7 +21128,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1630886400000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21204,7 +21204,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631059200000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21432,7 +21432,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21926,7 +21926,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632700800000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -22002,7 +22002,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1632873600000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22192,7 +22192,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633305600000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22306,7 +22306,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22458,7 +22458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633910400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22800,7 +22800,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 281,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 692,
+        "F\u00e4lle_Meldedatum": 691,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23332,7 +23332,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635897600000,
-        "F\u00e4lle_Meldedatum": 563,
+        "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23524,7 +23524,7 @@
         "Datum_neu": 1636329600000,
         "F\u00e4lle_Meldedatum": 714,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 978,
+        "F\u00e4lle_Meldedatum": 977,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23610,7 +23610,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1569,
+        "F\u00e4lle_Meldedatum": 1568,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1669,
+        "F\u00e4lle_Meldedatum": 1668,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1478,
+        "F\u00e4lle_Meldedatum": 1477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1198,
+        "F\u00e4lle_Meldedatum": 1197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1338,
+        "F\u00e4lle_Meldedatum": 1337,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1122,
+        "F\u00e4lle_Meldedatum": 1119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1014,
+        "F\u00e4lle_Meldedatum": 1016,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24586,9 +24586,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 980,
+        "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 44,
+        "Hosp_Meldedatum": 43,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24626,7 +24626,7 @@
         "Datum_neu": 1638835200000,
         "F\u00e4lle_Meldedatum": 1256,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24662,9 +24662,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 867,
+        "F\u00e4lle_Meldedatum": 868,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 38,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 903,
+        "F\u00e4lle_Meldedatum": 902,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 784,
+        "F\u00e4lle_Meldedatum": 786,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 859,
+        "F\u00e4lle_Meldedatum": 858,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1060,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -24902,7 +24902,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 8,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 765,
+        "F\u00e4lle_Meldedatum": 764,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25004,9 +25004,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 536,
+        "F\u00e4lle_Meldedatum": 535,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25054,7 +25054,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25092,7 +25092,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25120,7 +25120,7 @@
         "Datum_neu": 1639958400000,
         "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 45,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 936,
+        "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 432,
+        "F\u00e4lle_Meldedatum": 431,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25206,7 +25206,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25282,7 +25282,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -25396,7 +25396,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25424,7 +25424,7 @@
         "Datum_neu": 1640649600000,
         "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25434,7 +25434,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25472,7 +25472,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25498,7 +25498,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 406,
+        "F\u00e4lle_Meldedatum": 408,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25534,15 +25534,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 687,
         "BelegteBetten": null,
-        "Inzidenz": 313.948058479112,
+        "Inzidenz": null,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 324.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1082,
-        "Krh_I_belegt": 456,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25552,7 +25552,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.12.2021"
@@ -25572,15 +25572,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 230,
         "BelegteBetten": null,
-        "Inzidenz": 281.798915190919,
+        "Inzidenz": null,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 333,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1030,
-        "Krh_I_belegt": 443,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25590,7 +25590,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.62,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.12.2021"
@@ -25610,15 +25610,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 184,
         "BelegteBetten": null,
-        "Inzidenz": 262.401666726535,
+        "Inzidenz": null,
         "Datum_neu": 1641081600000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 348.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1042,
-        "Krh_I_belegt": 442,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25628,7 +25628,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.01.2022"
@@ -25650,9 +25650,9 @@
         "BelegteBetten": null,
         "Inzidenz": 358.130679981321,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 651,
+        "F\u00e4lle_Meldedatum": 654,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": 354.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1091,
@@ -25666,7 +25666,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.25,
+        "H_Inzidenz": 7.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2022"
@@ -25688,9 +25688,9 @@
         "BelegteBetten": null,
         "Inzidenz": 379.683178275082,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 529,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 263.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1137,
@@ -25704,7 +25704,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
+        "H_Inzidenz": 7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2022"
@@ -25726,9 +25726,9 @@
         "BelegteBetten": null,
         "Inzidenz": 395.308739538058,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 317,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 319.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1028,
@@ -25738,11 +25738,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": 6.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2022"
@@ -25764,9 +25764,9 @@
         "BelegteBetten": null,
         "Inzidenz": 398.541614282122,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 294,
+        "F\u00e4lle_Meldedatum": 317,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 352.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 997,
@@ -25776,11 +25776,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.13,
+        "H_Inzidenz": 6.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2022"
@@ -25791,38 +25791,152 @@
         "Datum": "07.01.2022",
         "Fallzahl": 84855,
         "ObjectId": 672,
-        "Sterbefall": 1498,
-        "Genesungsfall": 78833,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4187,
-        "Zuwachs_Fallzahl": 284,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 210,
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 39,
-        "Zeitraum": "31.12.2021 - 06.01.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 231,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 342.3,
-        "Fallzahl_aktiv": 4524,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 928,
         "Krh_I_belegt": 383,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 67,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 67,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.19,
-        "H_Zeitraum": "31.12.2021 - 06.01.2022",
-        "H_Datum": "07.01.2022",
+        "H_Inzidenz": 5.57,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.01.2022",
+        "Fallzahl": 85188,
+        "ObjectId": 673,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 190,
+        "BelegteBetten": null,
+        "Inzidenz": 365.853658536585,
+        "Datum_neu": 1641600000000,
+        "F\u00e4lle_Meldedatum": 124,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 367.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 866,
+        "Krh_I_belegt": 376,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.05,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "07.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.01.2022",
+        "Fallzahl": 85222,
+        "ObjectId": 674,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 135,
+        "BelegteBetten": null,
+        "Inzidenz": 344.839972700169,
+        "Datum_neu": 1641686400000,
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 382.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 846,
+        "Krh_I_belegt": 371,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "08.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.01.2022",
+        "Fallzahl": 85264,
+        "ObjectId": 675,
+        "Sterbefall": 1511,
+        "Genesungsfall": 79686,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4217,
+        "Zuwachs_Fallzahl": 409,
+        "Zuwachs_Sterbefall": 13,
+        "Zuwachs_Krankenhauseinweisung": 30,
+        "Zuwachs_Genesung": 528,
+        "BelegteBetten": null,
+        "Inzidenz": 399.978447501706,
+        "Datum_neu": 1641772800000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "03.01.2022 - 09.01.2022",
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": 394.1,
+        "Fallzahl_aktiv": 4067,
+        "Krh_N_belegt": 846,
+        "Krh_I_belegt": 371,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -132,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 97,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.12,
+        "H_Zeitraum": "03.01.2022 - 09.01.2022",
+        "H_Datum": "09.01.2022",
+        "Datum_Bett": "09.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
