### PR TITLE
New data set: 2022-01-14T111503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-13T112303Z.json
+pjson/2022-01-14T111503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-13T112303Z.json pjson/2022-01-14T111503Z.json```:
```
--- pjson/2022-01-13T112303Z.json	2022-01-13 11:23:04.127579786 +0000
+++ pjson/2022-01-14T111503Z.json	2022-01-14 11:15:03.245122074 +0000
@@ -12160,7 +12160,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -15010,7 +15010,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616976000000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -15428,7 +15428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -15732,7 +15732,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618617600000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -16226,7 +16226,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619740800000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -16378,7 +16378,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1233,
+        "F\u00e4lle_Meldedatum": 1232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1145,
+        "F\u00e4lle_Meldedatum": 1146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1011,
+        "F\u00e4lle_Meldedatum": 1009,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24512,7 +24512,7 @@
         "Datum_neu": 1638576000000,
         "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1251,
+        "F\u00e4lle_Meldedatum": 1250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24664,7 +24664,7 @@
         "Datum_neu": 1638921600000,
         "F\u00e4lle_Meldedatum": 867,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 890,
+        "F\u00e4lle_Meldedatum": 889,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 861,
+        "F\u00e4lle_Meldedatum": 860,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24892,7 +24892,7 @@
         "Datum_neu": 1639440000000,
         "F\u00e4lle_Meldedatum": 1057,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 688,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25422,7 +25422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 488,
+        "F\u00e4lle_Meldedatum": 489,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25460,9 +25460,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 327,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 657,
+        "F\u00e4lle_Meldedatum": 658,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 329,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25762,15 +25762,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 408,
         "BelegteBetten": null,
-        "Inzidenz": 398.541614282122,
+        "Inzidenz": null,
         "Datum_neu": 1641427200000,
         "F\u00e4lle_Meldedatum": 308,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 352.4,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 997,
-        "Krh_I_belegt": 397,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25780,7 +25780,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.54,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2022"
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.940407342218,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 342.3,
@@ -25818,7 +25818,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.1,
+        "H_Inzidenz": 7.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.01.2022"
@@ -25840,7 +25840,7 @@
         "BelegteBetten": null,
         "Inzidenz": 365.853658536585,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 367.3,
@@ -25856,7 +25856,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.75,
+        "H_Inzidenz": 7.2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.01.2022"
@@ -25878,7 +25878,7 @@
         "BelegteBetten": null,
         "Inzidenz": 344.839972700169,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 382.8,
@@ -25894,7 +25894,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.01.2022"
@@ -25916,7 +25916,7 @@
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 405,
+        "F\u00e4lle_Meldedatum": 409,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 394.1,
@@ -25932,7 +25932,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.19,
+        "H_Inzidenz": 6.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.01.2022"
@@ -25954,9 +25954,9 @@
         "BelegteBetten": null,
         "Inzidenz": 354.538596932361,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 333,
+        "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 288,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 847,
@@ -25970,7 +25970,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 5.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2022"
@@ -25992,9 +25992,9 @@
         "BelegteBetten": null,
         "Inzidenz": 321.491432881928,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 282.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 772,
@@ -26008,7 +26008,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.14,
+        "H_Inzidenz": 4.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.01.2022"
@@ -26019,38 +26019,76 @@
         "Datum": "13.01.2022",
         "Fallzahl": 86237,
         "ObjectId": 678,
-        "Sterbefall": 1528,
-        "Genesungsfall": 80899,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 4245,
-        "Zuwachs_Fallzahl": 336,
-        "Zuwachs_Sterbefall": 7,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 411,
         "BelegteBetten": null,
         "Inzidenz": 321.491432881928,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 51,
-        "Zeitraum": "06.01.2022 - 12.01.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 244,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 277,
-        "Fallzahl_aktiv": 3810,
-        "Krh_N_belegt": 772,
-        "Krh_I_belegt": 349,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 715,
+        "Krh_I_belegt": 347,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -82,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 212,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.16,
-        "H_Zeitraum": "06.01.2022 - 12.01.2022",
-        "H_Datum": "12.01.2022",
+        "H_Inzidenz": 3.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.01.2022",
+        "Fallzahl": 86554,
+        "ObjectId": 679,
+        "Sterbefall": 1529,
+        "Genesungsfall": 81041,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4251,
+        "Zuwachs_Fallzahl": 317,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 142,
+        "BelegteBetten": null,
+        "Inzidenz": 318.438162290312,
+        "Datum_neu": 1642118400000,
+        "F\u00e4lle_Meldedatum": 87,
+        "Zeitraum": "07.01.2022 - 13.01.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 279.2,
+        "Fallzahl_aktiv": 3984,
+        "Krh_N_belegt": 715,
+        "Krh_I_belegt": 347,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 174,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 245,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.81,
+        "H_Zeitraum": "07.01.2022 - 13.01.2022",
+        "H_Datum": "13.01.2023",
+        "Datum_Bett": "13.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
