### PR TITLE
New data set: 2022-01-24T112104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-21T111204Z.json
+pjson/2022-01-24T112104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-21T111204Z.json pjson/2022-01-24T112104Z.json```:
```
--- pjson/2022-01-21T111204Z.json	2022-01-21 11:12:04.388045706 +0000
+++ pjson/2022-01-24T112104Z.json	2022-01-24 11:21:04.131914463 +0000
@@ -16492,7 +16492,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620345600000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -22610,7 +22610,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634256000000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 164,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1480,
+        "F\u00e4lle_Meldedatum": 1479,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1475,
+        "F\u00e4lle_Meldedatum": 1476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1116,
+        "F\u00e4lle_Meldedatum": 1115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1251,
+        "F\u00e4lle_Meldedatum": 1250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 863,
+        "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -25688,7 +25688,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 533,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 338,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 305,
+        "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25814,7 +25814,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25840,7 +25840,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -25966,7 +25966,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 297,
+        "F\u00e4lle_Meldedatum": 298,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26066,15 +26066,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 145,
         "BelegteBetten": null,
-        "Inzidenz": 318.438162290312,
+        "Inzidenz": null,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 366,
+        "F\u00e4lle_Meldedatum": 372,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 279.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 654,
-        "Krh_I_belegt": 325,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26084,7 +26084,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.02,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2022"
@@ -26104,15 +26104,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 167,
         "BelegteBetten": null,
-        "Inzidenz": 291.317935270663,
+        "Inzidenz": null,
         "Datum_neu": 1642204800000,
         "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 298.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 554,
-        "Krh_I_belegt": 319,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26122,7 +26122,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2022"
@@ -26142,25 +26142,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 70,
         "BelegteBetten": null,
-        "Inzidenz": 282.696935953159,
+        "Inzidenz": null,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 341.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 538,
-        "Krh_I_belegt": 302,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2022"
@@ -26182,7 +26182,7 @@
         "BelegteBetten": null,
         "Inzidenz": 358.849096591113,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 346.3,
@@ -26198,7 +26198,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.38,
+        "H_Inzidenz": 3.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.01.2022"
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": 401.594884873738,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 686,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 290.7,
@@ -26236,7 +26236,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.91,
+        "H_Inzidenz": 3.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.01.2022"
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": 465.533963145228,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 668,
+        "F\u00e4lle_Meldedatum": 670,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 375.4,
@@ -26274,7 +26274,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.88,
+        "H_Inzidenz": 3.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.01.2022"
@@ -26285,34 +26285,34 @@
         "Datum": "20.01.2022",
         "Fallzahl": 89417,
         "ObjectId": 685,
-        "Sterbefall": 1546,
-        "Genesungsfall": 82977,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4281,
-        "Zuwachs_Fallzahl": 741,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 329,
         "BelegteBetten": null,
         "Inzidenz": 535.399978447502,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 548,
+        "F\u00e4lle_Meldedatum": 604,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 430.4,
-        "Fallzahl_aktiv": 4894,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 432,
         "Krh_I_belegt": 244,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 406,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.59,
+        "H_Inzidenz": 3.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2022"
@@ -26325,36 +26325,150 @@
         "ObjectId": 686,
         "Sterbefall": 1549,
         "Genesungsfall": 83227,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4289,
         "Zuwachs_Fallzahl": 584,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Sterbefall": 1549,
+        "Zuwachs_Krankenhauseinweisung": 4289,
         "Zuwachs_Genesung": 250,
         "BelegteBetten": null,
         "Inzidenz": 593.950932145551,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 92,
-        "Zeitraum": "14.01.2022 - 20.01.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 499,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 515.4,
         "Fallzahl_aktiv": 5225,
-        "Krh_N_belegt": 432,
-        "Krh_I_belegt": 244,
+        "Krh_N_belegt": 404,
+        "Krh_I_belegt": 233,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 331,
+        "Fallzahl_aktiv_Zuwachs": -1215,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 742,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.34,
-        "H_Zeitraum": "14.01.2022 - 20.01.2022",
-        "H_Datum": "20.01.2022",
+        "H_Inzidenz": 3.52,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.01.2022",
+        "Fallzahl": 90619,
+        "ObjectId": 687,
+        "Sterbefall": null,
+        "Genesungsfall": 83378,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 151,
+        "BelegteBetten": null,
+        "Inzidenz": 628.973741872912,
+        "Datum_neu": 1642809600000,
+        "F\u00e4lle_Meldedatum": 250,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 551.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 344,
+        "Krh_I_belegt": 217,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.35,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.01.2022",
+        "Fallzahl": 90663,
+        "ObjectId": 688,
+        "Sterbefall": null,
+        "Genesungsfall": 83458,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 80,
+        "BelegteBetten": null,
+        "Inzidenz": 635.798699665936,
+        "Datum_neu": 1642896000000,
+        "F\u00e4lle_Meldedatum": 127,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 569.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 341,
+        "Krh_I_belegt": 210,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.3,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.01.2022",
+        "Fallzahl": 90911,
+        "ObjectId": 689,
+        "Sterbefall": 1553,
+        "Genesungsfall": 83858,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4296,
+        "Zuwachs_Fallzahl": 910,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 400,
+        "BelegteBetten": null,
+        "Inzidenz": 634.361866446352,
+        "Datum_neu": 1642982400000,
+        "F\u00e4lle_Meldedatum": 57,
+        "Zeitraum": "17.01.2022 - 23.01.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 601.7,
+        "Fallzahl_aktiv": 5500,
+        "Krh_N_belegt": 341,
+        "Krh_I_belegt": 210,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 506,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 925,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.13,
+        "H_Zeitraum": "17.01.2022 - 23.01.2022",
+        "H_Datum": "23.01.2022",
+        "Datum_Bett": "23.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
