### PR TITLE
New data set: 2022-03-03T114103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-02T113504Z.json
+pjson/2022-03-03T114103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-02T114603Z.json pjson/2022-03-03T114103Z.json```:
```
--- pjson/2022-03-02T114603Z.json	2022-03-02 11:46:03.580743859 +0000
+++ pjson/2022-03-03T114103Z.json	2022-03-03 11:41:03.191328870 +0000
@@ -24206,7 +24206,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637884800000,
-        "F\u00e4lle_Meldedatum": 1196,
+        "F\u00e4lle_Meldedatum": 1195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 426,
+        "F\u00e4lle_Meldedatum": 425,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1660,
+        "F\u00e4lle_Meldedatum": 1661,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1245,
+        "F\u00e4lle_Meldedatum": 1244,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1800,
+        "F\u00e4lle_Meldedatum": 1799,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27056,9 +27056,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1612,
+        "F\u00e4lle_Meldedatum": 1611,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1350,
+        "F\u00e4lle_Meldedatum": 1349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 958,
+        "F\u00e4lle_Meldedatum": 960,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1478,
+        "F\u00e4lle_Meldedatum": 1481,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1232,
+        "F\u00e4lle_Meldedatum": 1235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 939,
+        "F\u00e4lle_Meldedatum": 940,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1157,
+        "F\u00e4lle_Meldedatum": 1159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27448,7 +27448,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27586,25 +27586,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1621,
         "BelegteBetten": null,
-        "Inzidenz": 1124.50159847696,
+        "Inzidenz": null,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1415,
+        "F\u00e4lle_Meldedatum": 1419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 1001.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 844,
-        "Krh_I_belegt": 153,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.02.2022"
@@ -27638,11 +27638,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.26,
+        "H_Inzidenz": 8.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.02.2022"
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1276.62631560042,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 783,
+        "F\u00e4lle_Meldedatum": 792,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1092.5,
@@ -27680,7 +27680,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.18,
+        "H_Inzidenz": 8.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.02.2022"
@@ -27702,7 +27702,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1249.86529688566,
         "Datum_neu": 1645833600000,
-        "F\u00e4lle_Meldedatum": 564,
+        "F\u00e4lle_Meldedatum": 577,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1127.2,
@@ -27718,7 +27718,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
+        "H_Inzidenz": 8.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.02.2022"
@@ -27740,7 +27740,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1237.83181867165,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1081.9,
@@ -27756,7 +27756,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.67,
+        "H_Inzidenz": 8.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.02.2022"
@@ -27778,7 +27778,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1184.13017708969,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1472,
+        "F\u00e4lle_Meldedatum": 1563,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 1069.2,
@@ -27794,7 +27794,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.3,
+        "H_Inzidenz": 8.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.02.2022"
@@ -27805,34 +27805,34 @@
         "Datum": "01.03.2022",
         "Fallzahl": 128333,
         "ObjectId": 725,
-        "Sterbefall": 1589,
-        "Genesungsfall": 114574,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4591,
-        "Zuwachs_Fallzahl": 1444,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 35,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1211,
         "BelegteBetten": null,
         "Inzidenz": 1146.77251338051,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1221,
+        "F\u00e4lle_Meldedatum": 1757,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 956.3,
-        "Fallzahl_aktiv": 12170,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 960,
         "Krh_I_belegt": 169,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 225,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.51,
+        "H_Inzidenz": 7.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.02.2022"
@@ -27845,7 +27845,7 @@
         "ObjectId": 726,
         "Sterbefall": 1593,
         "Genesungsfall": 115514,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4643,
         "Zuwachs_Fallzahl": 1719,
         "Zuwachs_Sterbefall": 4,
@@ -27854,13 +27854,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1243.75875570243,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 190,
-        "Zeitraum": "23.02.2022 - 01.03.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1214,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1014.5,
         "Fallzahl_aktiv": 12945,
-        "Krh_N_belegt": 960,
-        "Krh_I_belegt": 169,
+        "Krh_N_belegt": 920,
+        "Krh_I_belegt": 184,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 775,
         "Krh_I": null,
@@ -27868,13 +27868,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4674,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
-        "H_Zeitraum": "23.02.2022 - 01.03.2022",
-        "H_Datum": "01.03.2022",
+        "H_Inzidenz": 7.12,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.03.2022",
+        "Fallzahl": 131983,
+        "ObjectId": 727,
+        "Sterbefall": 1599,
+        "Genesungsfall": 116660,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4651,
+        "Zuwachs_Fallzahl": 1931,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 1146,
+        "BelegteBetten": null,
+        "Inzidenz": 1326.91547828586,
+        "Datum_neu": 1646265600000,
+        "F\u00e4lle_Meldedatum": 233,
+        "Zeitraum": "24.02.2022 - 02.03.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1151.1,
+        "Fallzahl_aktiv": 13724,
+        "Krh_N_belegt": 920,
+        "Krh_I_belegt": 184,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 779,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4840,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.11,
+        "H_Zeitraum": "24.02.2022 - 02.03.2022",
+        "H_Datum": "02.03.2022",
+        "Datum_Bett": "02.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
