### PR TITLE
New data set: 2022-02-22T112902Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-21T112402Z.json
+pjson/2022-02-22T112902Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-21T112402Z.json pjson/2022-02-22T112902Z.json```:
```
--- pjson/2022-02-21T112402Z.json	2022-02-21 11:24:02.931138820 +0000
+++ pjson/2022-02-22T112902Z.json	2022-02-22 11:29:03.119279574 +0000
@@ -11820,7 +11820,7 @@
         "Datum_neu": 1609718400000,
         "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12010,7 +12010,7 @@
         "Datum_neu": 1610150400000,
         "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -12618,7 +12618,7 @@
         "Datum_neu": 1611532800000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -13832,7 +13832,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -25384,7 +25384,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640563200000,
-        "F\u00e4lle_Meldedatum": 543,
+        "F\u00e4lle_Meldedatum": 544,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1170,
+        "F\u00e4lle_Meldedatum": 1169,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1002,
+        "F\u00e4lle_Meldedatum": 1003,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1497,
+        "F\u00e4lle_Meldedatum": 1495,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1352,
+        "F\u00e4lle_Meldedatum": 1350,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27018,7 +27018,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1776,
+        "F\u00e4lle_Meldedatum": 1775,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1615,
+        "F\u00e4lle_Meldedatum": 1616,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1345,
+        "F\u00e4lle_Meldedatum": 1349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 953,
+        "F\u00e4lle_Meldedatum": 955,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27208,7 +27208,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644710400000,
-        "F\u00e4lle_Meldedatum": 317,
+        "F\u00e4lle_Meldedatum": 316,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -27244,15 +27244,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1485,
         "BelegteBetten": null,
-        "Inzidenz": 1488.37961133661,
+        "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1473,
+        "F\u00e4lle_Meldedatum": 1476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 1349.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 679,
-        "Krh_I_belegt": 151,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27262,7 +27262,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.53,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.02.2022"
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1440.425302633,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1224,
+        "F\u00e4lle_Meldedatum": 1231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1229.2,
@@ -27300,7 +27300,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.53,
+        "H_Inzidenz": 8.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.02.2022"
@@ -27322,9 +27322,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1346.85153920759,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 903,
+        "F\u00e4lle_Meldedatum": 927,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1229.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 715,
@@ -27338,7 +27338,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.18,
+        "H_Inzidenz": 8.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.02.2022"
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1218.97338266461,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1128,
+        "F\u00e4lle_Meldedatum": 1146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1120.4,
@@ -27376,7 +27376,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.13,
+        "H_Inzidenz": 8.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.02.2022"
@@ -27387,34 +27387,34 @@
         "Datum": "18.02.2022",
         "Fallzahl": 118266,
         "ObjectId": 714,
-        "Sterbefall": 1575,
-        "Genesungsfall": 102500,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4516,
-        "Zuwachs_Fallzahl": 1220,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1100,
         "BelegteBetten": null,
         "Inzidenz": 1198.49850928553,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 819,
+        "F\u00e4lle_Meldedatum": 877,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1037.2,
-        "Fallzahl_aktiv": 14191,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 782,
         "Krh_I_belegt": 151,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 120,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.76,
+        "H_Inzidenz": 8.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.02.2022"
@@ -27426,7 +27426,7 @@
         "Fallzahl": 118981,
         "ObjectId": 715,
         "Sterbefall": null,
-        "Genesungsfall": 102965,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1208.91555012752,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 401,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1066.3,
@@ -27452,7 +27452,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.95,
+        "H_Inzidenz": 7.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.02.2022"
@@ -27464,7 +27464,7 @@
         "Fallzahl": 119076,
         "ObjectId": 716,
         "Sterbefall": null,
-        "Genesungsfall": 103264,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -27474,7 +27474,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1125.22001508675,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 390,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 956.6,
@@ -27490,7 +27490,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.36,
+        "H_Inzidenz": 7.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.02.2022"
@@ -27503,7 +27503,7 @@
         "ObjectId": 717,
         "Sterbefall": 1576,
         "Genesungsfall": 105058,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4521,
         "Zuwachs_Fallzahl": 1609,
         "Zuwachs_Sterbefall": 1,
@@ -27512,13 +27512,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1120.37070297065,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "14.02.2022 - 20.02.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1058,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 981.1,
         "Fallzahl_aktiv": 13241,
-        "Krh_N_belegt": 736,
-        "Krh_I_belegt": 138,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 140,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -186,
         "Krh_I": null,
@@ -27526,13 +27526,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4018,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.67,
-        "H_Zeitraum": "14.02.2022 - 20.02.2022",
-        "H_Datum": "20.02.2022",
+        "H_Inzidenz": 6.73,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.02.2022",
+        "Fallzahl": 121483,
+        "ObjectId": 718,
+        "Sterbefall": 1576,
+        "Genesungsfall": 106822,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4528,
+        "Zuwachs_Fallzahl": 1608,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 1764,
+        "BelegteBetten": null,
+        "Inzidenz": 1096.84255899996,
+        "Datum_neu": 1645488000000,
+        "F\u00e4lle_Meldedatum": 282,
+        "Zeitraum": "15.02.2022 - 21.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 903,
+        "Fallzahl_aktiv": 13085,
+        "Krh_N_belegt": 822,
+        "Krh_I_belegt": 145,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -156,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4079,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.4,
+        "H_Zeitraum": "15.02.2022 - 21.02.2022",
+        "H_Datum": "22.02.2022",
+        "Datum_Bett": "21.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
