### PR TITLE
New data set: 2022-01-27T120005Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-26T112103Z.json
+pjson/2022-01-27T120005Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-26T112103Z.json pjson/2022-01-27T120005Z.json```:
```
--- pjson/2022-01-26T112103Z.json	2022-01-26 11:21:03.761294291 +0000
+++ pjson/2022-01-27T120005Z.json	2022-01-27 12:00:05.851293597 +0000
@@ -16378,7 +16378,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620086400000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1232,
+        "F\u00e4lle_Meldedatum": 1233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1086,
+        "F\u00e4lle_Meldedatum": 1085,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 980,
+        "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
         "Hosp_Meldedatum": 43,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1252,
+        "F\u00e4lle_Meldedatum": 1251,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 297,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26256,15 +26256,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 359,
         "BelegteBetten": null,
-        "Inzidenz": 465.533963145228,
+        "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 375.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 492,
-        "Krh_I_belegt": 254,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26274,7 +26274,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.4,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.01.2022"
@@ -26296,7 +26296,7 @@
         "BelegteBetten": null,
         "Inzidenz": 535.399978447502,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 621,
+        "F\u00e4lle_Meldedatum": 620,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 430.4,
@@ -26312,7 +26312,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.43,
+        "H_Inzidenz": 3.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2022"
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": 593.950932145551,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 520,
+        "F\u00e4lle_Meldedatum": 525,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 515.4,
@@ -26350,7 +26350,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 3.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2022"
@@ -26372,9 +26372,9 @@
         "BelegteBetten": null,
         "Inzidenz": 628.973741872912,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 300,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 551.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 344,
@@ -26388,7 +26388,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.7,
+        "H_Inzidenz": 3.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2022"
@@ -26410,7 +26410,7 @@
         "BelegteBetten": null,
         "Inzidenz": 635.798699665936,
         "Datum_neu": 1642896000000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 569.7,
@@ -26426,7 +26426,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2022"
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": 634.361866446352,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1131,
+        "F\u00e4lle_Meldedatum": 1162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 601.7,
@@ -26464,7 +26464,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.82,
+        "H_Inzidenz": 3.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2022"
@@ -26475,34 +26475,34 @@
         "Datum": "25.01.2022",
         "Fallzahl": 92315,
         "ObjectId": 690,
-        "Sterbefall": 1554,
-        "Genesungsfall": 84217,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4300,
-        "Zuwachs_Fallzahl": 1404,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 359,
         "BelegteBetten": null,
         "Inzidenz": 714.824526743058,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1155,
+        "F\u00e4lle_Meldedatum": 1268,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 525,
-        "Fallzahl_aktiv": 6544,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 372,
         "Krh_I_belegt": 211,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1044,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 4.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2022"
@@ -26515,7 +26515,7 @@
         "ObjectId": 691,
         "Sterbefall": 1555,
         "Genesungsfall": 84587,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4308,
         "Zuwachs_Fallzahl": 1224,
         "Zuwachs_Sterbefall": 1,
@@ -26524,13 +26524,13 @@
         "BelegteBetten": null,
         "Inzidenz": 827.256726175509,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 216,
-        "Zeitraum": "19.01.2022 - 25.01.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 995,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 682.5,
         "Fallzahl_aktiv": 7397,
-        "Krh_N_belegt": 372,
-        "Krh_I_belegt": 211,
+        "Krh_N_belegt": 390,
+        "Krh_I_belegt": 206,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 853,
         "Krh_I": null,
@@ -26538,13 +26538,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1209,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
-        "H_Zeitraum": "19.01.2022 - 25.01.2022",
-        "H_Datum": "25.01.2022",
+        "H_Inzidenz": 3.8,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.01.2022",
+        "Fallzahl": 94709,
+        "ObjectId": 692,
+        "Sterbefall": 1555,
+        "Genesungsfall": 84902,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4312,
+        "Zuwachs_Fallzahl": 1170,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 315,
+        "BelegteBetten": null,
+        "Inzidenz": 909.695032149143,
+        "Datum_neu": 1643241600000,
+        "F\u00e4lle_Meldedatum": 239,
+        "Zeitraum": "20.01.2022 - 26.01.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 757.6,
+        "Fallzahl_aktiv": 8252,
+        "Krh_N_belegt": 390,
+        "Krh_I_belegt": 206,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 855,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1353,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.18,
+        "H_Zeitraum": "20.01.2022 - 26.01.2022",
+        "H_Datum": "26.01.2022",
+        "Datum_Bett": "26.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
