### PR TITLE
New data set: 2022-03-04T115203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-03T114103Z.json
+pjson/2022-03-04T115203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-03T114103Z.json pjson/2022-03-04T115203Z.json```:
```
--- pjson/2022-03-03T114103Z.json	2022-03-03 11:41:03.191328870 +0000
+++ pjson/2022-03-04T115203Z.json	2022-03-04 11:52:03.247837135 +0000
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 982,
+        "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
         "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 938,
+        "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -26220,7 +26220,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642464000000,
-        "F\u00e4lle_Meldedatum": 695,
+        "F\u00e4lle_Meldedatum": 694,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1349,
+        "F\u00e4lle_Meldedatum": 1350,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 870,
+        "F\u00e4lle_Meldedatum": 871,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 940,
+        "F\u00e4lle_Meldedatum": 941,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 517,
+        "F\u00e4lle_Meldedatum": 516,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27550,7 +27550,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1187,
+        "F\u00e4lle_Meldedatum": 1188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27624,15 +27624,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1336,
         "BelegteBetten": null,
-        "Inzidenz": 1227.95359028701,
+        "Inzidenz": null,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1196,
+        "F\u00e4lle_Meldedatum": 1194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 1045.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 859,
-        "Krh_I_belegt": 152,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27642,7 +27642,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.02.2022"
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1276.62631560042,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 792,
+        "F\u00e4lle_Meldedatum": 794,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1092.5,
@@ -27680,7 +27680,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.82,
+        "H_Inzidenz": 9.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.02.2022"
@@ -27702,7 +27702,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1249.86529688566,
         "Datum_neu": 1645833600000,
-        "F\u00e4lle_Meldedatum": 577,
+        "F\u00e4lle_Meldedatum": 580,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1127.2,
@@ -27718,7 +27718,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.41,
+        "H_Inzidenz": 8.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.02.2022"
@@ -27740,7 +27740,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1237.83181867165,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 289,
+        "F\u00e4lle_Meldedatum": 290,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1081.9,
@@ -27756,7 +27756,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.53,
+        "H_Inzidenz": 9.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.02.2022"
@@ -27778,7 +27778,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1184.13017708969,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1563,
+        "F\u00e4lle_Meldedatum": 1579,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 1069.2,
@@ -27794,7 +27794,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.38,
+        "H_Inzidenz": 8.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.02.2022"
@@ -27816,9 +27816,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1146.77251338051,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1757,
+        "F\u00e4lle_Meldedatum": 1792,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 956.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 960,
@@ -27832,7 +27832,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
+        "H_Inzidenz": 8.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.02.2022"
@@ -27843,34 +27843,34 @@
         "Datum": "02.03.2022",
         "Fallzahl": 130052,
         "ObjectId": 726,
-        "Sterbefall": 1593,
-        "Genesungsfall": 115514,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4643,
-        "Zuwachs_Fallzahl": 1719,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 52,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 940,
         "BelegteBetten": null,
         "Inzidenz": 1243.75875570243,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1214,
+        "F\u00e4lle_Meldedatum": 1318,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1014.5,
-        "Fallzahl_aktiv": 12945,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 920,
         "Krh_I_belegt": 184,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 775,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.12,
+        "H_Inzidenz": 8.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.03.2022"
@@ -27883,7 +27883,7 @@
         "ObjectId": 727,
         "Sterbefall": 1599,
         "Genesungsfall": 116660,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4651,
         "Zuwachs_Fallzahl": 1931,
         "Zuwachs_Sterbefall": 6,
@@ -27892,27 +27892,65 @@
         "BelegteBetten": null,
         "Inzidenz": 1326.91547828586,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 233,
-        "Zeitraum": "24.02.2022 - 02.03.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1056,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1151.1,
         "Fallzahl_aktiv": 13724,
-        "Krh_N_belegt": 920,
-        "Krh_I_belegt": 184,
+        "Krh_N_belegt": 945,
+        "Krh_I_belegt": 177,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 779,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 4840,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.11,
-        "H_Zeitraum": "24.02.2022 - 02.03.2022",
-        "H_Datum": "02.03.2022",
+        "H_Inzidenz": 7.64,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.03.2022",
+        "Fallzahl": 133074,
+        "ObjectId": 728,
+        "Sterbefall": 1601,
+        "Genesungsfall": 117556,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4667,
+        "Zuwachs_Fallzahl": 1091,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 896,
+        "BelegteBetten": null,
+        "Inzidenz": 1330.68716548727,
+        "Datum_neu": 1646352000000,
+        "F\u00e4lle_Meldedatum": 109,
+        "Zeitraum": "25.02.2022 - 03.03.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1176,
+        "Fallzahl_aktiv": 13917,
+        "Krh_N_belegt": 981,
+        "Krh_I_belegt": 172,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 193,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 4926,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.58,
+        "H_Zeitraum": "25.02.2022 - 03.03.2022",
+        "H_Datum": "04.03.2022",
+        "Datum_Bett": "03.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
