### PR TITLE
New data set: 2022-02-02T112403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-01T112003Z.json
+pjson/2022-02-02T112403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-01T112003Z.json pjson/2022-02-02T112403Z.json```:
```
--- pjson/2022-02-01T112003Z.json	2022-02-01 11:20:04.136007230 +0000
+++ pjson/2022-02-02T112403Z.json	2022-02-02 11:24:03.880833518 +0000
@@ -12084,7 +12084,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610323200000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -12884,7 +12884,7 @@
         "Datum_neu": 1612137600000,
         "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15960,7 +15960,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619136000000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1103,
+        "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1383,
+        "F\u00e4lle_Meldedatum": 1382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24588,7 +24588,7 @@
         "Datum_neu": 1638748800000,
         "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 43,
+        "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 866,
+        "F\u00e4lle_Meldedatum": 867,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 892,
+        "F\u00e4lle_Meldedatum": 891,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 864,
+        "F\u00e4lle_Meldedatum": 865,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -25386,7 +25386,7 @@
         "Datum_neu": 1640563200000,
         "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25424,7 +25424,7 @@
         "Datum_neu": 1640649600000,
         "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25574,9 +25574,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 161,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 657,
+        "F\u00e4lle_Meldedatum": 656,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 690,
+        "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26296,7 +26296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 622,
+        "F\u00e4lle_Meldedatum": 624,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1174,
+        "F\u00e4lle_Meldedatum": 1173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26484,15 +26484,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 359,
         "BelegteBetten": null,
-        "Inzidenz": 714.824526743058,
+        "Inzidenz": null,
         "Datum_neu": 1643068800000,
         "F\u00e4lle_Meldedatum": 1320,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 525,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 372,
-        "Krh_I_belegt": 211,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26502,7 +26502,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2022"
@@ -26524,7 +26524,7 @@
         "BelegteBetten": null,
         "Inzidenz": 827.256726175509,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 1140,
+        "F\u00e4lle_Meldedatum": 1143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 682.5,
@@ -26540,7 +26540,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.61,
+        "H_Inzidenz": 4.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2022"
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": 909.695032149143,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 926,
+        "F\u00e4lle_Meldedatum": 929,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 757.6,
@@ -26578,7 +26578,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": 4.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.01.2022"
@@ -26600,9 +26600,9 @@
         "BelegteBetten": null,
         "Inzidenz": 999.13790006825,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 987,
+        "F\u00e4lle_Meldedatum": 1000,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 852.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 382,
@@ -26616,7 +26616,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.34,
+        "H_Inzidenz": 4.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2022"
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1075.2900607062,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 422,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 932.2,
@@ -26654,7 +26654,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.14,
+        "H_Inzidenz": 4.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.01.2022"
@@ -26676,7 +26676,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1087.14393476777,
         "Datum_neu": 1643500800000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 947.6,
@@ -26692,7 +26692,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
+        "H_Inzidenz": 4.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.01.2022"
@@ -26703,34 +26703,34 @@
         "Datum": "31.01.2022",
         "Fallzahl": 97108,
         "ObjectId": 696,
-        "Sterbefall": 1562,
-        "Genesungsfall": 86324,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4336,
-        "Zuwachs_Fallzahl": 1480,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 696,
         "BelegteBetten": null,
         "Inzidenz": 1076.18808146844,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1292,
+        "F\u00e4lle_Meldedatum": 1463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 999.4,
-        "Fallzahl_aktiv": 9222,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 401,
         "Krh_I_belegt": 174,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 783,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
+        "H_Inzidenz": 4.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.01.2022"
@@ -26743,7 +26743,7 @@
         "ObjectId": 697,
         "Sterbefall": 1567,
         "Genesungsfall": 87013,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4354,
         "Zuwachs_Fallzahl": 1715,
         "Zuwachs_Sterbefall": 5,
@@ -26752,13 +26752,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1128.45288983081,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 305,
-        "Zeitraum": "25.01.2022 - 31.01.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 1471,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 905.6,
         "Fallzahl_aktiv": 10243,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 174,
+        "Krh_N_belegt": 419,
+        "Krh_I_belegt": 154,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 1021,
         "Krh_I": null,
@@ -26766,13 +26766,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 1885,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.16,
-        "H_Zeitraum": "25.01.2022 - 31.01.2022",
-        "H_Datum": "31.01.2022",
+        "H_Inzidenz": 4.07,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "31.01.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "02.02.2022",
+        "Fallzahl": 100400,
+        "ObjectId": 698,
+        "Sterbefall": 1567,
+        "Genesungsfall": 87727,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4366,
+        "Zuwachs_Fallzahl": 1577,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 714,
+        "BelegteBetten": null,
+        "Inzidenz": 1196.52286360861,
+        "Datum_neu": 1643760000000,
+        "F\u00e4lle_Meldedatum": 175,
+        "Zeitraum": "26.01.2022 - 01.02.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1019.5,
+        "Fallzahl_aktiv": 11106,
+        "Krh_N_belegt": 419,
+        "Krh_I_belegt": 154,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 863,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2010,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.43,
+        "H_Zeitraum": "26.01.2022 - 01.02.2022",
+        "H_Datum": "01.02.2022",
+        "Datum_Bett": "01.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
