### PR TITLE
New data set: 2022-02-21T112402Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-17T112803Z.json
+pjson/2022-02-21T112402Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-18T114102Z.json pjson/2022-02-21T112402Z.json```:
```
--- pjson/2022-02-18T114102Z.json	2022-02-18 11:41:02.602876588 +0000
+++ pjson/2022-02-21T112402Z.json	2022-02-21 11:24:02.931138820 +0000
@@ -12616,7 +12616,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1611532800000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -16758,7 +16758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620950400000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1146,
+        "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 886,
+        "F\u00e4lle_Meldedatum": 885,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 981,
+        "F\u00e4lle_Meldedatum": 982,
         "Zeitraum": null,
         "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
@@ -25232,7 +25232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 402,
+        "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25614,7 +25614,7 @@
         "Datum_neu": 1641081600000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25652,7 +25652,7 @@
         "Datum_neu": 1641168000000,
         "F\u00e4lle_Meldedatum": 657,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 936,
+        "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 426,
+        "F\u00e4lle_Meldedatum": 425,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1666,
+        "F\u00e4lle_Meldedatum": 1663,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1353,
+        "F\u00e4lle_Meldedatum": 1352,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1250,
+        "F\u00e4lle_Meldedatum": 1249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1103,
+        "F\u00e4lle_Meldedatum": 1102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 490,
+        "F\u00e4lle_Meldedatum": 491,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -26980,9 +26980,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1805,
+        "F\u00e4lle_Meldedatum": 1807,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27030,7 +27030,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 5,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1616,
+        "F\u00e4lle_Meldedatum": 1615,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1342,
+        "F\u00e4lle_Meldedatum": 1345,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27130,15 +27130,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 997,
         "BelegteBetten": null,
-        "Inzidenz": 1460.54096770717,
+        "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 955,
+        "F\u00e4lle_Meldedatum": 953,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 1260.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 635,
-        "Krh_I_belegt": 141,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27148,7 +27148,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.25,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.02.2022"
@@ -27168,15 +27168,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 437,
         "BelegteBetten": null,
-        "Inzidenz": 1282.01444017386,
+        "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 866,
+        "F\u00e4lle_Meldedatum": 867,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 1304.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 613,
-        "Krh_I_belegt": 133,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27186,7 +27186,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.57,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.02.2022"
@@ -27206,15 +27206,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 254,
         "BelegteBetten": null,
-        "Inzidenz": 1214.48327885341,
+        "Inzidenz": null,
         "Datum_neu": 1644710400000,
         "F\u00e4lle_Meldedatum": 317,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 1307.6,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 620,
-        "Krh_I_belegt": 153,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27224,7 +27224,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.02.2022"
@@ -27246,9 +27246,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1488.37961133661,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1466,
+        "F\u00e4lle_Meldedatum": 1473,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 1349.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 679,
@@ -27262,7 +27262,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.08,
+        "H_Inzidenz": 8.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.02.2022"
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1440.425302633,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1214,
+        "F\u00e4lle_Meldedatum": 1224,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1229.2,
@@ -27300,7 +27300,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.99,
+        "H_Inzidenz": 8.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.02.2022"
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1346.85153920759,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 847,
+        "F\u00e4lle_Meldedatum": 903,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 1229.2,
@@ -27338,7 +27338,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
+        "H_Inzidenz": 8.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.02.2022"
@@ -27349,26 +27349,26 @@
         "Datum": "17.02.2022",
         "Fallzahl": 117046,
         "ObjectId": 713,
-        "Sterbefall": 1575,
-        "Genesungsfall": 101400,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4504,
-        "Zuwachs_Fallzahl": 881,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1245,
         "BelegteBetten": null,
         "Inzidenz": 1218.97338266461,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1008,
+        "F\u00e4lle_Meldedatum": 1128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1120.4,
-        "Fallzahl_aktiv": 14071,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 714,
         "Krh_I_belegt": 152,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -365,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -27376,7 +27376,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.47,
+        "H_Inzidenz": 8.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.02.2022"
@@ -27389,7 +27389,7 @@
         "ObjectId": 714,
         "Sterbefall": 1575,
         "Genesungsfall": 102500,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4516,
         "Zuwachs_Fallzahl": 1220,
         "Zuwachs_Sterbefall": 0,
@@ -27398,13 +27398,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1198.49850928553,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 112,
-        "Zeitraum": "11.02.2022 - 17.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 819,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1037.2,
         "Fallzahl_aktiv": 14191,
-        "Krh_N_belegt": 714,
-        "Krh_I_belegt": 152,
+        "Krh_N_belegt": 782,
+        "Krh_I_belegt": 151,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 120,
         "Krh_I": null,
@@ -27412,13 +27412,127 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 3835,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
-        "H_Zeitraum": "11.02.2022 - 17.02.2022",
-        "H_Datum": "17.02.2022",
+        "H_Inzidenz": 7.76,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "19.02.2022",
+        "Fallzahl": 118981,
+        "ObjectId": 715,
+        "Sterbefall": null,
+        "Genesungsfall": 102965,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 465,
+        "BelegteBetten": null,
+        "Inzidenz": 1208.91555012752,
+        "Datum_neu": 1645228800000,
+        "F\u00e4lle_Meldedatum": 401,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1066.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 725,
+        "Krh_I_belegt": 140,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.95,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.02.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.02.2022",
+        "Fallzahl": 119076,
+        "ObjectId": 716,
+        "Sterbefall": null,
+        "Genesungsfall": 103264,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 299,
+        "BelegteBetten": null,
+        "Inzidenz": 1125.22001508675,
+        "Datum_neu": 1645315200000,
+        "F\u00e4lle_Meldedatum": 290,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 956.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 736,
+        "Krh_I_belegt": 138,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.36,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.02.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.02.2022",
+        "Fallzahl": 119875,
+        "ObjectId": 717,
+        "Sterbefall": 1576,
+        "Genesungsfall": 105058,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4521,
+        "Zuwachs_Fallzahl": 1609,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 1794,
+        "BelegteBetten": null,
+        "Inzidenz": 1120.37070297065,
+        "Datum_neu": 1645401600000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "14.02.2022 - 20.02.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 981.1,
+        "Fallzahl_aktiv": 13241,
+        "Krh_N_belegt": 736,
+        "Krh_I_belegt": 138,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -186,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4018,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.67,
+        "H_Zeitraum": "14.02.2022 - 20.02.2022",
+        "H_Datum": "20.02.2022",
+        "Datum_Bett": "20.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
