### PR TITLE
New data set: 2022-01-12T112303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-11T111903Z.json
+pjson/2022-01-12T112303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-11T111903Z.json pjson/2022-01-12T112303Z.json```:
```
--- pjson/2022-01-11T111903Z.json	2022-01-11 11:19:03.949578371 +0000
+++ pjson/2022-01-12T112303Z.json	2022-01-12 11:23:03.725864657 +0000
@@ -10652,7 +10652,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 10,
+        "SterbeF_Sterbedatum": 11,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -11934,7 +11934,7 @@
         "Datum_neu": 1609977600000,
         "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12048,7 +12048,7 @@
         "Datum_neu": 1610236800000,
         "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -14858,7 +14858,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -14934,7 +14934,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616803200000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -15010,7 +15010,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -15846,7 +15846,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618876800000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -15884,7 +15884,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618963200000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -15960,7 +15960,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -15998,7 +15998,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619222400000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 57,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -16226,7 +16226,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -17708,7 +17708,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1623110400000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -20482,7 +20482,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629417600000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -20520,7 +20520,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629504000000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -21204,7 +21204,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631059200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -21280,7 +21280,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631232000000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21318,7 +21318,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631318400000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -21356,7 +21356,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631404800000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22838,7 +22838,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634774400000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22876,7 +22876,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634860800000,
-        "F\u00e4lle_Meldedatum": 332,
+        "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -23066,7 +23066,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635292800000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 714,
+        "F\u00e4lle_Meldedatum": 715,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1233,
+        "F\u00e4lle_Meldedatum": 1232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1038,
+        "F\u00e4lle_Meldedatum": 1036,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1145,
+        "F\u00e4lle_Meldedatum": 1146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23864,7 +23864,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637107200000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 936,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1100,
+        "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1484,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 907,
+        "F\u00e4lle_Meldedatum": 905,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1385,
+        "F\u00e4lle_Meldedatum": 1383,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1089,
+        "F\u00e4lle_Meldedatum": 1086,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 771,
+        "F\u00e4lle_Meldedatum": 770,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 286,
+        "F\u00e4lle_Meldedatum": 287,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1331,
+        "F\u00e4lle_Meldedatum": 1328,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 538,
+        "F\u00e4lle_Meldedatum": 539,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 890,
+        "F\u00e4lle_Meldedatum": 891,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 786,
+        "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 480,
+        "F\u00e4lle_Meldedatum": 482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 858,
+        "F\u00e4lle_Meldedatum": 861,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1059,
+        "F\u00e4lle_Meldedatum": 1057,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 685,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 762,
+        "F\u00e4lle_Meldedatum": 761,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 535,
+        "F\u00e4lle_Meldedatum": 538,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25042,7 +25042,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 178,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 547,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -25194,9 +25194,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 427,
+        "F\u00e4lle_Meldedatum": 425,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25232,7 +25232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 401,
+        "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 187,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25308,7 +25308,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -25396,7 +25396,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25422,7 +25422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 486,
+        "F\u00e4lle_Meldedatum": 487,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25498,7 +25498,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 408,
+        "F\u00e4lle_Meldedatum": 409,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25536,7 +25536,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -25612,9 +25612,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25624,7 +25624,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 655,
+        "F\u00e4lle_Meldedatum": 656,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -25662,7 +25662,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25686,15 +25686,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 905,
         "BelegteBetten": null,
-        "Inzidenz": 379.683178275082,
+        "Inzidenz": null,
         "Datum_neu": 1641254400000,
         "F\u00e4lle_Meldedatum": 526,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 263.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1137,
-        "Krh_I_belegt": 446,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25704,7 +25704,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.3,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2022"
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": 395.308739538058,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 319.7,
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 342.3,
@@ -25840,7 +25840,7 @@
         "BelegteBetten": null,
         "Inzidenz": 365.853658536585,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 367.3,
@@ -25916,7 +25916,7 @@
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 371,
+        "F\u00e4lle_Meldedatum": 397,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 394.1,
@@ -25943,38 +25943,76 @@
         "Datum": "11.01.2022",
         "Fallzahl": 85625,
         "ObjectId": 676,
-        "Sterbefall": 1514,
-        "Genesungsfall": 80153,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4233,
-        "Zuwachs_Fallzahl": 361,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 467,
         "BelegteBetten": null,
         "Inzidenz": 354.538596932361,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 113,
-        "Zeitraum": "04.01.2022 - 10.01.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 311,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 288,
-        "Fallzahl_aktiv": 3958,
-        "Krh_N_belegt": 860,
-        "Krh_I_belegt": 370,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 847,
+        "Krh_I_belegt": 356,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -109,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 112,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 3.82,
-        "H_Zeitraum": "04.01.2022 - 10.01.2022",
-        "H_Datum": "10.01.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.01.2022",
+        "Fallzahl": 85901,
+        "ObjectId": 677,
+        "Sterbefall": 1521,
+        "Genesungsfall": 80488,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4239,
+        "Zuwachs_Fallzahl": 276,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 335,
+        "BelegteBetten": null,
+        "Inzidenz": 321.491432881928,
+        "Datum_neu": 1641945600000,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": "05.01.2022 - 11.01.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 282.6,
+        "Fallzahl_aktiv": 3892,
+        "Krh_N_belegt": 847,
+        "Krh_I_belegt": 356,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -66,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 184,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.82,
+        "H_Zeitraum": "04.01.2022 - 10.01.2022",
+        "H_Datum": "11.01.2022",
+        "Datum_Bett": "11.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
