### PR TITLE
New data set: 2022-02-03T112004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-02T112403Z.json
+pjson/2022-02-03T112004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-02T112403Z.json pjson/2022-02-03T112004Z.json```:
```
--- pjson/2022-02-02T112403Z.json	2022-02-02 11:24:03.880833518 +0000
+++ pjson/2022-02-03T112004Z.json	2022-02-03 11:20:04.370941823 +0000
@@ -12160,7 +12160,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1038,
+        "F\u00e4lle_Meldedatum": 1037,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1147,
+        "F\u00e4lle_Meldedatum": 1148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1569,
+        "F\u00e4lle_Meldedatum": 1570,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 891,
+        "F\u00e4lle_Meldedatum": 890,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 865,
+        "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1057,
+        "F\u00e4lle_Meldedatum": 1056,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -25574,7 +25574,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640995200000,
-        "F\u00e4lle_Meldedatum": 161,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 352,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26068,7 +26068,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26182,7 +26182,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 700,
+        "F\u00e4lle_Meldedatum": 701,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 692,
+        "F\u00e4lle_Meldedatum": 693,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 688,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26410,7 +26410,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642896000000,
-        "F\u00e4lle_Meldedatum": 198,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1173,
+        "F\u00e4lle_Meldedatum": 1171,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1320,
+        "F\u00e4lle_Meldedatum": 1323,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -26522,15 +26522,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 370,
         "BelegteBetten": null,
-        "Inzidenz": 827.256726175509,
+        "Inzidenz": null,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 1143,
+        "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 682.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 390,
-        "Krh_I_belegt": 206,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26540,7 +26540,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2022"
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": 909.695032149143,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 929,
+        "F\u00e4lle_Meldedatum": 934,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 757.6,
@@ -26578,7 +26578,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.73,
+        "H_Inzidenz": 4.83,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.01.2022"
@@ -26616,7 +26616,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.54,
+        "H_Inzidenz": 4.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2022"
@@ -26654,7 +26654,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.01.2022"
@@ -26676,7 +26676,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1087.14393476777,
         "Datum_neu": 1643500800000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 947.6,
@@ -26692,7 +26692,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.01.2022"
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1076.18808146844,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1463,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 999.4,
@@ -26730,7 +26730,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 4.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.01.2022"
@@ -26741,34 +26741,34 @@
         "Datum": "01.02.2022",
         "Fallzahl": 98823,
         "ObjectId": 697,
-        "Sterbefall": 1567,
-        "Genesungsfall": 87013,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4354,
-        "Zuwachs_Fallzahl": 1715,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 689,
         "BelegteBetten": null,
         "Inzidenz": 1128.45288983081,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1471,
+        "F\u00e4lle_Meldedatum": 1632,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 905.6,
-        "Fallzahl_aktiv": 10243,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 419,
         "Krh_I_belegt": 154,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1021,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
+        "H_Inzidenz": 4.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.01.2022"
@@ -26781,7 +26781,7 @@
         "ObjectId": 698,
         "Sterbefall": 1567,
         "Genesungsfall": 87727,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4366,
         "Zuwachs_Fallzahl": 1577,
         "Zuwachs_Sterbefall": 0,
@@ -26790,13 +26790,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1196.52286360861,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 175,
-        "Zeitraum": "26.01.2022 - 01.02.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1166,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 1019.5,
         "Fallzahl_aktiv": 11106,
         "Krh_N_belegt": 419,
-        "Krh_I_belegt": 154,
+        "Krh_I_belegt": 148,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 863,
         "Krh_I": null,
@@ -26804,13 +26804,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2010,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.43,
-        "H_Zeitraum": "26.01.2022 - 01.02.2022",
-        "H_Datum": "01.02.2022",
+        "H_Inzidenz": 4.24,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.02.2022",
+        "Fallzahl": 101789,
+        "ObjectId": 699,
+        "Sterbefall": 1567,
+        "Genesungsfall": 88355,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4376,
+        "Zuwachs_Fallzahl": 1389,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 628,
+        "BelegteBetten": null,
+        "Inzidenz": 1234.95815223248,
+        "Datum_neu": 1643846400000,
+        "F\u00e4lle_Meldedatum": 201,
+        "Zeitraum": "27.01.2022 - 02.02.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1041.5,
+        "Fallzahl_aktiv": 11867,
+        "Krh_N_belegt": 419,
+        "Krh_I_belegt": 148,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 761,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2177,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.62,
+        "H_Zeitraum": "27.01.2022 - 02.02.2022",
+        "H_Datum": "02.02.2022",
+        "Datum_Bett": "02.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
