### PR TITLE
New data set: 2022-02-07T112403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-04T113103Z.json
+pjson/2022-02-07T112403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-04T113103Z.json pjson/2022-02-07T112403Z.json```:
```
--- pjson/2022-02-04T113103Z.json	2022-02-04 11:31:04.089931771 +0000
+++ pjson/2022-02-07T112403Z.json	2022-02-07 11:24:03.648340251 +0000
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1116,
+        "F\u00e4lle_Meldedatum": 1117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1252,
+        "F\u00e4lle_Meldedatum": 1253,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 890,
+        "F\u00e4lle_Meldedatum": 889,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 481,
+        "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 763,
+        "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 938,
+        "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 336,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 354,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 531,
+        "F\u00e4lle_Meldedatum": 532,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26372,7 +26372,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 300,
+        "F\u00e4lle_Meldedatum": 301,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1323,
+        "F\u00e4lle_Meldedatum": 1322,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -26524,7 +26524,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 1145,
+        "F\u00e4lle_Meldedatum": 1144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 932,
+        "F\u00e4lle_Meldedatum": 934,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26598,15 +26598,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 364,
         "BelegteBetten": null,
-        "Inzidenz": 999.13790006825,
+        "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1000,
+        "F\u00e4lle_Meldedatum": 1001,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 852.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 382,
-        "Krh_I_belegt": 192,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26616,7 +26616,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2022"
@@ -26636,15 +26636,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 228,
         "BelegteBetten": null,
-        "Inzidenz": 1075.2900607062,
+        "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 423,
+        "F\u00e4lle_Meldedatum": 424,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 932.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 366,
-        "Krh_I_belegt": 168,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26654,7 +26654,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.01.2022"
@@ -26674,15 +26674,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 134,
         "BelegteBetten": null,
-        "Inzidenz": 1087.14393476777,
+        "Inzidenz": null,
         "Datum_neu": 1643500800000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 947.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 361,
-        "Krh_I_belegt": 167,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26692,7 +26692,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.01.2022"
@@ -26714,9 +26714,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1076.18808146844,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1493,
+        "F\u00e4lle_Meldedatum": 1501,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 999.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 401,
@@ -26730,7 +26730,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.71,
+        "H_Inzidenz": 4.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.01.2022"
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1128.45288983081,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1653,
+        "F\u00e4lle_Meldedatum": 1662,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 905.6,
@@ -26768,7 +26768,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.61,
+        "H_Inzidenz": 4.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.01.2022"
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1196.52286360861,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1304,
+        "F\u00e4lle_Meldedatum": 1332,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1019.5,
@@ -26806,7 +26806,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.71,
+        "H_Inzidenz": 5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.02.2022"
@@ -26817,34 +26817,34 @@
         "Datum": "03.02.2022",
         "Fallzahl": 101789,
         "ObjectId": 699,
-        "Sterbefall": 1567,
-        "Genesungsfall": 88355,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4376,
-        "Zuwachs_Fallzahl": 1389,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 628,
         "BelegteBetten": null,
         "Inzidenz": 1234.95815223248,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1129,
+        "F\u00e4lle_Meldedatum": 1228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1041.5,
-        "Fallzahl_aktiv": 11867,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 437,
         "Krh_I_belegt": 134,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 761,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.71,
+        "H_Inzidenz": 5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.02.2022"
@@ -26856,8 +26856,8 @@
         "Fallzahl": 102966,
         "ObjectId": 700,
         "Sterbefall": 1568,
-        "Genesungsfall": 88892,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 88900,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4384,
         "Zuwachs_Fallzahl": 1177,
         "Zuwachs_Sterbefall": 1,
@@ -26866,13 +26866,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1300.513667876,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 90,
-        "Zeitraum": "28.01.2022 - 03.02.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 966,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1157.4,
-        "Fallzahl_aktiv": 12506,
-        "Krh_N_belegt": 437,
-        "Krh_I_belegt": 134,
+        "Fallzahl_aktiv": 12498,
+        "Krh_N_belegt": 457,
+        "Krh_I_belegt": 138,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 639,
         "Krh_I": null,
@@ -26880,13 +26880,127 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2372,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
-        "H_Zeitraum": "28.01.2022 - 03.02.2022",
-        "H_Datum": "03.02.2022",
+        "H_Inzidenz": 5.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.02.2022",
+        "Fallzahl": 103981,
+        "ObjectId": 701,
+        "Sterbefall": null,
+        "Genesungsfall": 89207,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 307,
+        "BelegteBetten": null,
+        "Inzidenz": 1137.07388914832,
+        "Datum_neu": 1644019200000,
+        "F\u00e4lle_Meldedatum": 382,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1167.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 454,
+        "Krh_I_belegt": 135,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.98,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.02.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.02.2022",
+        "Fallzahl": 104010,
+        "ObjectId": 702,
+        "Sterbefall": null,
+        "Genesungsfall": 89410,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 203,
+        "BelegteBetten": null,
+        "Inzidenz": 1077.44531053558,
+        "Datum_neu": 1644105600000,
+        "F\u00e4lle_Meldedatum": 181,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1150.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 466,
+        "Krh_I_belegt": 139,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.63,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "05.02.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.02.2022",
+        "Fallzahl": 104617,
+        "ObjectId": 703,
+        "Sterbefall": 1568,
+        "Genesungsfall": 90571,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4392,
+        "Zuwachs_Fallzahl": 1651,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 1161,
+        "BelegteBetten": null,
+        "Inzidenz": 1302.48931355293,
+        "Datum_neu": 1644192000000,
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": "31.01.2022 - 06.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1207.6,
+        "Fallzahl_aktiv": 12478,
+        "Krh_N_belegt": 466,
+        "Krh_I_belegt": 139,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 490,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2537,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.31,
+        "H_Zeitraum": "31.01.2022 - 06.02.2022",
+        "H_Datum": "06.02.2022",
+        "Datum_Bett": "06.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
