### PR TITLE
New data set: 2022-01-28T112204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-27T120005Z.json
+pjson/2022-01-28T112204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-27T120005Z.json pjson/2022-01-28T112204Z.json```:
```
--- pjson/2022-01-27T120005Z.json	2022-01-27 12:00:05.851293597 +0000
+++ pjson/2022-01-28T112204Z.json	2022-01-28 11:22:04.451329628 +0000
@@ -11096,7 +11096,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 361,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -12350,7 +12350,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1233,
+        "F\u00e4lle_Meldedatum": 1232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1325,
+        "F\u00e4lle_Meldedatum": 1327,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1114,
+        "F\u00e4lle_Meldedatum": 1115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 891,
+        "F\u00e4lle_Meldedatum": 892,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 655,
+        "F\u00e4lle_Meldedatum": 656,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -25688,7 +25688,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 531,
+        "F\u00e4lle_Meldedatum": 530,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25916,7 +25916,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 361,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 352,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26068,7 +26068,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 370,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26080,7 +26080,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26106,7 +26106,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642204800000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -26118,7 +26118,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26182,7 +26182,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 697,
+        "F\u00e4lle_Meldedatum": 698,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -26270,7 +26270,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26294,15 +26294,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 329,
         "BelegteBetten": null,
-        "Inzidenz": 535.399978447502,
+        "Inzidenz": null,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 620,
+        "F\u00e4lle_Meldedatum": 622,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 430.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 432,
-        "Krh_I_belegt": 244,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26312,7 +26312,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.6,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2022"
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": 593.950932145551,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 525,
+        "F\u00e4lle_Meldedatum": 526,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 515.4,
@@ -26346,11 +26346,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2022"
@@ -26372,7 +26372,7 @@
         "BelegteBetten": null,
         "Inzidenz": 628.973741872912,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 551.4,
@@ -26388,7 +26388,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2022"
@@ -26410,7 +26410,7 @@
         "BelegteBetten": null,
         "Inzidenz": 635.798699665936,
         "Datum_neu": 1642896000000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 569.7,
@@ -26426,7 +26426,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.97,
+        "H_Inzidenz": 4.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2022"
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": 634.361866446352,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1162,
+        "F\u00e4lle_Meldedatum": 1172,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 601.7,
@@ -26464,7 +26464,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.99,
+        "H_Inzidenz": 4.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2022"
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": 714.824526743058,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1268,
+        "F\u00e4lle_Meldedatum": 1300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 525,
@@ -26502,7 +26502,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.09,
+        "H_Inzidenz": 4.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2022"
@@ -26513,34 +26513,34 @@
         "Datum": "26.01.2022",
         "Fallzahl": 93539,
         "ObjectId": 691,
-        "Sterbefall": 1555,
-        "Genesungsfall": 84587,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4308,
-        "Zuwachs_Fallzahl": 1224,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 370,
         "BelegteBetten": null,
         "Inzidenz": 827.256726175509,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 995,
+        "F\u00e4lle_Meldedatum": 1100,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 682.5,
-        "Fallzahl_aktiv": 7397,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 390,
         "Krh_I_belegt": 206,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 853,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 4.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2022"
@@ -26553,7 +26553,7 @@
         "ObjectId": 692,
         "Sterbefall": 1555,
         "Genesungsfall": 84902,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4312,
         "Zuwachs_Fallzahl": 1170,
         "Zuwachs_Sterbefall": 0,
@@ -26562,13 +26562,13 @@
         "BelegteBetten": null,
         "Inzidenz": 909.695032149143,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 239,
-        "Zeitraum": "20.01.2022 - 26.01.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 836,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 757.6,
         "Fallzahl_aktiv": 8252,
-        "Krh_N_belegt": 390,
-        "Krh_I_belegt": 206,
+        "Krh_N_belegt": 393,
+        "Krh_I_belegt": 203,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 855,
         "Krh_I": null,
@@ -26576,13 +26576,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1353,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.18,
-        "H_Zeitraum": "20.01.2022 - 26.01.2022",
-        "H_Datum": "26.01.2022",
+        "H_Inzidenz": 3.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.01.2022",
+        "Fallzahl": 95628,
+        "ObjectId": 693,
+        "Sterbefall": 1561,
+        "Genesungsfall": 85266,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4320,
+        "Zuwachs_Fallzahl": 919,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 364,
+        "BelegteBetten": null,
+        "Inzidenz": 975.430151945113,
+        "Datum_neu": 1643328000000,
+        "F\u00e4lle_Meldedatum": 172,
+        "Zeitraum": "21.01.2022 - 27.01.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 852.7,
+        "Fallzahl_aktiv": 8801,
+        "Krh_N_belegt": 393,
+        "Krh_I_belegt": 203,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 549,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1570,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.2,
+        "H_Zeitraum": "21.01.2022 - 27.01.2022",
+        "H_Datum": "27.01.2022",
+        "Datum_Bett": "27.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
