### PR TITLE
New data set: 2022-03-01T113104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-02-28T114103Z.json
+pjson/2022-03-01T113104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-02-28T114103Z.json pjson/2022-03-01T113104Z.json```:
```
--- pjson/2022-02-28T114103Z.json	2022-02-28 11:41:03.741037620 +0000
+++ pjson/2022-03-01T113104Z.json	2022-03-01 11:31:04.284424360 +0000
@@ -11020,7 +11020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607904000000,
-        "F\u00e4lle_Meldedatum": 427,
+        "F\u00e4lle_Meldedatum": 428,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -14604,7 +14604,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -17378,7 +17378,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -22850,7 +22850,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26372,7 +26372,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 301,
+        "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 938,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1005,
+        "F\u00e4lle_Meldedatum": 1006,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 425,
+        "F\u00e4lle_Meldedatum": 426,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26802,7 +26802,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1101,
+        "F\u00e4lle_Meldedatum": 1102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 490,
+        "F\u00e4lle_Meldedatum": 489,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -26992,7 +26992,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27030,7 +27030,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1612,
+        "F\u00e4lle_Meldedatum": 1613,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1349,
+        "F\u00e4lle_Meldedatum": 1350,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27208,7 +27208,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644710400000,
-        "F\u00e4lle_Meldedatum": 319,
+        "F\u00e4lle_Meldedatum": 321,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -27220,7 +27220,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1480,
+        "F\u00e4lle_Meldedatum": 1479,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1231,
+        "F\u00e4lle_Meldedatum": 1232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27296,7 +27296,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 940,
+        "F\u00e4lle_Meldedatum": 941,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27334,7 +27334,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27400,7 +27400,7 @@
         "Datum_neu": 1645142400000,
         "F\u00e4lle_Meldedatum": 900,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 517,
+        "F\u00e4lle_Meldedatum": 516,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27474,7 +27474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 435,
+        "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -27510,15 +27510,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1794,
         "BelegteBetten": null,
-        "Inzidenz": 1120.37070297065,
+        "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1475,
+        "F\u00e4lle_Meldedatum": 1478,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 981.1,
+        "Hosp_Meldedatum": 21,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 140,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27528,7 +27528,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.43,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.02.2022"
@@ -27550,9 +27550,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1096.84255899996,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1181,
+        "F\u00e4lle_Meldedatum": 1183,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 903,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 822,
@@ -27566,7 +27566,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.99,
+        "H_Inzidenz": 8.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.02.2022"
@@ -27588,9 +27588,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1124.50159847696,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1411,
+        "F\u00e4lle_Meldedatum": 1414,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1001.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 844,
@@ -27604,7 +27604,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.39,
+        "H_Inzidenz": 7.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.02.2022"
@@ -27626,9 +27626,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1227.95359028701,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1189,
+        "F\u00e4lle_Meldedatum": 1196,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1045.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 859,
@@ -27638,11 +27638,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.83,
+        "H_Inzidenz": 7.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.02.2022"
@@ -27653,34 +27653,34 @@
         "Datum": "25.02.2022",
         "Fallzahl": 125460,
         "ObjectId": 721,
-        "Sterbefall": 1579,
-        "Genesungsfall": 110733,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4543,
-        "Zuwachs_Fallzahl": 1161,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 956,
         "BelegteBetten": null,
         "Inzidenz": 1276.62631560042,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 751,
+        "F\u00e4lle_Meldedatum": 771,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1092.5,
-        "Fallzahl_aktiv": 13148,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 872,
         "Krh_I_belegt": 172,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 205,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.33,
+        "H_Inzidenz": 6.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.02.2022"
@@ -27692,7 +27692,7 @@
         "Fallzahl": 126183,
         "ObjectId": 722,
         "Sterbefall": null,
-        "Genesungsfall": 111578,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -27702,7 +27702,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1249.86529688566,
         "Datum_neu": 1645833600000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 525,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1127.2,
@@ -27718,7 +27718,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.47,
+        "H_Inzidenz": 6.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.02.2022"
@@ -27730,7 +27730,7 @@
         "Fallzahl": 126196,
         "ObjectId": 723,
         "Sterbefall": null,
-        "Genesungsfall": 111904,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -27740,9 +27740,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1237.83181867165,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1081.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 840,
@@ -27756,7 +27756,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.13,
+        "H_Inzidenz": 6.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.02.2022"
@@ -27769,7 +27769,7 @@
         "ObjectId": 724,
         "Sterbefall": 1581,
         "Genesungsfall": 113363,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4556,
         "Zuwachs_Fallzahl": 1429,
         "Zuwachs_Sterbefall": 2,
@@ -27778,9 +27778,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1184.13017708969,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "21.02.2022 - 27.02.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1088,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1069.2,
         "Fallzahl_aktiv": 11945,
         "Krh_N_belegt": 903,
@@ -27790,14 +27790,52 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 2,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.64,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.02.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.03.2022",
+        "Fallzahl": 128333,
+        "ObjectId": 725,
+        "Sterbefall": 1589,
+        "Genesungsfall": 114574,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4591,
+        "Zuwachs_Fallzahl": 1444,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 35,
+        "Zuwachs_Genesung": 1211,
+        "BelegteBetten": null,
+        "Inzidenz": 1146.77251338051,
+        "Datum_neu": 1646092800000,
+        "F\u00e4lle_Meldedatum": 201,
+        "Zeitraum": "22.02.2022 - 28.02.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 956.3,
+        "Fallzahl_aktiv": 12170,
+        "Krh_N_belegt": 903,
+        "Krh_I_belegt": 178,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 225,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4458,
+        "Mutation": 4529,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
-        "H_Zeitraum": "21.02.2022 - 27.02.2022",
+        "H_Inzidenz": 4.22,
+        "H_Zeitraum": "22.02.2022 - 28.02.2022",
         "H_Datum": "28.02.2022",
-        "Datum_Bett": "27.02.2022"
+        "Datum_Bett": "28.02.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
