### PR TITLE
New data set: 2022-02-15T115004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-14T120803Z.json
+pjson/2022-02-15T115004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-14T120803Z.json pjson/2022-02-15T115004Z.json```:
```
--- pjson/2022-02-14T120803Z.json	2022-02-14 12:08:03.650814213 +0000
+++ pjson/2022-02-15T115004Z.json	2022-02-15 11:50:04.907065544 +0000
@@ -11286,7 +11286,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608508800000,
-        "F\u00e4lle_Meldedatum": 435,
+        "F\u00e4lle_Meldedatum": 434,
         "Zeitraum": null,
         "Hosp_Meldedatum": 47,
         "Inzidenz_RKI": null,
@@ -11932,7 +11932,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609977600000,
-        "F\u00e4lle_Meldedatum": 264,
+        "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -12198,7 +12198,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610582400000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -13414,7 +13414,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 75,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -16150,7 +16150,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -25612,7 +25612,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 656,
+        "F\u00e4lle_Meldedatum": 657,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -26372,7 +26372,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 301,
+        "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1169,
+        "F\u00e4lle_Meldedatum": 1170,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1320,
+        "F\u00e4lle_Meldedatum": 1319,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26602,7 +26602,7 @@
         "Datum_neu": 1643328000000,
         "F\u00e4lle_Meldedatum": 1005,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1666,
+        "F\u00e4lle_Meldedatum": 1665,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1353,
+        "F\u00e4lle_Meldedatum": 1356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1107,
+        "F\u00e4lle_Meldedatum": 1108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 489,
+        "F\u00e4lle_Meldedatum": 491,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -26978,15 +26978,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1161,
         "BelegteBetten": null,
-        "Inzidenz": 1302.48931355293,
+        "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1805,
+        "F\u00e4lle_Meldedatum": 1806,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 1207.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 501,
-        "Krh_I_belegt": 143,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -26996,7 +26996,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.21,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.02.2022"
@@ -27018,7 +27018,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1351.52124717123,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1780,
+        "F\u00e4lle_Meldedatum": 1779,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1085.9,
@@ -27034,7 +27034,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.7,
+        "H_Inzidenz": 6.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.02.2022"
@@ -27056,9 +27056,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1382.0539530874,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1597,
+        "F\u00e4lle_Meldedatum": 1611,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1185.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 600,
@@ -27072,7 +27072,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
+        "H_Inzidenz": 6.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.02.2022"
@@ -27094,9 +27094,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1440.96411509034,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1289,
+        "F\u00e4lle_Meldedatum": 1333,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1260.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 630,
@@ -27106,11 +27106,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.51,
+        "H_Inzidenz": 6.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.02.2022"
@@ -27121,34 +27121,34 @@
         "Datum": "11.02.2022",
         "Fallzahl": 111327,
         "ObjectId": 707,
-        "Sterbefall": 1573,
-        "Genesungsfall": 94971,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4439,
-        "Zuwachs_Fallzahl": 1189,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 997,
         "BelegteBetten": null,
         "Inzidenz": 1460.54096770717,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 844,
+        "F\u00e4lle_Meldedatum": 942,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1260.3,
-        "Fallzahl_aktiv": 14783,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 635,
         "Krh_I_belegt": 141,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 192,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.21,
+        "H_Inzidenz": 6.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.02.2022"
@@ -27160,7 +27160,7 @@
         "Fallzahl": 112448,
         "ObjectId": 708,
         "Sterbefall": null,
-        "Genesungsfall": 95408,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -27170,9 +27170,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1282.01444017386,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 777,
+        "F\u00e4lle_Meldedatum": 847,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1304.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 613,
@@ -27186,7 +27186,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.72,
+        "H_Inzidenz": 6.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.02.2022"
@@ -27198,7 +27198,7 @@
         "Fallzahl": 112474,
         "ObjectId": 709,
         "Sterbefall": null,
-        "Genesungsfall": 95662,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -27208,9 +27208,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1644710400000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1307.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 620,
@@ -27224,7 +27224,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.45,
+        "H_Inzidenz": 6.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.02.2022"
@@ -27237,7 +27237,7 @@
         "ObjectId": 710,
         "Sterbefall": 1573,
         "Genesungsfall": 97147,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4454,
         "Zuwachs_Fallzahl": 1988,
         "Zuwachs_Sterbefall": 0,
@@ -27246,13 +27246,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1488.37961133661,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 51,
-        "Zeitraum": "07.02.2022 - 13.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1219,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1349.6,
         "Fallzahl_aktiv": 14595,
-        "Krh_N_belegt": 620,
-        "Krh_I_belegt": 153,
+        "Krh_N_belegt": 679,
+        "Krh_I_belegt": 151,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 503,
         "Krh_I": null,
@@ -27260,13 +27260,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3380,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.08,
-        "H_Zeitraum": "07.02.2022 - 13.02.2022",
-        "H_Datum": "13.02.2022",
+        "H_Inzidenz": 6.48,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.02.2022",
+        "Fallzahl": 115148,
+        "ObjectId": 711,
+        "Sterbefall": 1574,
+        "Genesungsfall": 98807,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4482,
+        "Zuwachs_Fallzahl": 1833,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 28,
+        "Zuwachs_Genesung": 1660,
+        "BelegteBetten": null,
+        "Inzidenz": 1440.425302633,
+        "Datum_neu": 1644883200000,
+        "F\u00e4lle_Meldedatum": 340,
+        "Zeitraum": "08.02.2022 - 14.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1229.2,
+        "Fallzahl_aktiv": 14767,
+        "Krh_N_belegt": 679,
+        "Krh_I_belegt": 151,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 172,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3450,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.2,
+        "H_Zeitraum": "08.02.2022 - 14.02.2022",
+        "H_Datum": "14.02.2022",
+        "Datum_Bett": "14.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
