### PR TITLE
New data set: 2022-02-04T113103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-03T112004Z.json
+pjson/2022-02-04T113103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-03T112004Z.json pjson/2022-02-04T113103Z.json```:
```
--- pjson/2022-02-03T112004Z.json	2022-02-03 11:20:04.370941823 +0000
+++ pjson/2022-02-04T113103Z.json	2022-02-04 11:31:04.089931771 +0000
@@ -12160,7 +12160,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610496000000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -14680,7 +14680,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22648,7 +22648,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634342400000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1661,
+        "F\u00e4lle_Meldedatum": 1662,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24510,7 +24510,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638576000000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1251,
+        "F\u00e4lle_Meldedatum": 1252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24662,7 +24662,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638921600000,
-        "F\u00e4lle_Meldedatum": 867,
+        "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 764,
+        "F\u00e4lle_Meldedatum": 763,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 938,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 425,
+        "F\u00e4lle_Meldedatum": 424,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -25612,7 +25612,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 336,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25916,7 +25916,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 352,
+        "F\u00e4lle_Meldedatum": 351,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26068,7 +26068,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 370,
+        "F\u00e4lle_Meldedatum": 371,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26232,7 +26232,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26296,7 +26296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 624,
+        "F\u00e4lle_Meldedatum": 622,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 529,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1171,
+        "F\u00e4lle_Meldedatum": 1170,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26536,7 +26536,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26560,15 +26560,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 315,
         "BelegteBetten": null,
-        "Inzidenz": 909.695032149143,
+        "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 934,
+        "F\u00e4lle_Meldedatum": 932,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 757.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 393,
-        "Krh_I_belegt": 203,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26578,7 +26578,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.83,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.01.2022"
@@ -26616,7 +26616,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.66,
+        "H_Inzidenz": 4.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2022"
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1075.2900607062,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 422,
+        "F\u00e4lle_Meldedatum": 423,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 932.2,
@@ -26654,7 +26654,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 4.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.01.2022"
@@ -26692,7 +26692,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 4.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.01.2022"
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1076.18808146844,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1493,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 999.4,
@@ -26730,7 +26730,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": 4.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.01.2022"
@@ -26752,9 +26752,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1128.45288983081,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1632,
+        "F\u00e4lle_Meldedatum": 1653,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 905.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 419,
@@ -26768,7 +26768,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.39,
+        "H_Inzidenz": 4.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.01.2022"
@@ -26779,34 +26779,34 @@
         "Datum": "02.02.2022",
         "Fallzahl": 100400,
         "ObjectId": 698,
-        "Sterbefall": 1567,
-        "Genesungsfall": 87727,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4366,
-        "Zuwachs_Fallzahl": 1577,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 714,
         "BelegteBetten": null,
         "Inzidenz": 1196.52286360861,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1166,
+        "F\u00e4lle_Meldedatum": 1304,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1019.5,
-        "Fallzahl_aktiv": 11106,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 419,
         "Krh_I_belegt": 148,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 863,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.24,
+        "H_Inzidenz": 4.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.02.2022"
@@ -26819,7 +26819,7 @@
         "ObjectId": 699,
         "Sterbefall": 1567,
         "Genesungsfall": 88355,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4376,
         "Zuwachs_Fallzahl": 1389,
         "Zuwachs_Sterbefall": 0,
@@ -26828,13 +26828,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1234.95815223248,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 201,
-        "Zeitraum": "27.01.2022 - 02.02.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1129,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1041.5,
         "Fallzahl_aktiv": 11867,
-        "Krh_N_belegt": 419,
-        "Krh_I_belegt": 148,
+        "Krh_N_belegt": 437,
+        "Krh_I_belegt": 134,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 761,
         "Krh_I": null,
@@ -26842,13 +26842,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2177,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.62,
-        "H_Zeitraum": "27.01.2022 - 02.02.2022",
-        "H_Datum": "02.02.2022",
+        "H_Inzidenz": 4.71,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.02.2022",
+        "Fallzahl": 102966,
+        "ObjectId": 700,
+        "Sterbefall": 1568,
+        "Genesungsfall": 88892,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4384,
+        "Zuwachs_Fallzahl": 1177,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 537,
+        "BelegteBetten": null,
+        "Inzidenz": 1300.513667876,
+        "Datum_neu": 1643932800000,
+        "F\u00e4lle_Meldedatum": 90,
+        "Zeitraum": "28.01.2022 - 03.02.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1157.4,
+        "Fallzahl_aktiv": 12506,
+        "Krh_N_belegt": 437,
+        "Krh_I_belegt": 134,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 639,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2372,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.31,
+        "H_Zeitraum": "28.01.2022 - 03.02.2022",
+        "H_Datum": "03.02.2022",
+        "Datum_Bett": "03.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
