### PR TITLE
New data set: 2022-02-24T115103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-23T112802Z.json
+pjson/2022-02-24T115103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-23T112802Z.json pjson/2022-02-24T115103Z.json```:
```
--- pjson/2022-02-23T112802Z.json	2022-02-23 11:28:02.993307230 +0000
+++ pjson/2022-02-24T115103Z.json	2022-02-24 11:51:03.369815969 +0000
@@ -14782,7 +14782,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 171,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23560,7 +23560,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
-        "F\u00e4lle_Meldedatum": 1233,
+        "F\u00e4lle_Meldedatum": 1232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1039,
+        "F\u00e4lle_Meldedatum": 1038,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1347,
+        "F\u00e4lle_Meldedatum": 1346,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1246,
+        "F\u00e4lle_Meldedatum": 1245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1807,
+        "F\u00e4lle_Meldedatum": 1805,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27020,7 +27020,7 @@
         "Datum_neu": 1644278400000,
         "F\u00e4lle_Meldedatum": 1776,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1615,
+        "F\u00e4lle_Meldedatum": 1613,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27068,7 +27068,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27132,9 +27132,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 957,
+        "F\u00e4lle_Meldedatum": 956,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 869,
+        "F\u00e4lle_Meldedatum": 870,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27182,7 +27182,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27208,7 +27208,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644710400000,
-        "F\u00e4lle_Meldedatum": 316,
+        "F\u00e4lle_Meldedatum": 318,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1232,
+        "F\u00e4lle_Meldedatum": 1230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27320,15 +27320,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1348,
         "BelegteBetten": null,
-        "Inzidenz": 1346.85153920759,
+        "Inzidenz": null,
         "Datum_neu": 1644969600000,
         "F\u00e4lle_Meldedatum": 935,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 1229.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 715,
-        "Krh_I_belegt": 155,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27338,7 +27338,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.65,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.02.2022"
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1218.97338266461,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1155,
+        "F\u00e4lle_Meldedatum": 1154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1120.4,
@@ -27376,7 +27376,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.7,
+        "H_Inzidenz": 8.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.02.2022"
@@ -27398,7 +27398,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1198.49850928553,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 893,
+        "F\u00e4lle_Meldedatum": 896,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1037.2,
@@ -27414,7 +27414,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.45,
+        "H_Inzidenz": 8.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.02.2022"
@@ -27436,9 +27436,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1208.91555012752,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 507,
+        "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1066.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 725,
@@ -27452,7 +27452,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.18,
+        "H_Inzidenz": 8.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.02.2022"
@@ -27474,7 +27474,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1125.22001508675,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 423,
+        "F\u00e4lle_Meldedatum": 434,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 956.6,
@@ -27490,7 +27490,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.67,
+        "H_Inzidenz": 7.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.02.2022"
@@ -27512,9 +27512,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1120.37070297065,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1393,
+        "F\u00e4lle_Meldedatum": 1455,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 981.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
@@ -27528,7 +27528,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.35,
+        "H_Inzidenz": 7.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.02.2022"
@@ -27539,26 +27539,26 @@
         "Datum": "22.02.2022",
         "Fallzahl": 121483,
         "ObjectId": 718,
-        "Sterbefall": 1576,
-        "Genesungsfall": 106822,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4528,
-        "Zuwachs_Fallzahl": 1608,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1764,
         "BelegteBetten": null,
         "Inzidenz": 1096.84255899996,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 955,
+        "F\u00e4lle_Meldedatum": 1133,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 903,
-        "Fallzahl_aktiv": 13085,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 822,
         "Krh_I_belegt": 145,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -156,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -27566,7 +27566,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": 6.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.02.2022"
@@ -27579,7 +27579,7 @@
         "ObjectId": 719,
         "Sterbefall": 1577,
         "Genesungsfall": 108443,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4534,
         "Zuwachs_Fallzahl": 1475,
         "Zuwachs_Sterbefall": 1,
@@ -27588,13 +27588,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1124.50159847696,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 366,
-        "Zeitraum": "16.02.2022 - 22.02.2022",
+        "F\u00e4lle_Meldedatum": 1250,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1001.4,
         "Fallzahl_aktiv": 12938,
-        "Krh_N_belegt": 822,
-        "Krh_I_belegt": 145,
+        "Krh_N_belegt": 844,
+        "Krh_I_belegt": 153,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -147,
         "Krh_I": null,
@@ -27602,13 +27602,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4185,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.27,
-        "H_Zeitraum": "16.02.2022 - 22.02.2022",
-        "H_Datum": "22.02.2022",
+        "H_Inzidenz": 6.21,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.02.2022",
+        "Fallzahl": 124299,
+        "ObjectId": 720,
+        "Sterbefall": 1579,
+        "Genesungsfall": 109777,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4537,
+        "Zuwachs_Fallzahl": 1341,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 1334,
+        "BelegteBetten": null,
+        "Inzidenz": 1227.95359028701,
+        "Datum_neu": 1645660800000,
+        "F\u00e4lle_Meldedatum": 204,
+        "Zeitraum": "17.02.2022 - 23.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1045.8,
+        "Fallzahl_aktiv": 12943,
+        "Krh_N_belegt": 844,
+        "Krh_I_belegt": 153,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 5,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4235,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.95,
+        "H_Zeitraum": "17.02.2022 - 23.02.2022",
+        "H_Datum": "23.02.2022",
+        "Datum_Bett": "23.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
