### PR TITLE
New data set: 2022-03-07T112703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-04T115203Z.json
+pjson/2022-03-07T112703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-04T115203Z.json pjson/2022-03-07T112703Z.json```:
```
--- pjson/2022-03-04T115203Z.json	2022-03-04 11:52:03.247837135 +0000
+++ pjson/2022-03-07T112703Z.json	2022-03-07 11:27:04.033235523 +0000
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26448,7 +26448,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642982400000,
-        "F\u00e4lle_Meldedatum": 1169,
+        "F\u00e4lle_Meldedatum": 1168,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 938,
+        "F\u00e4lle_Meldedatum": 939,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26754,7 +26754,7 @@
         "Datum_neu": 1643673600000,
         "F\u00e4lle_Meldedatum": 1661,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -27018,7 +27018,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1770,
+        "F\u00e4lle_Meldedatum": 1771,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 960,
+        "F\u00e4lle_Meldedatum": 959,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1481,
+        "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1235,
+        "F\u00e4lle_Meldedatum": 1237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1159,
+        "F\u00e4lle_Meldedatum": 1158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27398,7 +27398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 900,
+        "F\u00e4lle_Meldedatum": 898,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 516,
+        "F\u00e4lle_Meldedatum": 514,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1480,
+        "F\u00e4lle_Meldedatum": 1481,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -27550,7 +27550,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1188,
+        "F\u00e4lle_Meldedatum": 1190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27588,7 +27588,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1419,
+        "F\u00e4lle_Meldedatum": 1416,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -27662,15 +27662,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 956,
         "BelegteBetten": null,
-        "Inzidenz": 1276.62631560042,
+        "Inzidenz": null,
         "Datum_neu": 1645747200000,
         "F\u00e4lle_Meldedatum": 794,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
-        "Inzidenz_RKI": 1092.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 872,
-        "Krh_I_belegt": 172,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27680,7 +27680,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.02,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.02.2022"
@@ -27700,15 +27700,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 845,
         "BelegteBetten": null,
-        "Inzidenz": 1249.86529688566,
+        "Inzidenz": null,
         "Datum_neu": 1645833600000,
-        "F\u00e4lle_Meldedatum": 580,
+        "F\u00e4lle_Meldedatum": 583,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 1127.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 809,
-        "Krh_I_belegt": 178,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27718,7 +27718,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.87,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.02.2022"
@@ -27738,15 +27738,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 326,
         "BelegteBetten": null,
-        "Inzidenz": 1237.83181867165,
+        "Inzidenz": null,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 1081.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 840,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27756,7 +27756,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.02,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.02.2022"
@@ -27774,13 +27774,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1459,
+        "Zuwachs_Genesung": 1458,
         "BelegteBetten": null,
-        "Inzidenz": 1184.13017708969,
+        "Inzidenz": null,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1579,
+        "F\u00e4lle_Meldedatum": 1584,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1069.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 903,
@@ -27794,7 +27794,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.9,
+        "H_Inzidenz": 9.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.02.2022"
@@ -27814,9 +27814,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1211,
         "BelegteBetten": null,
-        "Inzidenz": 1146.77251338051,
+        "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1792,
+        "F\u00e4lle_Meldedatum": 1800,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 956.3,
@@ -27832,7 +27832,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.5,
+        "H_Inzidenz": 9.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.02.2022"
@@ -27850,11 +27850,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 940,
+        "Zuwachs_Genesung": 947,
         "BelegteBetten": null,
-        "Inzidenz": 1243.75875570243,
+        "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1318,
+        "F\u00e4lle_Meldedatum": 1346,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1014.5,
@@ -27870,7 +27870,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.21,
+        "H_Inzidenz": 8.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.03.2022"
@@ -27881,34 +27881,34 @@
         "Datum": "03.03.2022",
         "Fallzahl": 131983,
         "ObjectId": 727,
-        "Sterbefall": 1599,
-        "Genesungsfall": 116660,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4651,
-        "Zuwachs_Fallzahl": 1931,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 8,
-        "Zuwachs_Genesung": 1146,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1156,
         "BelegteBetten": null,
-        "Inzidenz": 1326.91547828586,
+        "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1056,
+        "F\u00e4lle_Meldedatum": 1190,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1151.1,
-        "Fallzahl_aktiv": 13724,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 945,
         "Krh_I_belegt": 177,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 779,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.64,
+        "H_Inzidenz": 8.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.03.2022"
@@ -27921,36 +27921,150 @@
         "ObjectId": 728,
         "Sterbefall": 1601,
         "Genesungsfall": 117556,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4667,
         "Zuwachs_Fallzahl": 1091,
         "Zuwachs_Sterbefall": 2,
         "Zuwachs_Krankenhauseinweisung": 16,
-        "Zuwachs_Genesung": 896,
+        "Zuwachs_Genesung": 900,
         "BelegteBetten": null,
         "Inzidenz": 1330.68716548727,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 109,
-        "Zeitraum": "25.02.2022 - 03.03.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 921,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1176,
         "Fallzahl_aktiv": 13917,
         "Krh_N_belegt": 981,
         "Krh_I_belegt": 172,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 193,
+        "Fallzahl_aktiv_Zuwachs": 189,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 4926,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.58,
-        "H_Zeitraum": "25.02.2022 - 03.03.2022",
-        "H_Datum": "04.03.2022",
+        "H_Inzidenz": 7.96,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.03.2022",
+        "Fallzahl": 134704,
+        "ObjectId": 729,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 523,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1646438400000,
+        "F\u00e4lle_Meldedatum": 637,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1228.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 945,
+        "Krh_I_belegt": 163,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.1,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.03.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.03.2022",
+        "Fallzahl": 134828,
+        "ObjectId": 730,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 442,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1646524800000,
+        "F\u00e4lle_Meldedatum": 124,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1161.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 956,
+        "Krh_I_belegt": 136,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.19,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "05.03.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.03.2022",
+        "Fallzahl": 134895,
+        "ObjectId": 731,
+        "Sterbefall": 1601,
+        "Genesungsfall": 119998,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4677,
+        "Zuwachs_Fallzahl": 1821,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 1457,
+        "BelegteBetten": null,
+        "Inzidenz": 1365.35076690973,
+        "Datum_neu": 1646611200000,
+        "F\u00e4lle_Meldedatum": 67,
+        "Zeitraum": "28.02.2022 - 06.03.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1220,
+        "Fallzahl_aktiv": 13296,
+        "Krh_N_belegt": 956,
+        "Krh_I_belegt": 136,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 364,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 5115,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.74,
+        "H_Zeitraum": "28.02.2022 - 06.03.2022",
+        "H_Datum": "06.03.2022",
+        "Datum_Bett": "06.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
