### PR TITLE
New data set: 2022-02-08T112303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-07T112403Z.json
+pjson/2022-02-08T112303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-07T112403Z.json pjson/2022-02-08T112303Z.json```:
```
--- pjson/2022-02-07T112403Z.json	2022-02-07 11:24:03.648340251 +0000
+++ pjson/2022-02-08T112303Z.json	2022-02-08 11:23:03.481153358 +0000
@@ -25612,7 +25612,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 338,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 351,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26068,7 +26068,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 371,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 532,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26372,7 +26372,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 301,
+        "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26486,9 +26486,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1322,
+        "F\u00e4lle_Meldedatum": 1321,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 934,
+        "F\u00e4lle_Meldedatum": 935,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 424,
+        "F\u00e4lle_Meldedatum": 426,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26676,7 +26676,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643500800000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26712,15 +26712,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 696,
         "BelegteBetten": null,
-        "Inzidenz": 1076.18808146844,
+        "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1501,
+        "F\u00e4lle_Meldedatum": 1499,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 999.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 174,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26730,7 +26730,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.93,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.01.2022"
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1128.45288983081,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1662,
+        "F\u00e4lle_Meldedatum": 1666,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 905.6,
@@ -26768,7 +26768,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.91,
+        "H_Inzidenz": 5.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.01.2022"
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1196.52286360861,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1332,
+        "F\u00e4lle_Meldedatum": 1341,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1019.5,
@@ -26806,7 +26806,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5,
+        "H_Inzidenz": 5.2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.02.2022"
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1234.95815223248,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1228,
+        "F\u00e4lle_Meldedatum": 1243,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1041.5,
@@ -26844,7 +26844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5,
+        "H_Inzidenz": 5.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.02.2022"
@@ -26855,34 +26855,34 @@
         "Datum": "04.02.2022",
         "Fallzahl": 102966,
         "ObjectId": 700,
-        "Sterbefall": 1568,
-        "Genesungsfall": 88900,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4384,
-        "Zuwachs_Fallzahl": 1177,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 537,
         "BelegteBetten": null,
         "Inzidenz": 1300.513667876,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 966,
+        "F\u00e4lle_Meldedatum": 1087,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1157.4,
-        "Fallzahl_aktiv": 12498,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 457,
         "Krh_I_belegt": 138,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 639,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 5.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.02.2022"
@@ -26894,7 +26894,7 @@
         "Fallzahl": 103981,
         "ObjectId": 701,
         "Sterbefall": null,
-        "Genesungsfall": 89207,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1137.07388914832,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 382,
+        "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1167.5,
@@ -26920,7 +26920,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.98,
+        "H_Inzidenz": 5.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.02.2022"
@@ -26932,7 +26932,7 @@
         "Fallzahl": 104010,
         "ObjectId": 702,
         "Sterbefall": null,
-        "Genesungsfall": 89410,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -26942,9 +26942,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1077.44531053558,
         "Datum_neu": 1644105600000,
-        "F\u00e4lle_Meldedatum": 181,
+        "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1150.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 466,
@@ -26958,7 +26958,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": 4.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.02.2022"
@@ -26971,7 +26971,7 @@
         "ObjectId": 703,
         "Sterbefall": 1568,
         "Genesungsfall": 90571,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4392,
         "Zuwachs_Fallzahl": 1651,
         "Zuwachs_Sterbefall": 0,
@@ -26980,27 +26980,65 @@
         "BelegteBetten": null,
         "Inzidenz": 1302.48931355293,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 65,
-        "Zeitraum": "31.01.2022 - 06.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1475,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1207.6,
         "Fallzahl_aktiv": 12478,
-        "Krh_N_belegt": 466,
-        "Krh_I_belegt": 139,
+        "Krh_N_belegt": 501,
+        "Krh_I_belegt": 143,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 490,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 2537,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
-        "H_Zeitraum": "31.01.2022 - 06.02.2022",
-        "H_Datum": "06.02.2022",
+        "H_Inzidenz": 4.73,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.02.2022",
+        "Fallzahl": 106623,
+        "ObjectId": 704,
+        "Sterbefall": 1570,
+        "Genesungsfall": 91893,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4405,
+        "Zuwachs_Fallzahl": 2006,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 1322,
+        "BelegteBetten": null,
+        "Inzidenz": 1351.52124717123,
+        "Datum_neu": 1644278400000,
+        "F\u00e4lle_Meldedatum": 297,
+        "Zeitraum": "01.02.2022 - 07.02.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1085.9,
+        "Fallzahl_aktiv": 13160,
+        "Krh_N_belegt": 501,
+        "Krh_I_belegt": 143,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 682,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2690,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.94,
+        "H_Zeitraum": "01.02.2022 - 07.02.2022",
+        "H_Datum": "07.02.2022",
+        "Datum_Bett": "07.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
