### PR TITLE
New data set: 2022-03-02T113504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-01T113104Z.json
+pjson/2022-03-02T113504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-01T113104Z.json pjson/2022-03-02T113504Z.json```:
```
--- pjson/2022-03-01T113104Z.json	2022-03-01 11:31:04.284424360 +0000
+++ pjson/2022-03-02T113504Z.json	2022-03-02 11:35:04.308267147 +0000
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 939,
+        "F\u00e4lle_Meldedatum": 938,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -25422,7 +25422,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640649600000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 657,
+        "F\u00e4lle_Meldedatum": 658,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -25688,7 +25688,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 529,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1244,
+        "F\u00e4lle_Meldedatum": 1245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1801,
+        "F\u00e4lle_Meldedatum": 1800,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1613,
+        "F\u00e4lle_Meldedatum": 1612,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 957,
+        "F\u00e4lle_Meldedatum": 958,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27170,9 +27170,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 869,
+        "F\u00e4lle_Meldedatum": 870,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27208,7 +27208,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644710400000,
-        "F\u00e4lle_Meldedatum": 321,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1479,
+        "F\u00e4lle_Meldedatum": 1478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 941,
+        "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1156,
+        "F\u00e4lle_Meldedatum": 1157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27372,7 +27372,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 516,
+        "F\u00e4lle_Meldedatum": 517,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27448,7 +27448,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27474,9 +27474,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 436,
+        "F\u00e4lle_Meldedatum": 435,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27512,9 +27512,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1478,
+        "F\u00e4lle_Meldedatum": 1480,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27548,15 +27548,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1764,
         "BelegteBetten": null,
-        "Inzidenz": 1096.84255899996,
+        "Inzidenz": null,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1183,
+        "F\u00e4lle_Meldedatum": 1187,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 903,
+        "Hosp_Meldedatum": 15,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 822,
-        "Krh_I_belegt": 145,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27566,7 +27566,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.11,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.02.2022"
@@ -27588,9 +27588,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1124.50159847696,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1414,
+        "F\u00e4lle_Meldedatum": 1415,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1001.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 844,
@@ -27604,7 +27604,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
+        "H_Inzidenz": 8.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.02.2022"
@@ -27628,7 +27628,7 @@
         "Datum_neu": 1645660800000,
         "F\u00e4lle_Meldedatum": 1196,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1045.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 859,
@@ -27642,7 +27642,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.25,
+        "H_Inzidenz": 8.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.02.2022"
@@ -27664,9 +27664,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1276.62631560042,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 771,
+        "F\u00e4lle_Meldedatum": 783,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1092.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 872,
@@ -27680,7 +27680,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
+        "H_Inzidenz": 8.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.02.2022"
@@ -27702,9 +27702,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1249.86529688566,
         "Datum_neu": 1645833600000,
-        "F\u00e4lle_Meldedatum": 525,
+        "F\u00e4lle_Meldedatum": 564,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1127.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 809,
@@ -27718,7 +27718,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.29,
+        "H_Inzidenz": 7.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.02.2022"
@@ -27740,9 +27740,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1237.83181867165,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1081.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 840,
@@ -27756,7 +27756,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.09,
+        "H_Inzidenz": 7.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.02.2022"
@@ -27767,34 +27767,34 @@
         "Datum": "28.02.2022",
         "Fallzahl": 126889,
         "ObjectId": 724,
-        "Sterbefall": 1581,
-        "Genesungsfall": 113363,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4556,
-        "Zuwachs_Fallzahl": 1429,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1459,
         "BelegteBetten": null,
         "Inzidenz": 1184.13017708969,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1088,
+        "F\u00e4lle_Meldedatum": 1472,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 1069.2,
-        "Fallzahl_aktiv": 11945,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 903,
         "Krh_I_belegt": 178,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -32,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.64,
+        "H_Inzidenz": 7.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.02.2022"
@@ -27807,7 +27807,7 @@
         "ObjectId": 725,
         "Sterbefall": 1589,
         "Genesungsfall": 114574,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4591,
         "Zuwachs_Fallzahl": 1444,
         "Zuwachs_Sterbefall": 8,
@@ -27816,13 +27816,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1146.77251338051,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 201,
-        "Zeitraum": "22.02.2022 - 28.02.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1221,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 956.3,
         "Fallzahl_aktiv": 12170,
-        "Krh_N_belegt": 903,
-        "Krh_I_belegt": 178,
+        "Krh_N_belegt": 960,
+        "Krh_I_belegt": 169,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 225,
         "Krh_I": null,
@@ -27830,13 +27830,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4529,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.22,
-        "H_Zeitraum": "22.02.2022 - 28.02.2022",
-        "H_Datum": "28.02.2022",
+        "H_Inzidenz": 6.51,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.02.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "02.03.2022",
+        "Fallzahl": 130052,
+        "ObjectId": 726,
+        "Sterbefall": 1593,
+        "Genesungsfall": 115514,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4643,
+        "Zuwachs_Fallzahl": 1719,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 52,
+        "Zuwachs_Genesung": 940,
+        "BelegteBetten": null,
+        "Inzidenz": 1243.75875570243,
+        "Datum_neu": 1646179200000,
+        "F\u00e4lle_Meldedatum": 190,
+        "Zeitraum": "23.02.2022 - 01.03.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1014.5,
+        "Fallzahl_aktiv": 12945,
+        "Krh_N_belegt": 960,
+        "Krh_I_belegt": 169,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 775,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4674,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.32,
+        "H_Zeitraum": "23.02.2022 - 01.03.2022",
+        "H_Datum": "01.03.2022",
+        "Datum_Bett": "01.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
