### PR TITLE
New data set: 2022-01-11T111903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-10T111804Z.json
+pjson/2022-01-11T111903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-10T111804Z.json pjson/2022-01-11T111903Z.json```:
```
--- pjson/2022-01-10T111804Z.json	2022-01-10 11:18:04.386176087 +0000
+++ pjson/2022-01-11T111903Z.json	2022-01-11 11:19:03.949578371 +0000
@@ -8246,7 +8246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601596800000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -8398,7 +8398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1601942400000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -9272,7 +9272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603929600000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -9348,7 +9348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604102400000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -9728,7 +9728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1604966400000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -9994,7 +9994,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605571200000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10184,7 +10184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606003200000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 30,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -10374,7 +10374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606435200000,
-        "F\u00e4lle_Meldedatum": 232,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -10868,7 +10868,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607558400000,
-        "F\u00e4lle_Meldedatum": 462,
+        "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -11020,7 +11020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 428,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -11096,7 +11096,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 361,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -11134,7 +11134,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 514,
+        "F\u00e4lle_Meldedatum": 513,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -11324,7 +11324,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 482,
+        "F\u00e4lle_Meldedatum": 477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -11362,7 +11362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 445,
+        "F\u00e4lle_Meldedatum": 446,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -11590,7 +11590,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609200000000,
-        "F\u00e4lle_Meldedatum": 575,
+        "F\u00e4lle_Meldedatum": 576,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -11628,7 +11628,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609286400000,
-        "F\u00e4lle_Meldedatum": 452,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -11666,7 +11666,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -11818,7 +11818,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609718400000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -11894,7 +11894,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609891200000,
-        "F\u00e4lle_Meldedatum": 346,
+        "F\u00e4lle_Meldedatum": 343,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -11932,7 +11932,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -12008,7 +12008,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -12160,7 +12160,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -12388,7 +12388,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611014400000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -12426,7 +12426,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611100800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -12502,7 +12502,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611273600000,
-        "F\u00e4lle_Meldedatum": 115,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -12692,7 +12692,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611705600000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -13414,7 +13414,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13680,7 +13680,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613952000000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -15010,7 +15010,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -15314,7 +15314,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 153,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -15352,7 +15352,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617753600000,
-        "F\u00e4lle_Meldedatum": 242,
+        "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -16188,7 +16188,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619654400000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -16264,7 +16264,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619827200000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -16530,7 +16530,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620432000000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21242,7 +21242,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631145600000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22914,7 +22914,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634947200000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -22990,7 +22990,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23066,7 +23066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23180,7 +23180,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 290,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23370,7 +23370,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635984000000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 685,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 543,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1240,
+        "F\u00e4lle_Meldedatum": 1233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 977,
+        "F\u00e4lle_Meldedatum": 973,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1039,
+        "F\u00e4lle_Meldedatum": 1038,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 497,
+        "F\u00e4lle_Meldedatum": 494,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1146,
+        "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1568,
+        "F\u00e4lle_Meldedatum": 1567,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 940,
+        "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1101,
+        "F\u00e4lle_Meldedatum": 1100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1488,
+        "F\u00e4lle_Meldedatum": 1484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1668,
+        "F\u00e4lle_Meldedatum": 1663,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1091,
+        "F\u00e4lle_Meldedatum": 1089,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1477,
+        "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1197,
+        "F\u00e4lle_Meldedatum": 1194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1337,
+        "F\u00e4lle_Meldedatum": 1331,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1119,
+        "F\u00e4lle_Meldedatum": 1118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 898,
+        "F\u00e4lle_Meldedatum": 896,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1016,
+        "F\u00e4lle_Meldedatum": 1013,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 538,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1256,
+        "F\u00e4lle_Meldedatum": 1252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 868,
+        "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 902,
+        "F\u00e4lle_Meldedatum": 890,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1059,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 764,
+        "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25158,7 +25158,7 @@
         "Datum_neu": 1640044800000,
         "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 431,
+        "F\u00e4lle_Meldedatum": 427,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25232,7 +25232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 403,
+        "F\u00e4lle_Meldedatum": 401,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25308,7 +25308,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25574,7 +25574,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -25648,15 +25648,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 512,
         "BelegteBetten": null,
-        "Inzidenz": 358.130679981321,
+        "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 654,
+        "F\u00e4lle_Meldedatum": 655,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
-        "Inzidenz_RKI": 354.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1091,
-        "Krh_I_belegt": 443,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25666,7 +25666,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2022"
@@ -25688,9 +25688,9 @@
         "BelegteBetten": null,
         "Inzidenz": 379.683178275082,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 526,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 263.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1137,
@@ -25704,7 +25704,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7,
+        "H_Inzidenz": 7.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2022"
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": 395.308739538058,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 319.7,
@@ -25742,7 +25742,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.51,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2022"
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": 398.541614282122,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 317,
+        "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 352.4,
@@ -25780,7 +25780,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.09,
+        "H_Inzidenz": 6.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2022"
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 342.3,
@@ -25818,7 +25818,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.57,
+        "H_Inzidenz": 6.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.01.2022"
@@ -25840,9 +25840,9 @@
         "BelegteBetten": null,
         "Inzidenz": 365.853658536585,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 367.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 866,
@@ -25856,7 +25856,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.05,
+        "H_Inzidenz": 5.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.01.2022"
@@ -25878,9 +25878,9 @@
         "BelegteBetten": null,
         "Inzidenz": 344.839972700169,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 382.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 846,
@@ -25890,11 +25890,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": 5.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.01.2022"
@@ -25905,38 +25905,76 @@
         "Datum": "10.01.2022",
         "Fallzahl": 85264,
         "ObjectId": 675,
-        "Sterbefall": 1511,
-        "Genesungsfall": 79686,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4217,
-        "Zuwachs_Fallzahl": 409,
-        "Zuwachs_Sterbefall": 13,
-        "Zuwachs_Krankenhauseinweisung": 30,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 528,
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "03.01.2022 - 09.01.2022",
-        "Hosp_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 371,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 394.1,
-        "Fallzahl_aktiv": 4067,
-        "Krh_N_belegt": 846,
-        "Krh_I_belegt": 371,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 860,
+        "Krh_I_belegt": 370,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -132,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 97,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.12,
-        "H_Zeitraum": "03.01.2022 - 09.01.2022",
-        "H_Datum": "09.01.2022",
+        "H_Inzidenz": 5,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.01.2022",
+        "Fallzahl": 85625,
+        "ObjectId": 676,
+        "Sterbefall": 1514,
+        "Genesungsfall": 80153,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4233,
+        "Zuwachs_Fallzahl": 361,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 467,
+        "BelegteBetten": null,
+        "Inzidenz": 354.538596932361,
+        "Datum_neu": 1641859200000,
+        "F\u00e4lle_Meldedatum": 113,
+        "Zeitraum": "04.01.2022 - 10.01.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 288,
+        "Fallzahl_aktiv": 3958,
+        "Krh_N_belegt": 860,
+        "Krh_I_belegt": 370,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -109,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 112,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.82,
+        "H_Zeitraum": "04.01.2022 - 10.01.2022",
+        "H_Datum": "10.01.2022",
+        "Datum_Bett": "10.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
