### PR TITLE
New data set: 2022-02-28T114103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-24T115103Z.json
+pjson/2022-02-28T114103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-25T112903Z.json pjson/2022-02-28T114103Z.json```:
```
--- pjson/2022-02-25T112903Z.json	2022-02-25 11:29:03.742934778 +0000
+++ pjson/2022-02-28T114103Z.json	2022-02-28 11:41:03.741037620 +0000
@@ -11096,7 +11096,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608076800000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -11134,7 +11134,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608163200000,
-        "F\u00e4lle_Meldedatum": 513,
+        "F\u00e4lle_Meldedatum": 512,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -13832,7 +13832,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -14604,7 +14604,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -17378,7 +17378,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22850,7 +22850,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25918,7 +25918,7 @@
         "Datum_neu": 1641772800000,
         "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1662,
+        "F\u00e4lle_Meldedatum": 1660,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1803,
+        "F\u00e4lle_Meldedatum": 1801,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27018,7 +27018,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1774,
+        "F\u00e4lle_Meldedatum": 1770,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27030,7 +27030,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27106,7 +27106,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 956,
+        "F\u00e4lle_Meldedatum": 957,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 870,
+        "F\u00e4lle_Meldedatum": 869,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1482,
+        "F\u00e4lle_Meldedatum": 1480,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 940,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1154,
+        "F\u00e4lle_Meldedatum": 1156,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27396,25 +27396,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1100,
         "BelegteBetten": null,
-        "Inzidenz": 1198.49850928553,
+        "Inzidenz": null,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 897,
+        "F\u00e4lle_Meldedatum": 900,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 1037.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 782,
-        "Krh_I_belegt": 151,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.63,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.02.2022"
@@ -27434,15 +27434,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 465,
         "BelegteBetten": null,
-        "Inzidenz": 1208.91555012752,
+        "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 515,
+        "F\u00e4lle_Meldedatum": 517,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 1066.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 725,
-        "Krh_I_belegt": 140,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27452,7 +27452,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.02.2022"
@@ -27472,15 +27472,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 299,
         "BelegteBetten": null,
-        "Inzidenz": 1125.22001508675,
+        "Inzidenz": null,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 434,
+        "F\u00e4lle_Meldedatum": 435,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 956.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 736,
-        "Krh_I_belegt": 138,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27490,7 +27490,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.13,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.02.2022"
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1120.37070297065,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1467,
+        "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 981.1,
@@ -27524,11 +27524,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.91,
+        "H_Inzidenz": 8.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.02.2022"
@@ -27550,9 +27550,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1096.84255899996,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1164,
+        "F\u00e4lle_Meldedatum": 1181,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 903,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 822,
@@ -27566,7 +27566,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.32,
+        "H_Inzidenz": 7.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.02.2022"
@@ -27588,7 +27588,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1124.50159847696,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1387,
+        "F\u00e4lle_Meldedatum": 1411,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1001.4,
@@ -27604,7 +27604,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.61,
+        "H_Inzidenz": 7.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.02.2022"
@@ -27615,34 +27615,34 @@
         "Datum": "24.02.2022",
         "Fallzahl": 124299,
         "ObjectId": 720,
-        "Sterbefall": 1579,
-        "Genesungsfall": 109777,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4537,
-        "Zuwachs_Fallzahl": 1341,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1336,
         "BelegteBetten": null,
         "Inzidenz": 1227.95359028701,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1003,
+        "F\u00e4lle_Meldedatum": 1189,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1045.8,
-        "Fallzahl_aktiv": 12943,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 859,
         "Krh_I_belegt": 152,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.87,
+        "H_Inzidenz": 6.83,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.02.2022"
@@ -27655,22 +27655,22 @@
         "ObjectId": 721,
         "Sterbefall": 1579,
         "Genesungsfall": 110733,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4543,
         "Zuwachs_Fallzahl": 1161,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 6,
         "Zuwachs_Genesung": 956,
         "BelegteBetten": null,
-        "Inzidenz": 1233.34171486045,
+        "Inzidenz": 1276.62631560042,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 179,
-        "Zeitraum": "18.02.2022 - 24.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 751,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1092.5,
         "Fallzahl_aktiv": 13148,
-        "Krh_N_belegt": 859,
-        "Krh_I_belegt": 152,
+        "Krh_N_belegt": 872,
+        "Krh_I_belegt": 172,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 205,
         "Krh_I": null,
@@ -27678,13 +27678,127 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4371,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.18,
-        "H_Zeitraum": "18.02.2022 - 24.02.2022",
-        "H_Datum": "24.02.2022",
+        "H_Inzidenz": 6.33,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.02.2022",
+        "Fallzahl": 126183,
+        "ObjectId": 722,
+        "Sterbefall": null,
+        "Genesungsfall": 111578,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 845,
+        "BelegteBetten": null,
+        "Inzidenz": 1249.86529688566,
+        "Datum_neu": 1645833600000,
+        "F\u00e4lle_Meldedatum": 450,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1127.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 809,
+        "Krh_I_belegt": 178,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.47,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.02.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.02.2022",
+        "Fallzahl": 126196,
+        "ObjectId": 723,
+        "Sterbefall": null,
+        "Genesungsfall": 111904,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 326,
+        "BelegteBetten": null,
+        "Inzidenz": 1237.83181867165,
+        "Datum_neu": 1645920000000,
+        "F\u00e4lle_Meldedatum": 136,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1081.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 840,
+        "Krh_I_belegt": 170,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.13,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.02.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.02.2022",
+        "Fallzahl": 126889,
+        "ObjectId": 724,
+        "Sterbefall": 1581,
+        "Genesungsfall": 113363,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4556,
+        "Zuwachs_Fallzahl": 1429,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 1459,
+        "BelegteBetten": null,
+        "Inzidenz": 1184.13017708969,
+        "Datum_neu": 1646006400000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "21.02.2022 - 27.02.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1069.2,
+        "Fallzahl_aktiv": 11945,
+        "Krh_N_belegt": 903,
+        "Krh_I_belegt": 178,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -32,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4458,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.58,
+        "H_Zeitraum": "21.02.2022 - 27.02.2022",
+        "H_Datum": "28.02.2022",
+        "Datum_Bett": "27.02.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
