### PR TITLE
New data set: 2022-02-01T112003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-01-31T112603Z.json
+pjson/2022-02-01T112003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-01-31T112603Z.json pjson/2022-02-01T112003Z.json```:
```
--- pjson/2022-01-31T112603Z.json	2022-01-31 11:26:03.940307969 +0000
+++ pjson/2022-02-01T112003Z.json	2022-02-01 11:20:04.136007230 +0000
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1085,
+        "F\u00e4lle_Meldedatum": 1086,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 982,
+        "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
         "Hosp_Meldedatum": 43,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25422,7 +25422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 486,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25510,7 +25510,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25574,7 +25574,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 656,
+        "F\u00e4lle_Meldedatum": 657,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25878,7 +25878,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25916,7 +25916,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 414,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -26042,7 +26042,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26222,7 +26222,7 @@
         "Datum_neu": 1642464000000,
         "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26384,7 +26384,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26410,7 +26410,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642896000000,
-        "F\u00e4lle_Meldedatum": 197,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26446,15 +26446,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 400,
         "BelegteBetten": null,
-        "Inzidenz": 634.361866446352,
+        "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1173,
+        "F\u00e4lle_Meldedatum": 1174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 601.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 353,
-        "Krh_I_belegt": 212,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26464,7 +26464,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2022"
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": 714.824526743058,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1317,
+        "F\u00e4lle_Meldedatum": 1320,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 525,
@@ -26502,7 +26502,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.49,
+        "H_Inzidenz": 4.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2022"
@@ -26524,7 +26524,7 @@
         "BelegteBetten": null,
         "Inzidenz": 827.256726175509,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 1132,
+        "F\u00e4lle_Meldedatum": 1140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 682.5,
@@ -26540,7 +26540,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.44,
+        "H_Inzidenz": 4.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2022"
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": 909.695032149143,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 917,
+        "F\u00e4lle_Meldedatum": 926,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 757.6,
@@ -26578,7 +26578,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.39,
+        "H_Inzidenz": 4.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.01.2022"
@@ -26589,34 +26589,34 @@
         "Datum": "28.01.2022",
         "Fallzahl": 95628,
         "ObjectId": 693,
-        "Sterbefall": 1561,
-        "Genesungsfall": 85266,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4320,
-        "Zuwachs_Fallzahl": 919,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 364,
         "BelegteBetten": null,
         "Inzidenz": 999.13790006825,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 951,
+        "F\u00e4lle_Meldedatum": 987,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 852.7,
-        "Fallzahl_aktiv": 8801,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 382,
         "Krh_I_belegt": 192,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 549,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.17,
+        "H_Inzidenz": 4.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2022"
@@ -26628,7 +26628,7 @@
         "Fallzahl": 96608,
         "ObjectId": 694,
         "Sterbefall": null,
-        "Genesungsfall": 85494,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -26638,9 +26638,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1075.2900607062,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 366,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 932.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 366,
@@ -26654,7 +26654,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": 4.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.01.2022"
@@ -26666,7 +26666,7 @@
         "Fallzahl": 96610,
         "ObjectId": 695,
         "Sterbefall": null,
-        "Genesungsfall": 85628,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -26676,7 +26676,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1087.14393476777,
         "Datum_neu": 1643500800000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 947.6,
@@ -26688,11 +26688,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 4.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.01.2022"
@@ -26705,7 +26705,7 @@
         "ObjectId": 696,
         "Sterbefall": 1562,
         "Genesungsfall": 86324,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4336,
         "Zuwachs_Fallzahl": 1480,
         "Zuwachs_Sterbefall": 1,
@@ -26714,13 +26714,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1076.18808146844,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 62,
-        "Zeitraum": "24.01.2022 - 30.01.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1292,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 999.4,
         "Fallzahl_aktiv": 9222,
-        "Krh_N_belegt": 361,
-        "Krh_I_belegt": 167,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 174,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 783,
         "Krh_I": null,
@@ -26728,13 +26728,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1755,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.33,
-        "H_Zeitraum": "24.01.2022 - 30.01.2022",
-        "H_Datum": "30.01.2022",
+        "H_Inzidenz": 3.92,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "30.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.02.2022",
+        "Fallzahl": 98823,
+        "ObjectId": 697,
+        "Sterbefall": 1567,
+        "Genesungsfall": 87013,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4354,
+        "Zuwachs_Fallzahl": 1715,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 689,
+        "BelegteBetten": null,
+        "Inzidenz": 1128.45288983081,
+        "Datum_neu": 1643673600000,
+        "F\u00e4lle_Meldedatum": 305,
+        "Zeitraum": "25.01.2022 - 31.01.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 905.6,
+        "Fallzahl_aktiv": 10243,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 174,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1021,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 1885,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.16,
+        "H_Zeitraum": "25.01.2022 - 31.01.2022",
+        "H_Datum": "31.01.2022",
+        "Datum_Bett": "31.01.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
