### PR TITLE
New data set: 2022-02-16T114904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-15T115004Z.json
+pjson/2022-02-16T114904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-15T115004Z.json pjson/2022-02-16T114904Z.json```:
```
--- pjson/2022-02-15T115004Z.json	2022-02-15 11:50:04.907065544 +0000
+++ pjson/2022-02-16T114904Z.json	2022-02-16 11:49:04.327928284 +0000
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1106,
+        "F\u00e4lle_Meldedatum": 1105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 936,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1665,
+        "F\u00e4lle_Meldedatum": 1666,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1356,
+        "F\u00e4lle_Meldedatum": 1354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1108,
+        "F\u00e4lle_Meldedatum": 1107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1806,
+        "F\u00e4lle_Meldedatum": 1807,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -27016,15 +27016,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1322,
         "BelegteBetten": null,
-        "Inzidenz": 1351.52124717123,
+        "Inzidenz": null,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1779,
+        "F\u00e4lle_Meldedatum": 1780,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 1085.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 555,
-        "Krh_I_belegt": 149,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27034,7 +27034,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.8,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.02.2022"
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1382.0539530874,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1611,
+        "F\u00e4lle_Meldedatum": 1615,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1185.8,
@@ -27072,7 +27072,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.78,
+        "H_Inzidenz": 6.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.02.2022"
@@ -27094,9 +27094,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1440.96411509034,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1333,
+        "F\u00e4lle_Meldedatum": 1340,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1260.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 630,
@@ -27110,7 +27110,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.75,
+        "H_Inzidenz": 6.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.02.2022"
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1460.54096770717,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 942,
+        "F\u00e4lle_Meldedatum": 953,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1260.3,
@@ -27148,7 +27148,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.56,
+        "H_Inzidenz": 6.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.02.2022"
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1282.01444017386,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 847,
+        "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1304.1,
@@ -27186,7 +27186,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.58,
+        "H_Inzidenz": 7.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.02.2022"
@@ -27208,9 +27208,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1644710400000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1307.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 620,
@@ -27224,7 +27224,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.46,
+        "H_Inzidenz": 7.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.02.2022"
@@ -27235,34 +27235,34 @@
         "Datum": "14.02.2022",
         "Fallzahl": 113315,
         "ObjectId": 710,
-        "Sterbefall": 1573,
-        "Genesungsfall": 97147,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4454,
-        "Zuwachs_Fallzahl": 1988,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1485,
         "BelegteBetten": null,
         "Inzidenz": 1488.37961133661,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1219,
+        "F\u00e4lle_Meldedatum": 1395,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1349.6,
-        "Fallzahl_aktiv": 14595,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 679,
         "Krh_I_belegt": 151,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 503,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
+        "H_Inzidenz": 7.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.02.2022"
@@ -27275,7 +27275,7 @@
         "ObjectId": 711,
         "Sterbefall": 1574,
         "Genesungsfall": 98807,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4482,
         "Zuwachs_Fallzahl": 1833,
         "Zuwachs_Sterbefall": 1,
@@ -27284,13 +27284,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1440.425302633,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 340,
-        "Zeitraum": "08.02.2022 - 14.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1027,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1229.2,
         "Fallzahl_aktiv": 14767,
-        "Krh_N_belegt": 679,
-        "Krh_I_belegt": 151,
+        "Krh_N_belegt": 711,
+        "Krh_I_belegt": 155,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 172,
         "Krh_I": null,
@@ -27298,13 +27298,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3450,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.2,
-        "H_Zeitraum": "08.02.2022 - 14.02.2022",
-        "H_Datum": "14.02.2022",
+        "H_Inzidenz": 6.88,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "14.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.02.2022",
+        "Fallzahl": 116165,
+        "ObjectId": 712,
+        "Sterbefall": 1574,
+        "Genesungsfall": 100155,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4489,
+        "Zuwachs_Fallzahl": 1017,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 1348,
+        "BelegteBetten": null,
+        "Inzidenz": 1346.85153920759,
+        "Datum_neu": 1644969600000,
+        "F\u00e4lle_Meldedatum": 101,
+        "Zeitraum": "09.02.2022 - 15.02.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1229.2,
+        "Fallzahl_aktiv": 14436,
+        "Krh_N_belegt": 711,
+        "Krh_I_belegt": 155,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -331,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3613,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.62,
+        "H_Zeitraum": "09.02.2022 - 15.02.2022",
+        "H_Datum": "15.02.2022",
+        "Datum_Bett": "15.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
