### PR TITLE
New data set: 2022-01-19T111704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-18T113404Z.json
+pjson/2022-01-19T111704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-18T113404Z.json pjson/2022-01-19T111704Z.json```:
```
--- pjson/2022-01-18T113404Z.json	2022-01-18 11:34:04.710914376 +0000
+++ pjson/2022-01-19T111704Z.json	2022-01-19 11:17:04.744784448 +0000
@@ -10262,7 +10262,7 @@
         "Datum_neu": 1606176000000,
         "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -11020,7 +11020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 429,
+        "F\u00e4lle_Meldedatum": 428,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -11856,7 +11856,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609804800000,
-        "F\u00e4lle_Meldedatum": 388,
+        "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -12008,7 +12008,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610150400000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -12312,7 +12312,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610841600000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -16266,7 +16266,7 @@
         "Datum_neu": 1619827200000,
         "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20482,7 +20482,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629417600000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -20596,7 +20596,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1629676800000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22990,7 +22990,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635120000000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23028,7 +23028,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 471,
+        "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1105,
+        "F\u00e4lle_Meldedatum": 1106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1384,
+        "F\u00e4lle_Meldedatum": 1382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1476,
+        "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1329,
+        "F\u00e4lle_Meldedatum": 1328,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24928,9 +24928,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 690,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 762,
+        "F\u00e4lle_Meldedatum": 763,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 539,
+        "F\u00e4lle_Meldedatum": 538,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25384,7 +25384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 538,
+        "F\u00e4lle_Meldedatum": 540,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -25498,9 +25498,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 412,
+        "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25536,7 +25536,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -25574,7 +25574,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 658,
+        "F\u00e4lle_Meldedatum": 657,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -25688,9 +25688,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 531,
+        "F\u00e4lle_Meldedatum": 532,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 335,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25766,7 +25766,7 @@
         "Datum_neu": 1641427200000,
         "F\u00e4lle_Meldedatum": 308,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25840,7 +25840,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -25878,7 +25878,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25952,15 +25952,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 467,
         "BelegteBetten": null,
-        "Inzidenz": 354.538596932361,
+        "Inzidenz": null,
         "Datum_neu": 1641859200000,
         "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 288,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 847,
-        "Krh_I_belegt": 356,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -25970,7 +25970,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.06,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2022"
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": 321.491432881928,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 351,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 282.6,
@@ -26008,7 +26008,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.98,
+        "H_Inzidenz": 5.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.01.2022"
@@ -26030,9 +26030,9 @@
         "BelegteBetten": null,
         "Inzidenz": 321.491432881928,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 296,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 277,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 715,
@@ -26046,7 +26046,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.22,
+        "H_Inzidenz": 4.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.01.2022"
@@ -26068,9 +26068,9 @@
         "BelegteBetten": null,
         "Inzidenz": 318.438162290312,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 279.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 654,
@@ -26084,7 +26084,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 3.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2022"
@@ -26106,7 +26106,7 @@
         "BelegteBetten": null,
         "Inzidenz": 291.317935270663,
         "Datum_neu": 1642204800000,
-        "F\u00e4lle_Meldedatum": 204,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 298.1,
@@ -26122,7 +26122,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.35,
+        "H_Inzidenz": 3.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2022"
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 341.6,
@@ -26160,7 +26160,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.03,
+        "H_Inzidenz": 3.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2022"
@@ -26171,26 +26171,26 @@
         "Datum": "17.01.2022",
         "Fallzahl": 87192,
         "ObjectId": 682,
-        "Sterbefall": 1532,
-        "Genesungsfall": 81779,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4270,
-        "Zuwachs_Fallzahl": 300,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 881,
         "BelegteBetten": null,
         "Inzidenz": 358.849096591113,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 559,
+        "F\u00e4lle_Meldedatum": 651,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 346.3,
-        "Fallzahl_aktiv": 3881,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 544,
         "Krh_I_belegt": 293,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -584,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -26198,7 +26198,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
+        "H_Inzidenz": 2.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.01.2022"
@@ -26211,7 +26211,7 @@
         "ObjectId": 683,
         "Sterbefall": 1540,
         "Genesungsfall": 82289,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4271,
         "Zuwachs_Fallzahl": 788,
         "Zuwachs_Sterbefall": 8,
@@ -26220,13 +26220,13 @@
         "BelegteBetten": null,
         "Inzidenz": 401.594884873738,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 119,
-        "Zeitraum": "11.01.2022 - 17.01.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 588,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 290.7,
         "Fallzahl_aktiv": 4151,
-        "Krh_N_belegt": 544,
-        "Krh_I_belegt": 293,
+        "Krh_N_belegt": 515,
+        "Krh_I_belegt": 285,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 270,
         "Krh_I": null,
@@ -26234,12 +26234,50 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 410,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.34,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.01.2022",
+        "Fallzahl": 88676,
+        "ObjectId": 684,
+        "Sterbefall": 1540,
+        "Genesungsfall": 82648,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4278,
+        "Zuwachs_Fallzahl": 696,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 359,
+        "BelegteBetten": null,
+        "Inzidenz": 465.533963145228,
+        "Datum_neu": 1642550400000,
+        "F\u00e4lle_Meldedatum": 99,
+        "Zeitraum": "12.01.2022 - 18.01.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 375.4,
+        "Fallzahl_aktiv": 4488,
+        "Krh_N_belegt": 515,
+        "Krh_I_belegt": 285,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 337,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 520,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 2,
-        "H_Zeitraum": "11.01.2022 - 17.01.2022",
-        "H_Datum": "17.01.2022",
-        "Datum_Bett": "17.01.2022"
+        "H_Zeitraum": "12.01.2022 - 18.01.2022",
+        "H_Datum": "18.01.2022",
+        "Datum_Bett": "18.01.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
