### PR TITLE
New data set: 2022-02-14T120803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-11T115803Z.json
+pjson/2022-02-14T120803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-14T112702Z.json pjson/2022-02-14T120803Z.json```:
```
--- pjson/2022-02-14T112702Z.json	2022-02-14 11:27:02.667393398 +0000
+++ pjson/2022-02-14T120803Z.json	2022-02-14 12:08:03.650814213 +0000
@@ -27260,7 +27260,7 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3144,
+        "Mutation": 3380,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 5.08,
         "H_Zeitraum": "07.02.2022 - 13.02.2022",
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
