### PR TITLE
New data set: 2022-01-26T112103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-25T112002Z.json
+pjson/2022-01-26T112103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-25T112002Z.json pjson/2022-01-26T112103Z.json```:
```
--- pjson/2022-01-25T112002Z.json	2022-01-25 11:20:02.888079886 +0000
+++ pjson/2022-01-26T112103Z.json	2022-01-26 11:21:03.761294291 +0000
@@ -10792,7 +10792,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607385600000,
-        "F\u00e4lle_Meldedatum": 333,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -22496,7 +22496,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633996800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 715,
+        "F\u00e4lle_Meldedatum": 716,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1568,
+        "F\u00e4lle_Meldedatum": 1569,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1085,
+        "F\u00e4lle_Meldedatum": 1086,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1476,
+        "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1326,
+        "F\u00e4lle_Meldedatum": 1325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 887,
+        "F\u00e4lle_Meldedatum": 888,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 787,
+        "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 688,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 550,
+        "F\u00e4lle_Meldedatum": 551,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -25384,7 +25384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 307,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25954,9 +25954,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 362,
+        "F\u00e4lle_Meldedatum": 361,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 354,
+        "F\u00e4lle_Meldedatum": 353,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 298,
+        "F\u00e4lle_Meldedatum": 297,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26068,7 +26068,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 372,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26106,7 +26106,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642204800000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26182,7 +26182,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 694,
+        "F\u00e4lle_Meldedatum": 697,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26218,15 +26218,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 510,
         "BelegteBetten": null,
-        "Inzidenz": 401.594884873738,
+        "Inzidenz": null,
         "Datum_neu": 1642464000000,
         "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 290.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 515,
-        "Krh_I_belegt": 285,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26236,7 +26236,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.23,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.01.2022"
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": 465.533963145228,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 677,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 375.4,
@@ -26274,7 +26274,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.35,
+        "H_Inzidenz": 3.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.01.2022"
@@ -26296,7 +26296,7 @@
         "BelegteBetten": null,
         "Inzidenz": 535.399978447502,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 615,
+        "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 430.4,
@@ -26312,7 +26312,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.33,
+        "H_Inzidenz": 3.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2022"
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": 593.950932145551,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 514,
+        "F\u00e4lle_Meldedatum": 520,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 515.4,
@@ -26350,7 +26350,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.62,
+        "H_Inzidenz": 3.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2022"
@@ -26372,9 +26372,9 @@
         "BelegteBetten": null,
         "Inzidenz": 628.973741872912,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 294,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 551.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 344,
@@ -26388,7 +26388,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.52,
+        "H_Inzidenz": 3.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2022"
@@ -26410,7 +26410,7 @@
         "BelegteBetten": null,
         "Inzidenz": 635.798699665936,
         "Datum_neu": 1642896000000,
-        "F\u00e4lle_Meldedatum": 184,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 569.7,
@@ -26426,7 +26426,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.55,
+        "H_Inzidenz": 3.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2022"
@@ -26437,34 +26437,34 @@
         "Datum": "24.01.2022",
         "Fallzahl": 90911,
         "ObjectId": 689,
-        "Sterbefall": 1553,
-        "Genesungsfall": 83858,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4296,
-        "Zuwachs_Fallzahl": 910,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 400,
         "BelegteBetten": null,
         "Inzidenz": 634.361866446352,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1009,
+        "F\u00e4lle_Meldedatum": 1131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 601.7,
-        "Fallzahl_aktiv": 5500,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 353,
         "Krh_I_belegt": 212,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 506,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.4,
+        "H_Inzidenz": 3.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2022"
@@ -26477,7 +26477,7 @@
         "ObjectId": 690,
         "Sterbefall": 1554,
         "Genesungsfall": 84217,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4300,
         "Zuwachs_Fallzahl": 1404,
         "Zuwachs_Sterbefall": 1,
@@ -26486,27 +26486,65 @@
         "BelegteBetten": null,
         "Inzidenz": 714.824526743058,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 311,
-        "Zeitraum": "18.01.2022 - 24.01.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1155,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 525,
         "Fallzahl_aktiv": 6544,
-        "Krh_N_belegt": 353,
-        "Krh_I_belegt": 212,
+        "Krh_N_belegt": 372,
+        "Krh_I_belegt": 211,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 1044,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 1037,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.93,
-        "H_Zeitraum": "18.01.2022 - 24.01.2022",
-        "H_Datum": "24.01.2022",
+        "H_Inzidenz": 3.75,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.01.2022",
+        "Fallzahl": 93539,
+        "ObjectId": 691,
+        "Sterbefall": 1555,
+        "Genesungsfall": 84587,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4308,
+        "Zuwachs_Fallzahl": 1224,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 370,
+        "BelegteBetten": null,
+        "Inzidenz": 827.256726175509,
+        "Datum_neu": 1643155200000,
+        "F\u00e4lle_Meldedatum": 216,
+        "Zeitraum": "19.01.2022 - 25.01.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 682.5,
+        "Fallzahl_aktiv": 7397,
+        "Krh_N_belegt": 372,
+        "Krh_I_belegt": 211,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 853,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1209,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.98,
+        "H_Zeitraum": "19.01.2022 - 25.01.2022",
+        "H_Datum": "25.01.2022",
+        "Datum_Bett": "25.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
