### PR TITLE
New data set: 2022-01-13T112303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-12T112303Z.json
+pjson/2022-01-13T112303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-12T112303Z.json pjson/2022-01-13T112303Z.json```:
```
--- pjson/2022-01-12T112303Z.json	2022-01-12 11:23:03.725864657 +0000
+++ pjson/2022-01-13T112303Z.json	2022-01-13 11:23:04.127579786 +0000
@@ -11856,7 +11856,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 389,
+        "F\u00e4lle_Meldedatum": 388,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -11970,7 +11970,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610064000000,
-        "F\u00e4lle_Meldedatum": 217,
+        "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -13528,7 +13528,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613606400000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -15542,7 +15542,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618185600000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -15732,7 +15732,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -22724,7 +22724,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634515200000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23256,7 +23256,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635724800000,
-        "F\u00e4lle_Meldedatum": 498,
+        "F\u00e4lle_Meldedatum": 496,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1232,
+        "F\u00e4lle_Meldedatum": 1233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1103,
+        "F\u00e4lle_Meldedatum": 1102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1146,
+        "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24016,7 +24016,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637452800000,
-        "F\u00e4lle_Meldedatum": 398,
+        "F\u00e4lle_Meldedatum": 399,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -24170,7 +24170,7 @@
         "Datum_neu": 1637798400000,
         "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1194,
+        "F\u00e4lle_Meldedatum": 1195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1328,
+        "F\u00e4lle_Meldedatum": 1329,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1118,
+        "F\u00e4lle_Meldedatum": 1116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 896,
+        "F\u00e4lle_Meldedatum": 894,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1013,
+        "F\u00e4lle_Meldedatum": 1011,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 539,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 199,
+        "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 981,
+        "F\u00e4lle_Meldedatum": 980,
         "Zeitraum": null,
         "Hosp_Meldedatum": 43,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1252,
+        "F\u00e4lle_Meldedatum": 1251,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 866,
+        "F\u00e4lle_Meldedatum": 867,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 891,
+        "F\u00e4lle_Meldedatum": 890,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 482,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 547,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -25156,9 +25156,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 939,
+        "F\u00e4lle_Meldedatum": 940,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25308,7 +25308,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25384,7 +25384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25422,7 +25422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 487,
+        "F\u00e4lle_Meldedatum": 488,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25472,7 +25472,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25586,7 +25586,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25650,9 +25650,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 656,
+        "F\u00e4lle_Meldedatum": 657,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25662,7 +25662,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25724,15 +25724,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 442,
         "BelegteBetten": null,
-        "Inzidenz": 395.308739538058,
+        "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 326,
+        "F\u00e4lle_Meldedatum": 329,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 319.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1028,
-        "Krh_I_belegt": 414,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25742,7 +25742,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2022"
@@ -25764,9 +25764,9 @@
         "BelegteBetten": null,
         "Inzidenz": 398.541614282122,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 308,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 352.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 997,
@@ -25780,7 +25780,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.51,
+        "H_Inzidenz": 7.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2022"
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 342.3,
@@ -25814,11 +25814,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.09,
+        "H_Inzidenz": 7.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.01.2022"
@@ -25840,7 +25840,7 @@
         "BelegteBetten": null,
         "Inzidenz": 365.853658536585,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 367.3,
@@ -25856,7 +25856,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": 6.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.01.2022"
@@ -25878,7 +25878,7 @@
         "BelegteBetten": null,
         "Inzidenz": 344.839972700169,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 382.8,
@@ -25894,7 +25894,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 6.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.01.2022"
@@ -25916,9 +25916,9 @@
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 397,
+        "F\u00e4lle_Meldedatum": 405,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 394.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 860,
@@ -25932,7 +25932,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5,
+        "H_Inzidenz": 6.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.01.2022"
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": 354.538596932361,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 288,
@@ -25966,11 +25966,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.82,
+        "H_Inzidenz": 5.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2022"
@@ -25981,38 +25981,76 @@
         "Datum": "12.01.2022",
         "Fallzahl": 85901,
         "ObjectId": 677,
-        "Sterbefall": 1521,
-        "Genesungsfall": 80488,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4239,
-        "Zuwachs_Fallzahl": 276,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 335,
         "BelegteBetten": null,
         "Inzidenz": 321.491432881928,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 38,
-        "Zeitraum": "05.01.2022 - 11.01.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 292,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 282.6,
-        "Fallzahl_aktiv": 3892,
-        "Krh_N_belegt": 847,
-        "Krh_I_belegt": 356,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 772,
+        "Krh_I_belegt": 349,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -66,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 184,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.82,
-        "H_Zeitraum": "04.01.2022 - 10.01.2022",
-        "H_Datum": "11.01.2022",
+        "H_Inzidenz": 4.14,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.01.2022",
+        "Fallzahl": 86237,
+        "ObjectId": 678,
+        "Sterbefall": 1528,
+        "Genesungsfall": 80899,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4245,
+        "Zuwachs_Fallzahl": 336,
+        "Zuwachs_Sterbefall": 7,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 411,
+        "BelegteBetten": null,
+        "Inzidenz": 321.491432881928,
+        "Datum_neu": 1642032000000,
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": "06.01.2022 - 12.01.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 277,
+        "Fallzahl_aktiv": 3810,
+        "Krh_N_belegt": 772,
+        "Krh_I_belegt": 349,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -82,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 212,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.16,
+        "H_Zeitraum": "06.01.2022 - 12.01.2022",
+        "H_Datum": "12.01.2022",
+        "Datum_Bett": "12.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
