### PR TITLE
New data set: 2022-02-11T115803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-10T112303Z.json
+pjson/2022-02-11T115803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-10T112303Z.json pjson/2022-02-11T115803Z.json```:
```
--- pjson/2022-02-10T112303Z.json	2022-02-10 11:23:03.531644427 +0000
+++ pjson/2022-02-11T115803Z.json	2022-02-11 11:58:03.821033558 +0000
@@ -11324,7 +11324,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 477,
+        "F\u00e4lle_Meldedatum": 476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1037,
+        "F\u00e4lle_Meldedatum": 1038,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -24320,7 +24320,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638144000000,
-        "F\u00e4lle_Meldedatum": 881,
+        "F\u00e4lle_Meldedatum": 882,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -25384,7 +25384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -25688,7 +25688,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 530,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 692,
+        "F\u00e4lle_Meldedatum": 693,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26296,7 +26296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 621,
+        "F\u00e4lle_Meldedatum": 620,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 531,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26448,9 +26448,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1171,
+        "F\u00e4lle_Meldedatum": 1168,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 935,
+        "F\u00e4lle_Meldedatum": 936,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1501,
+        "F\u00e4lle_Meldedatum": 1502,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1350,
+        "F\u00e4lle_Meldedatum": 1351,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26826,15 +26826,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 628,
         "BelegteBetten": null,
-        "Inzidenz": 1234.95815223248,
+        "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1254,
+        "F\u00e4lle_Meldedatum": 1253,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 1041.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 437,
-        "Krh_I_belegt": 134,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26844,7 +26844,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.02.2022"
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1300.513667876,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1104,
+        "F\u00e4lle_Meldedatum": 1107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1157.4,
@@ -26882,7 +26882,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": 5.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.02.2022"
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1137.07388914832,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 487,
+        "F\u00e4lle_Meldedatum": 490,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1167.5,
@@ -26920,7 +26920,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.84,
+        "H_Inzidenz": 5.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.02.2022"
@@ -26942,7 +26942,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1077.44531053558,
         "Datum_neu": 1644105600000,
-        "F\u00e4lle_Meldedatum": 295,
+        "F\u00e4lle_Meldedatum": 296,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1150.2,
@@ -26958,7 +26958,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.72,
+        "H_Inzidenz": 5.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.02.2022"
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1302.48931355293,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1787,
+        "F\u00e4lle_Meldedatum": 1800,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1207.6,
@@ -26996,7 +26996,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.67,
+        "H_Inzidenz": 5.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.02.2022"
@@ -27018,9 +27018,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1351.52124717123,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1679,
+        "F\u00e4lle_Meldedatum": 1759,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1085.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 555,
@@ -27034,7 +27034,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.99,
+        "H_Inzidenz": 6.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.02.2022"
@@ -27045,34 +27045,34 @@
         "Datum": "09.02.2022",
         "Fallzahl": 108558,
         "ObjectId": 705,
-        "Sterbefall": 1572,
-        "Genesungsfall": 93042,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4410,
-        "Zuwachs_Fallzahl": 1935,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1155,
         "BelegteBetten": null,
         "Inzidenz": 1382.0539530874,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1417,
+        "F\u00e4lle_Meldedatum": 1554,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1185.8,
-        "Fallzahl_aktiv": 13944,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 600,
         "Krh_I_belegt": 147,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 778,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.82,
+        "H_Inzidenz": 6.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.02.2022"
@@ -27085,7 +27085,7 @@
         "ObjectId": 706,
         "Sterbefall": 1573,
         "Genesungsfall": 93974,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4430,
         "Zuwachs_Fallzahl": 1580,
         "Zuwachs_Sterbefall": 1,
@@ -27094,13 +27094,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1440.96411509034,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 286,
-        "Zeitraum": "03.02.2022 - 09.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1126,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1260.3,
         "Fallzahl_aktiv": 14591,
-        "Krh_N_belegt": 600,
-        "Krh_I_belegt": 147,
+        "Krh_N_belegt": 630,
+        "Krh_I_belegt": 144,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 647,
         "Krh_I": null,
@@ -27108,13 +27108,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3023,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.1,
-        "H_Zeitraum": "03.02.2022 - 09.02.2022",
-        "H_Datum": "09.02.2023",
+        "H_Inzidenz": 5.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.02.2022",
+        "Fallzahl": 111327,
+        "ObjectId": 707,
+        "Sterbefall": 1573,
+        "Genesungsfall": 94971,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4439,
+        "Zuwachs_Fallzahl": 1189,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 997,
+        "BelegteBetten": null,
+        "Inzidenz": 1460.54096770717,
+        "Datum_neu": 1644537600000,
+        "F\u00e4lle_Meldedatum": 113,
+        "Zeitraum": "04.02.2022 - 10.02.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1304.1,
+        "Fallzahl_aktiv": 14783,
+        "Krh_N_belegt": 630,
+        "Krh_I_belegt": 144,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 192,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3144,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.05,
+        "H_Zeitraum": "04.02.2022 - 10.02.2022",
+        "H_Datum": "10.02.2022",
+        "Datum_Bett": "10.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
