### PR TITLE
New data set: 2022-02-09T115603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-08T112303Z.json
+pjson/2022-02-09T115603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-08T112303Z.json pjson/2022-02-09T115603Z.json```:
```
--- pjson/2022-02-08T112303Z.json	2022-02-08 11:23:03.481153358 +0000
+++ pjson/2022-02-09T115603Z.json	2022-02-09 11:56:03.462151056 +0000
@@ -13008,7 +13008,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22116,7 +22116,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22774,7 +22774,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22888,7 +22888,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 228,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1232,
+        "F\u00e4lle_Meldedatum": 1233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 973,
+        "F\u00e4lle_Meldedatum": 974,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1105,
+        "F\u00e4lle_Meldedatum": 1106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -25498,7 +25498,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 415,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -25992,7 +25992,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641945600000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 350,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26182,7 +26182,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 701,
+        "F\u00e4lle_Meldedatum": 700,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 693,
+        "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 685,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26296,7 +26296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 622,
+        "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1170,
+        "F\u00e4lle_Meldedatum": 1171,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1321,
+        "F\u00e4lle_Meldedatum": 1322,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26536,7 +26536,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1001,
+        "F\u00e4lle_Meldedatum": 1004,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26650,7 +26650,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1499,
+        "F\u00e4lle_Meldedatum": 1501,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -26750,15 +26750,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 689,
         "BelegteBetten": null,
-        "Inzidenz": 1128.45288983081,
+        "Inzidenz": null,
         "Datum_neu": 1643673600000,
         "F\u00e4lle_Meldedatum": 1666,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 905.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 419,
-        "Krh_I_belegt": 154,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26768,7 +26768,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.05,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.01.2022"
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1196.52286360861,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1341,
+        "F\u00e4lle_Meldedatum": 1347,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1019.5,
@@ -26806,7 +26806,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.2,
+        "H_Inzidenz": 5.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.02.2022"
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1234.95815223248,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1243,
+        "F\u00e4lle_Meldedatum": 1248,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1041.5,
@@ -26844,7 +26844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 5.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.02.2022"
@@ -26866,9 +26866,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1300.513667876,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1087,
+        "F\u00e4lle_Meldedatum": 1102,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1157.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 457,
@@ -26882,7 +26882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.4,
+        "H_Inzidenz": 5.62,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.02.2022"
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1137.07388914832,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 453,
+        "F\u00e4lle_Meldedatum": 482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1167.5,
@@ -26920,7 +26920,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.25,
+        "H_Inzidenz": 5.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.02.2022"
@@ -26942,7 +26942,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1077.44531053558,
         "Datum_neu": 1644105600000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 290,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1150.2,
@@ -26958,7 +26958,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.93,
+        "H_Inzidenz": 5.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.02.2022"
@@ -26969,34 +26969,34 @@
         "Datum": "07.02.2022",
         "Fallzahl": 104617,
         "ObjectId": 703,
-        "Sterbefall": 1568,
-        "Genesungsfall": 90571,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4392,
-        "Zuwachs_Fallzahl": 1651,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1161,
         "BelegteBetten": null,
         "Inzidenz": 1302.48931355293,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1475,
+        "F\u00e4lle_Meldedatum": 1724,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1207.6,
-        "Fallzahl_aktiv": 12478,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 501,
         "Krh_I_belegt": 143,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 490,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.73,
+        "H_Inzidenz": 4.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.02.2022"
@@ -27009,7 +27009,7 @@
         "ObjectId": 704,
         "Sterbefall": 1570,
         "Genesungsfall": 91893,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4405,
         "Zuwachs_Fallzahl": 2006,
         "Zuwachs_Sterbefall": 2,
@@ -27018,27 +27018,65 @@
         "BelegteBetten": null,
         "Inzidenz": 1351.52124717123,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 297,
-        "Zeitraum": "01.02.2022 - 07.02.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1502,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1085.9,
         "Fallzahl_aktiv": 13160,
-        "Krh_N_belegt": 501,
-        "Krh_I_belegt": 143,
+        "Krh_N_belegt": 555,
+        "Krh_I_belegt": 149,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 682,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
-        "Mutation": 2690,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.94,
-        "H_Zeitraum": "01.02.2022 - 07.02.2022",
-        "H_Datum": "07.02.2022",
+        "H_Inzidenz": 5.37,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.02.2022",
+        "Fallzahl": 108558,
+        "ObjectId": 705,
+        "Sterbefall": 1572,
+        "Genesungsfall": 93048,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4410,
+        "Zuwachs_Fallzahl": 1935,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 1155,
+        "BelegteBetten": null,
+        "Inzidenz": 1382.0539530874,
+        "Datum_neu": 1644364800000,
+        "F\u00e4lle_Meldedatum": 388,
+        "Zeitraum": "02.02.2022 - 08.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1185.8,
+        "Fallzahl_aktiv": 13938,
+        "Krh_N_belegt": 555,
+        "Krh_I_belegt": 149,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 778,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 2869,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.41,
+        "H_Zeitraum": "02.02.2022 - 08.02.2022",
+        "H_Datum": "08.02.2022",
+        "Datum_Bett": "08.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
