### PR TITLE
New data set: 2022-02-23T112802Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-22T112902Z.json
+pjson/2022-02-23T112802Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-22T112902Z.json pjson/2022-02-23T112802Z.json```:
```
--- pjson/2022-02-22T112902Z.json	2022-02-22 11:29:03.119279574 +0000
+++ pjson/2022-02-23T112802Z.json	2022-02-23 11:28:02.993307230 +0000
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1038,
+        "F\u00e4lle_Meldedatum": 1039,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26790,9 +26790,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1350,
+        "F\u00e4lle_Meldedatum": 1347,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1249,
+        "F\u00e4lle_Meldedatum": 1246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 491,
+        "F\u00e4lle_Meldedatum": 490,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -27018,7 +27018,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1775,
+        "F\u00e4lle_Meldedatum": 1776,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -27030,7 +27030,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1616,
+        "F\u00e4lle_Meldedatum": 1615,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1349,
+        "F\u00e4lle_Meldedatum": 1351,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 955,
+        "F\u00e4lle_Meldedatum": 957,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 867,
+        "F\u00e4lle_Meldedatum": 869,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1476,
+        "F\u00e4lle_Meldedatum": 1480,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -27282,15 +27282,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1660,
         "BelegteBetten": null,
-        "Inzidenz": 1440.425302633,
+        "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1231,
+        "F\u00e4lle_Meldedatum": 1232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 1229.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 711,
-        "Krh_I_belegt": 155,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27300,7 +27300,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.63,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.02.2022"
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1346.85153920759,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 927,
+        "F\u00e4lle_Meldedatum": 935,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1229.2,
@@ -27338,7 +27338,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.33,
+        "H_Inzidenz": 8.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.02.2022"
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1218.97338266461,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1146,
+        "F\u00e4lle_Meldedatum": 1155,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1120.4,
@@ -27376,7 +27376,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.28,
+        "H_Inzidenz": 8.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.02.2022"
@@ -27398,9 +27398,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1198.49850928553,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 877,
+        "F\u00e4lle_Meldedatum": 893,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1037.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 782,
@@ -27414,7 +27414,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.01,
+        "H_Inzidenz": 8.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.02.2022"
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1208.91555012752,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 478,
+        "F\u00e4lle_Meldedatum": 507,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1066.3,
@@ -27452,7 +27452,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
+        "H_Inzidenz": 8.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.02.2022"
@@ -27474,7 +27474,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1125.22001508675,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 423,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 956.6,
@@ -27490,7 +27490,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.1,
+        "H_Inzidenz": 7.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.02.2022"
@@ -27501,26 +27501,26 @@
         "Datum": "21.02.2022",
         "Fallzahl": 119875,
         "ObjectId": 717,
-        "Sterbefall": 1576,
-        "Genesungsfall": 105058,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4521,
-        "Zuwachs_Fallzahl": 1609,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1794,
         "BelegteBetten": null,
         "Inzidenz": 1120.37070297065,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1058,
+        "F\u00e4lle_Meldedatum": 1393,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 981.1,
-        "Fallzahl_aktiv": 13241,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 140,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -186,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -27528,7 +27528,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.73,
+        "H_Inzidenz": 7.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.02.2022"
@@ -27541,7 +27541,7 @@
         "ObjectId": 718,
         "Sterbefall": 1576,
         "Genesungsfall": 106822,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4528,
         "Zuwachs_Fallzahl": 1608,
         "Zuwachs_Sterbefall": 0,
@@ -27550,9 +27550,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1096.84255899996,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 282,
-        "Zeitraum": "15.02.2022 - 21.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 955,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 903,
         "Fallzahl_aktiv": 13085,
         "Krh_N_belegt": 822,
@@ -27564,13 +27564,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4079,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.4,
-        "H_Zeitraum": "15.02.2022 - 21.02.2022",
-        "H_Datum": "22.02.2022",
+        "H_Inzidenz": 6.38,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.02.2022",
+        "Fallzahl": 122958,
+        "ObjectId": 719,
+        "Sterbefall": 1577,
+        "Genesungsfall": 108443,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4534,
+        "Zuwachs_Fallzahl": 1475,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 1621,
+        "BelegteBetten": null,
+        "Inzidenz": 1124.50159847696,
+        "Datum_neu": 1645574400000,
+        "F\u00e4lle_Meldedatum": 366,
+        "Zeitraum": "16.02.2022 - 22.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1001.4,
+        "Fallzahl_aktiv": 12938,
+        "Krh_N_belegt": 822,
+        "Krh_I_belegt": 145,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -147,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4185,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.27,
+        "H_Zeitraum": "16.02.2022 - 22.02.2022",
+        "H_Datum": "22.02.2022",
+        "Datum_Bett": "22.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
