### PR TITLE
New data set: 2022-02-10T112303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-09T115603Z.json
+pjson/2022-02-10T112303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-09T115603Z.json pjson/2022-02-10T112303Z.json```:
```
--- pjson/2022-02-09T115603Z.json	2022-02-09 11:56:03.462151056 +0000
+++ pjson/2022-02-10T112303Z.json	2022-02-10 11:23:03.531644427 +0000
@@ -10298,7 +10298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1606262400000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -12996,7 +12996,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1612396800000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -22116,7 +22116,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1633132800000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1233,
+        "F\u00e4lle_Meldedatum": 1232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 974,
+        "F\u00e4lle_Meldedatum": 973,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1480,
+        "F\u00e4lle_Meldedatum": 1481,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1662,
+        "F\u00e4lle_Meldedatum": 1661,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24130,7 +24130,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637712000000,
-        "F\u00e4lle_Meldedatum": 1086,
+        "F\u00e4lle_Meldedatum": 1085,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -25158,7 +25158,7 @@
         "Datum_neu": 1640044800000,
         "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25422,7 +25422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 327,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -25612,7 +25612,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25916,7 +25916,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 410,
+        "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 298,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26068,7 +26068,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642118400000,
-        "F\u00e4lle_Meldedatum": 370,
+        "F\u00e4lle_Meldedatum": 371,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26182,7 +26182,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 700,
+        "F\u00e4lle_Meldedatum": 701,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 685,
+        "F\u00e4lle_Meldedatum": 683,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1004,
+        "F\u00e4lle_Meldedatum": 1005,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 426,
+        "F\u00e4lle_Meldedatum": 427,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26676,7 +26676,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643500800000,
-        "F\u00e4lle_Meldedatum": 242,
+        "F\u00e4lle_Meldedatum": 243,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26788,15 +26788,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 714,
         "BelegteBetten": null,
-        "Inzidenz": 1196.52286360861,
+        "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1347,
+        "F\u00e4lle_Meldedatum": 1350,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 1019.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 419,
-        "Krh_I_belegt": 148,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26806,7 +26806,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.02.2022"
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1234.95815223248,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1248,
+        "F\u00e4lle_Meldedatum": 1254,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1041.5,
@@ -26844,7 +26844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.37,
+        "H_Inzidenz": 5.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.02.2022"
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1300.513667876,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1157.4,
@@ -26882,7 +26882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.62,
+        "H_Inzidenz": 5.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.02.2022"
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1137.07388914832,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 482,
+        "F\u00e4lle_Meldedatum": 487,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1167.5,
@@ -26920,7 +26920,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.67,
+        "H_Inzidenz": 5.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.02.2022"
@@ -26942,7 +26942,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1077.44531053558,
         "Datum_neu": 1644105600000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 295,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1150.2,
@@ -26954,11 +26954,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.55,
+        "H_Inzidenz": 5.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.02.2022"
@@ -26980,9 +26980,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1302.48931355293,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1724,
+        "F\u00e4lle_Meldedatum": 1787,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1207.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 501,
@@ -26996,7 +26996,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 5.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.02.2022"
@@ -27007,34 +27007,34 @@
         "Datum": "08.02.2022",
         "Fallzahl": 106623,
         "ObjectId": 704,
-        "Sterbefall": 1570,
-        "Genesungsfall": 91893,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4405,
-        "Zuwachs_Fallzahl": 2006,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1322,
         "BelegteBetten": null,
         "Inzidenz": 1351.52124717123,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1502,
+        "F\u00e4lle_Meldedatum": 1679,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1085.9,
-        "Fallzahl_aktiv": 13160,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 555,
         "Krh_I_belegt": 149,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 682,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.37,
+        "H_Inzidenz": 5.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.02.2022"
@@ -27046,8 +27046,8 @@
         "Fallzahl": 108558,
         "ObjectId": 705,
         "Sterbefall": 1572,
-        "Genesungsfall": 93048,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 93042,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4410,
         "Zuwachs_Fallzahl": 1935,
         "Zuwachs_Sterbefall": 2,
@@ -27056,13 +27056,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1382.0539530874,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 388,
-        "Zeitraum": "02.02.2022 - 08.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1417,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1185.8,
-        "Fallzahl_aktiv": 13938,
-        "Krh_N_belegt": 555,
-        "Krh_I_belegt": 149,
+        "Fallzahl_aktiv": 13944,
+        "Krh_N_belegt": 600,
+        "Krh_I_belegt": 147,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 778,
         "Krh_I": null,
@@ -27070,13 +27070,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 2869,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
-        "H_Zeitraum": "02.02.2022 - 08.02.2022",
-        "H_Datum": "08.02.2022",
+        "H_Inzidenz": 5.82,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.02.2022",
+        "Fallzahl": 110138,
+        "ObjectId": 706,
+        "Sterbefall": 1573,
+        "Genesungsfall": 93974,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4430,
+        "Zuwachs_Fallzahl": 1580,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 932,
+        "BelegteBetten": null,
+        "Inzidenz": 1440.96411509034,
+        "Datum_neu": 1644451200000,
+        "F\u00e4lle_Meldedatum": 286,
+        "Zeitraum": "03.02.2022 - 09.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1260.3,
+        "Fallzahl_aktiv": 14591,
+        "Krh_N_belegt": 600,
+        "Krh_I_belegt": 147,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 647,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3023,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.1,
+        "H_Zeitraum": "03.02.2022 - 09.02.2022",
+        "H_Datum": "09.02.2023",
+        "Datum_Bett": "09.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
