### PR TITLE
New data set: 2022-02-17T112803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-16T114904Z.json
+pjson/2022-02-17T112803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-16T114904Z.json pjson/2022-02-17T112803Z.json```:
```
--- pjson/2022-02-16T114904Z.json	2022-02-16 11:49:04.327928284 +0000
+++ pjson/2022-02-17T112803Z.json	2022-02-17 11:28:03.758043216 +0000
@@ -11362,7 +11362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 446,
+        "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 973,
+        "F\u00e4lle_Meldedatum": 972,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1147,
+        "F\u00e4lle_Meldedatum": 1146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1105,
+        "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1382,
+        "F\u00e4lle_Meldedatum": 1381,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 789,
+        "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25422,7 +25422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 486,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 338,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 692,
+        "F\u00e4lle_Meldedatum": 693,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26296,7 +26296,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642636800000,
-        "F\u00e4lle_Meldedatum": 621,
+        "F\u00e4lle_Meldedatum": 619,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1319,
+        "F\u00e4lle_Meldedatum": 1318,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 428,
+        "F\u00e4lle_Meldedatum": 427,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1502,
+        "F\u00e4lle_Meldedatum": 1499,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1666,
+        "F\u00e4lle_Meldedatum": 1667,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1107,
+        "F\u00e4lle_Meldedatum": 1106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26942,7 +26942,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644105600000,
-        "F\u00e4lle_Meldedatum": 296,
+        "F\u00e4lle_Meldedatum": 297,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -27054,15 +27054,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1155,
         "BelegteBetten": null,
-        "Inzidenz": 1382.0539530874,
+        "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1615,
+        "F\u00e4lle_Meldedatum": 1617,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 1185.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 600,
-        "Krh_I_belegt": 147,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27072,7 +27072,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.9,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.02.2022"
@@ -27110,7 +27110,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.95,
+        "H_Inzidenz": 7.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.02.2022"
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1460.54096770717,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 953,
+        "F\u00e4lle_Meldedatum": 954,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1260.3,
@@ -27148,7 +27148,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.93,
+        "H_Inzidenz": 7.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.02.2022"
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1282.01444017386,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 859,
+        "F\u00e4lle_Meldedatum": 863,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1304.1,
@@ -27186,7 +27186,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.17,
+        "H_Inzidenz": 7.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.02.2022"
@@ -27208,9 +27208,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1214.48327885341,
         "Datum_neu": 1644710400000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1307.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 620,
@@ -27224,7 +27224,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.27,
+        "H_Inzidenz": 7.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.02.2022"
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1488.37961133661,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1395,
+        "F\u00e4lle_Meldedatum": 1436,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1349.6,
@@ -27258,11 +27258,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.47,
+        "H_Inzidenz": 7.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.02.2022"
@@ -27284,9 +27284,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1440.425302633,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1027,
+        "F\u00e4lle_Meldedatum": 1186,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1229.2,
         "Fallzahl_aktiv": 14767,
         "Krh_N_belegt": 711,
@@ -27300,7 +27300,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": 7.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.02.2022"
@@ -27313,7 +27313,7 @@
         "ObjectId": 712,
         "Sterbefall": 1574,
         "Genesungsfall": 100155,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4489,
         "Zuwachs_Fallzahl": 1017,
         "Zuwachs_Sterbefall": 0,
@@ -27322,12 +27322,12 @@
         "BelegteBetten": null,
         "Inzidenz": 1346.85153920759,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 101,
-        "Zeitraum": "09.02.2022 - 15.02.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 693,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1229.2,
         "Fallzahl_aktiv": 14436,
-        "Krh_N_belegt": 711,
+        "Krh_N_belegt": 715,
         "Krh_I_belegt": 155,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -331,
@@ -27336,13 +27336,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3613,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.62,
-        "H_Zeitraum": "09.02.2022 - 15.02.2022",
-        "H_Datum": "15.02.2022",
+        "H_Inzidenz": 6.8,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.02.2022",
+        "Fallzahl": 117046,
+        "ObjectId": 713,
+        "Sterbefall": 1575,
+        "Genesungsfall": 101400,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4504,
+        "Zuwachs_Fallzahl": 881,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 1245,
+        "BelegteBetten": null,
+        "Inzidenz": 1218.97338266461,
+        "Datum_neu": 1645056000000,
+        "F\u00e4lle_Meldedatum": 91,
+        "Zeitraum": "10.02.2022 - 16.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1120.4,
+        "Fallzahl_aktiv": 14071,
+        "Krh_N_belegt": 715,
+        "Krh_I_belegt": 155,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -365,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 3744,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.92,
+        "H_Zeitraum": "10.02.2022 - 16.02.2022",
+        "H_Datum": "16.02.2022",
+        "Datum_Bett": "16.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
