### PR TITLE
New data set: 2022-01-31T112504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-28T112204Z.json
+pjson/2022-01-31T112504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-31T112403Z.json pjson/2022-01-31T112504Z.json```:
```
--- pjson/2022-01-31T112403Z.json	2022-01-31 11:24:03.956278643 +0000
+++ pjson/2022-01-31T112504Z.json	2022-01-31 11:25:04.664293334 +0000
@@ -50105,6 +50105,3084 @@
         "H_Datum": null,
         "Datum_Bett": "10.11.2021"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.11.2021",
+        "Fallzahl": 43096,
+        "ObjectId": 1312,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 215,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1636675200000,
+        "F\u00e4lle_Meldedatum": 1103,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.11.2021",
+        "Fallzahl": 44074,
+        "ObjectId": 1313,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 288,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1636761600000,
+        "F\u00e4lle_Meldedatum": 493,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "12.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.11.2021",
+        "Fallzahl": 44152,
+        "ObjectId": 1314,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 97,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1636848000000,
+        "F\u00e4lle_Meldedatum": 294,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 7,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "13.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.11.2021",
+        "Fallzahl": 44613,
+        "ObjectId": 1315,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 463,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1636934400000,
+        "F\u00e4lle_Meldedatum": 1147,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 30,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "14.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.11.2021",
+        "Fallzahl": 45534,
+        "ObjectId": 1316,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 667,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637020800000,
+        "F\u00e4lle_Meldedatum": 1569,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 25,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 7,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "15.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.11.2021",
+        "Fallzahl": 46485,
+        "ObjectId": 1317,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 559,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637107200000,
+        "F\u00e4lle_Meldedatum": 937,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "16.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.11.2021",
+        "Fallzahl": 47248,
+        "ObjectId": 1318,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 673,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637193600000,
+        "F\u00e4lle_Meldedatum": 1105,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 37,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.11.2021",
+        "Fallzahl": 48231,
+        "ObjectId": 1319,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 529,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637280000000,
+        "F\u00e4lle_Meldedatum": 1480,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 25,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 11,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.11.2021",
+        "Fallzahl": 49336,
+        "ObjectId": 1320,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 255,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637366400000,
+        "F\u00e4lle_Meldedatum": 906,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 9,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.11.2021",
+        "Fallzahl": 49340,
+        "ObjectId": 1321,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 226,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637452800000,
+        "F\u00e4lle_Meldedatum": 400,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 7,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "20.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.11.2021",
+        "Fallzahl": 49865,
+        "ObjectId": 1322,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 669,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637539200000,
+        "F\u00e4lle_Meldedatum": 1383,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 40,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 7,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.11.2021",
+        "Fallzahl": 51258,
+        "ObjectId": 1323,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1211,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637625600000,
+        "F\u00e4lle_Meldedatum": 1661,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 40,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.11.2021",
+        "Fallzahl": 53314,
+        "ObjectId": 1324,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 952,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637712000000,
+        "F\u00e4lle_Meldedatum": 1085,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 34,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 9,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.11.2021",
+        "Fallzahl": 54857,
+        "ObjectId": 1325,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1021,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637798400000,
+        "F\u00e4lle_Meldedatum": 1475,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 29,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 9,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "24.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.11.2021",
+        "Fallzahl": 57082,
+        "ObjectId": 1326,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1070,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637884800000,
+        "F\u00e4lle_Meldedatum": 1196,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 23,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 9,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.11.2021",
+        "Fallzahl": 58815,
+        "ObjectId": 1327,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 484,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1637971200000,
+        "F\u00e4lle_Meldedatum": 770,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 9,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.11.2021",
+        "Fallzahl": 58870,
+        "ObjectId": 1328,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 292,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638057600000,
+        "F\u00e4lle_Meldedatum": 288,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 11,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.11.2021",
+        "Fallzahl": 59832,
+        "ObjectId": 1329,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1095,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638144000000,
+        "F\u00e4lle_Meldedatum": 881,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 35,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 10,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "28.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.11.2021",
+        "Fallzahl": 61864,
+        "ObjectId": 1330,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1512,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638230400000,
+        "F\u00e4lle_Meldedatum": 1327,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 27,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 5,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "29.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.12.2021",
+        "Fallzahl": 63820,
+        "ObjectId": 1331,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 936,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638316800000,
+        "F\u00e4lle_Meldedatum": 1116,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 28,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 9,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.11.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.12.2021",
+        "Fallzahl": 64924,
+        "ObjectId": 1332,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1039,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638403200000,
+        "F\u00e4lle_Meldedatum": 886,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 35,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "01.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.12.2021",
+        "Fallzahl": 65958,
+        "ObjectId": 1333,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1439,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638489600000,
+        "F\u00e4lle_Meldedatum": 1004,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 19,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 12,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.12.2021",
+        "Fallzahl": 66053,
+        "ObjectId": 1334,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 907,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638576000000,
+        "F\u00e4lle_Meldedatum": 537,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "03.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.12.2021",
+        "Fallzahl": 66923,
+        "ObjectId": 1335,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 392,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638662400000,
+        "F\u00e4lle_Meldedatum": 193,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 5,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.12.2021",
+        "Fallzahl": 67676,
+        "ObjectId": 1336,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1303,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638748800000,
+        "F\u00e4lle_Meldedatum": 982,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 43,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 10,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "05.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.12.2021",
+        "Fallzahl": 68691,
+        "ObjectId": 1337,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1611,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638835200000,
+        "F\u00e4lle_Meldedatum": 1251,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 29,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 5,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "06.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.12.2021",
+        "Fallzahl": 69947,
+        "ObjectId": 1338,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1164,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1638921600000,
+        "F\u00e4lle_Meldedatum": 866,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 35,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "07.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.12.2021",
+        "Fallzahl": 71015,
+        "ObjectId": 1339,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1354,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639008000000,
+        "F\u00e4lle_Meldedatum": 892,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 20,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 7,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "08.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.12.2021",
+        "Fallzahl": 72011,
+        "ObjectId": 1340,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 971,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639094400000,
+        "F\u00e4lle_Meldedatum": 789,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 21,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 8,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "09.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.12.2021",
+        "Fallzahl": 73047,
+        "ObjectId": 1341,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1045,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639180800000,
+        "F\u00e4lle_Meldedatum": 481,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "10.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.12.2021",
+        "Fallzahl": 73062,
+        "ObjectId": 1342,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 284,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639267200000,
+        "F\u00e4lle_Meldedatum": 156,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.12.2021",
+        "Fallzahl": 73310,
+        "ObjectId": 1343,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 815,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639353600000,
+        "F\u00e4lle_Meldedatum": 864,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 28,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 8,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "12.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.12.2021",
+        "Fallzahl": 74391,
+        "ObjectId": 1344,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1283,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639440000000,
+        "F\u00e4lle_Meldedatum": 1057,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 24,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 9,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "13.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.12.2021",
+        "Fallzahl": 75332,
+        "ObjectId": 1345,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1087,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639526400000,
+        "F\u00e4lle_Meldedatum": 689,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 22,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "14.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.12.2021",
+        "Fallzahl": 76121,
+        "ObjectId": 1346,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 860,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639612800000,
+        "F\u00e4lle_Meldedatum": 764,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "15.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.12.2021",
+        "Fallzahl": 76854,
+        "ObjectId": 1347,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1158,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639699200000,
+        "F\u00e4lle_Meldedatum": 541,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 22,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 8,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "16.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.12.2021",
+        "Fallzahl": 77085,
+        "ObjectId": 1348,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 621,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639785600000,
+        "F\u00e4lle_Meldedatum": 207,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.12.2021",
+        "Fallzahl": 77178,
+        "ObjectId": 1349,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 208,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639872000000,
+        "F\u00e4lle_Meldedatum": 179,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.12.2021",
+        "Fallzahl": 77741,
+        "ObjectId": 1350,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 918,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1639958400000,
+        "F\u00e4lle_Meldedatum": 552,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 44,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.12.2021",
+        "Fallzahl": 78493,
+        "ObjectId": 1351,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1213,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640044800000,
+        "F\u00e4lle_Meldedatum": 937,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 34,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "20.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.12.2021",
+        "Fallzahl": 79472,
+        "ObjectId": 1352,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 834,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640131200000,
+        "F\u00e4lle_Meldedatum": 425,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 22,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.12.2021",
+        "Fallzahl": 79939,
+        "ObjectId": 1353,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 906,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640217600000,
+        "F\u00e4lle_Meldedatum": 402,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 5,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.12.2021",
+        "Fallzahl": 80410,
+        "ObjectId": 1354,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 801,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640304000000,
+        "F\u00e4lle_Meldedatum": 189,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.12.2021",
+        "Fallzahl": 80512,
+        "ObjectId": 1355,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 495,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640390400000,
+        "F\u00e4lle_Meldedatum": 113,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "24.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.12.2021",
+        "Fallzahl": 80554,
+        "ObjectId": 1356,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 169,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640476800000,
+        "F\u00e4lle_Meldedatum": 124,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.12.2021",
+        "Fallzahl": 80663,
+        "ObjectId": 1357,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 821,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640563200000,
+        "F\u00e4lle_Meldedatum": 541,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 24,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.12.2021",
+        "Fallzahl": 81370,
+        "ObjectId": 1358,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1022,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640649600000,
+        "F\u00e4lle_Meldedatum": 486,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 23,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.12.2021",
+        "Fallzahl": 81838,
+        "ObjectId": 1359,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 679,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640736000000,
+        "F\u00e4lle_Meldedatum": 327,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 6,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "28.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.12.2021",
+        "Fallzahl": 82168,
+        "ObjectId": 1360,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 773,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640822400000,
+        "F\u00e4lle_Meldedatum": 415,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "29.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.12.2021",
+        "Fallzahl": 82679,
+        "ObjectId": 1361,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 542,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640908800000,
+        "F\u00e4lle_Meldedatum": 131,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.01.2022",
+        "Fallzahl": 82811,
+        "ObjectId": 1362,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 226,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1640995200000,
+        "F\u00e4lle_Meldedatum": 157,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "31.12.2021"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.01.2022",
+        "Fallzahl": 82822,
+        "ObjectId": 1363,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 189,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641081600000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "01.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.01.2022",
+        "Fallzahl": 82900,
+        "ObjectId": 1364,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 504,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641168000000,
+        "F\u00e4lle_Meldedatum": 656,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 28,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.01.2022",
+        "Fallzahl": 83653,
+        "ObjectId": 1365,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 905,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641254400000,
+        "F\u00e4lle_Meldedatum": 530,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "03.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.01.2022",
+        "Fallzahl": 84215,
+        "ObjectId": 1366,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 442,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641340800000,
+        "F\u00e4lle_Meldedatum": 337,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 5,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.01.2022",
+        "Fallzahl": 84571,
+        "ObjectId": 1367,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 410,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641427200000,
+        "F\u00e4lle_Meldedatum": 310,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "05.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.01.2022",
+        "Fallzahl": 84855,
+        "ObjectId": 1368,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 210,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641513600000,
+        "F\u00e4lle_Meldedatum": 239,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 5,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "06.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.01.2022",
+        "Fallzahl": 85188,
+        "ObjectId": 1369,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 126,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641600000000,
+        "F\u00e4lle_Meldedatum": 145,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "07.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.01.2022",
+        "Fallzahl": 85222,
+        "ObjectId": 1370,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 135,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641686400000,
+        "F\u00e4lle_Meldedatum": 80,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "08.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.01.2022",
+        "Fallzahl": 85264,
+        "ObjectId": 1371,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 521,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641772800000,
+        "F\u00e4lle_Meldedatum": 414,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 20,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "09.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.01.2022",
+        "Fallzahl": 85625,
+        "ObjectId": 1372,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 467,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641859200000,
+        "F\u00e4lle_Meldedatum": 357,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 4,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "10.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.01.2022",
+        "Fallzahl": 85901,
+        "ObjectId": 1373,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 335,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1641945600000,
+        "F\u00e4lle_Meldedatum": 353,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.01.2022",
+        "Fallzahl": 86237,
+        "ObjectId": 1374,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 411,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642032000000,
+        "F\u00e4lle_Meldedatum": 298,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "12.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.01.2022",
+        "Fallzahl": 86892,
+        "ObjectId": 1375,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 145,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642118400000,
+        "F\u00e4lle_Meldedatum": 369,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "13.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.01.2022",
+        "Fallzahl": 87066,
+        "ObjectId": 1376,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 167,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642204800000,
+        "F\u00e4lle_Meldedatum": 213,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 3,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "14.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.01.2022",
+        "Fallzahl": 87099,
+        "ObjectId": 1377,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 70,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642291200000,
+        "F\u00e4lle_Meldedatum": 134,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "15.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.01.2022",
+        "Fallzahl": 87192,
+        "ObjectId": 1378,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 881,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642377600000,
+        "F\u00e4lle_Meldedatum": 700,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "16.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.01.2022",
+        "Fallzahl": 87980,
+        "ObjectId": 1379,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 510,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642464000000,
+        "F\u00e4lle_Meldedatum": 690,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.01.2022",
+        "Fallzahl": 88676,
+        "ObjectId": 1380,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 359,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642550400000,
+        "F\u00e4lle_Meldedatum": 688,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 7,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.01.2022",
+        "Fallzahl": 89417,
+        "ObjectId": 1381,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 329,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642636800000,
+        "F\u00e4lle_Meldedatum": 622,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.01.2022",
+        "Fallzahl": 90001,
+        "ObjectId": 1382,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 250,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642723200000,
+        "F\u00e4lle_Meldedatum": 527,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "20.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.01.2022",
+        "Fallzahl": 90619,
+        "ObjectId": 1383,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 151,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642809600000,
+        "F\u00e4lle_Meldedatum": 300,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.01.2022",
+        "Fallzahl": 90663,
+        "ObjectId": 1384,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 80,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1642896000000,
+        "F\u00e4lle_Meldedatum": 197,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.01.2022",
+        "Fallzahl": 90911,
+        "ObjectId": 1385,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 400,
+        "BelegteBetten": null,
+        "Inzidenz": 634.361866446352,
+        "Datum_neu": 1642982400000,
+        "F\u00e4lle_Meldedatum": 1173,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": 601.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 353,
+        "Krh_I_belegt": 212,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.31,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.01.2022",
+        "Fallzahl": 92315,
+        "ObjectId": 1386,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 359,
+        "BelegteBetten": null,
+        "Inzidenz": 714.824526743058,
+        "Datum_neu": 1643068800000,
+        "F\u00e4lle_Meldedatum": 1317,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 525,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 372,
+        "Krh_I_belegt": 211,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.49,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "24.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.01.2022",
+        "Fallzahl": 93539,
+        "ObjectId": 1387,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 370,
+        "BelegteBetten": null,
+        "Inzidenz": 827.256726175509,
+        "Datum_neu": 1643155200000,
+        "F\u00e4lle_Meldedatum": 1132,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": 682.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 390,
+        "Krh_I_belegt": 206,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.44,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.01.2022",
+        "Fallzahl": 94709,
+        "ObjectId": 1388,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 315,
+        "BelegteBetten": null,
+        "Inzidenz": 909.695032149143,
+        "Datum_neu": 1643241600000,
+        "F\u00e4lle_Meldedatum": 917,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": 757.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 393,
+        "Krh_I_belegt": 203,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.39,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.01.2022",
+        "Fallzahl": 95628,
+        "ObjectId": 1389,
+        "Sterbefall": 1561,
+        "Genesungsfall": 85266,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 4320,
+        "Zuwachs_Fallzahl": 919,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 364,
+        "BelegteBetten": null,
+        "Inzidenz": 999.13790006825,
+        "Datum_neu": 1643328000000,
+        "F\u00e4lle_Meldedatum": 951,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": 852.7,
+        "Fallzahl_aktiv": 8801,
+        "Krh_N_belegt": 382,
+        "Krh_I_belegt": 192,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 549,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.17,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.01.2022",
+        "Fallzahl": 96608,
+        "ObjectId": 1390,
+        "Sterbefall": null,
+        "Genesungsfall": 85494,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 228,
+        "BelegteBetten": null,
+        "Inzidenz": 1075.2900607062,
+        "Datum_neu": 1643414400000,
+        "F\u00e4lle_Meldedatum": 366,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 932.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 366,
+        "Krh_I_belegt": 168,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "28.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.01.2022",
+        "Fallzahl": 96610,
+        "ObjectId": 1391,
+        "Sterbefall": null,
+        "Genesungsfall": 85628,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 134,
+        "BelegteBetten": null,
+        "Inzidenz": 1087.14393476777,
+        "Datum_neu": 1643500800000,
+        "F\u00e4lle_Meldedatum": 136,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 947.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 361,
+        "Krh_I_belegt": 167,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.57,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "29.01.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.01.2022",
+        "Fallzahl": 97108,
+        "ObjectId": 1392,
+        "Sterbefall": 1562,
+        "Genesungsfall": 86324,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4336,
+        "Zuwachs_Fallzahl": 1480,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 696,
+        "BelegteBetten": null,
+        "Inzidenz": 1076.18808146844,
+        "Datum_neu": 1643587200000,
+        "F\u00e4lle_Meldedatum": 62,
+        "Zeitraum": "24.01.2022 - 30.01.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 999.4,
+        "Fallzahl_aktiv": 9222,
+        "Krh_N_belegt": 361,
+        "Krh_I_belegt": 167,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 783,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1755,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.33,
+        "H_Zeitraum": "24.01.2022 - 30.01.2022",
+        "H_Datum": "30.01.2022",
+        "Datum_Bett": "30.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
