### PR TITLE
New data set: 2022-01-18T113404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-17T112302Z.json
+pjson/2022-01-18T113404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-17T112302Z.json pjson/2022-01-18T113404Z.json```:
```
--- pjson/2022-01-17T112302Z.json	2022-01-17 11:23:02.839750065 +0000
+++ pjson/2022-01-18T113404Z.json	2022-01-18 11:34:04.710914376 +0000
@@ -9234,7 +9234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1603843200000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -10260,7 +10260,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606176000000,
-        "F\u00e4lle_Meldedatum": 264,
+        "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -10754,7 +10754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -11020,7 +11020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 428,
+        "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -11096,7 +11096,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 360,
+        "F\u00e4lle_Meldedatum": 361,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -11932,7 +11932,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 265,
+        "F\u00e4lle_Meldedatum": 264,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -15314,7 +15314,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617667200000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -16492,7 +16492,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -19456,7 +19456,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1627084800000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -21432,7 +21432,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1631577600000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22306,7 +22306,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633564800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23712,7 +23712,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636761600000,
-        "F\u00e4lle_Meldedatum": 494,
+        "F\u00e4lle_Meldedatum": 493,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1330,
+        "F\u00e4lle_Meldedatum": 1329,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 981,
+        "F\u00e4lle_Meldedatum": 982,
         "Zeitraum": null,
         "Hosp_Meldedatum": 43,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 890,
+        "F\u00e4lle_Meldedatum": 891,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 790,
+        "F\u00e4lle_Meldedatum": 791,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 481,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 861,
+        "F\u00e4lle_Meldedatum": 862,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1058,
+        "F\u00e4lle_Meldedatum": 1059,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -24902,7 +24902,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 8,
+        "SterbeF_Sterbedatum": 9,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25042,7 +25042,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 547,
+        "F\u00e4lle_Meldedatum": 548,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 940,
+        "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25308,7 +25308,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640390400000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25384,7 +25384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 538,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25498,7 +25498,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 410,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25510,7 +25510,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25536,7 +25536,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -25574,7 +25574,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25612,7 +25612,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 660,
+        "F\u00e4lle_Meldedatum": 658,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -25688,7 +25688,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 526,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -25700,7 +25700,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25738,7 +25738,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 308,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -25776,7 +25776,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25814,7 +25814,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25840,7 +25840,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -25852,7 +25852,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25878,7 +25878,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25914,15 +25914,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 521,
         "BelegteBetten": null,
-        "Inzidenz": 399.978447501706,
+        "Inzidenz": null,
         "Datum_neu": 1641772800000,
         "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
-        "Inzidenz_RKI": 394.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 860,
-        "Krh_I_belegt": 370,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25932,7 +25932,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.05,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.01.2022"
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": 354.538596932361,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 288,
@@ -25970,7 +25970,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.87,
+        "H_Inzidenz": 6.06,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2022"
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": 321.491432881928,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 339,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 282.6,
@@ -26008,7 +26008,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.78,
+        "H_Inzidenz": 4.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.01.2022"
@@ -26030,9 +26030,9 @@
         "BelegteBetten": null,
         "Inzidenz": 321.491432881928,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 294,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 277,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 715,
@@ -26046,7 +26046,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.02,
+        "H_Inzidenz": 4.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.01.2022"
@@ -26057,34 +26057,34 @@
         "Datum": "14.01.2022",
         "Fallzahl": 86892,
         "ObjectId": 679,
-        "Sterbefall": 1529,
-        "Genesungsfall": 80898,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4251,
-        "Zuwachs_Fallzahl": 317,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 145,
         "BelegteBetten": null,
         "Inzidenz": 318.438162290312,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 279.2,
-        "Fallzahl_aktiv": 4465,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 654,
         "Krh_I_belegt": 325,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 171,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.35,
+        "H_Inzidenz": 3.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2022"
@@ -26096,7 +26096,7 @@
         "Fallzahl": 87066,
         "ObjectId": 680,
         "Sterbefall": null,
-        "Genesungsfall": 81065,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -26106,7 +26106,7 @@
         "BelegteBetten": null,
         "Inzidenz": 291.317935270663,
         "Datum_neu": 1642204800000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 204,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 298.1,
@@ -26118,11 +26118,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.08,
+        "H_Inzidenz": 3.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2022"
@@ -26134,7 +26134,7 @@
         "Fallzahl": 87099,
         "ObjectId": 681,
         "Sterbefall": null,
-        "Genesungsfall": 81135,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 341.6,
@@ -26160,7 +26160,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": 3.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2022"
@@ -26173,7 +26173,7 @@
         "ObjectId": 682,
         "Sterbefall": 1532,
         "Genesungsfall": 81779,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4270,
         "Zuwachs_Fallzahl": 300,
         "Zuwachs_Sterbefall": 3,
@@ -26182,13 +26182,13 @@
         "BelegteBetten": null,
         "Inzidenz": 358.849096591113,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "10.01.2022 - 16.01.2022",
+        "F\u00e4lle_Meldedatum": 559,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 346.3,
         "Fallzahl_aktiv": 3881,
-        "Krh_N_belegt": 538,
-        "Krh_I_belegt": 302,
+        "Krh_N_belegt": 544,
+        "Krh_I_belegt": 293,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -584,
         "Krh_I": null,
@@ -26196,13 +26196,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 337,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.39,
-        "H_Zeitraum": "10.01.2022 - 16.01.2022",
-        "H_Datum": "16.01.2022",
+        "H_Inzidenz": 2.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.01.2022",
+        "Fallzahl": 87980,
+        "ObjectId": 683,
+        "Sterbefall": 1540,
+        "Genesungsfall": 82289,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4271,
+        "Zuwachs_Fallzahl": 788,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 510,
+        "BelegteBetten": null,
+        "Inzidenz": 401.594884873738,
+        "Datum_neu": 1642464000000,
+        "F\u00e4lle_Meldedatum": 119,
+        "Zeitraum": "11.01.2022 - 17.01.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 290.7,
+        "Fallzahl_aktiv": 4151,
+        "Krh_N_belegt": 544,
+        "Krh_I_belegt": 293,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 270,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 410,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2,
+        "H_Zeitraum": "11.01.2022 - 17.01.2022",
+        "H_Datum": "17.01.2022",
+        "Datum_Bett": "17.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
