### PR TITLE
New data set: 2022-03-08T113104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-07T112703Z.json
+pjson/2022-03-08T113104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-07T112703Z.json pjson/2022-03-08T113104Z.json```:
```
--- pjson/2022-03-07T112703Z.json	2022-03-07 11:27:04.033235523 +0000
+++ pjson/2022-03-08T113104Z.json	2022-03-08 11:31:04.181583097 +0000
@@ -25612,7 +25612,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641081600000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 658,
+        "F\u00e4lle_Meldedatum": 657,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26184,7 +26184,7 @@
         "Datum_neu": 1642377600000,
         "F\u00e4lle_Meldedatum": 701,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 683,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 939,
+        "F\u00e4lle_Meldedatum": 941,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1346,
+        "F\u00e4lle_Meldedatum": 1347,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 959,
+        "F\u00e4lle_Meldedatum": 957,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 871,
+        "F\u00e4lle_Meldedatum": 870,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1482,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1237,
+        "F\u00e4lle_Meldedatum": 1239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 514,
+        "F\u00e4lle_Meldedatum": 513,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27550,7 +27550,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1190,
+        "F\u00e4lle_Meldedatum": 1191,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27588,7 +27588,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1416,
+        "F\u00e4lle_Meldedatum": 1417,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -27626,7 +27626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1194,
+        "F\u00e4lle_Meldedatum": 1197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 794,
+        "F\u00e4lle_Meldedatum": 797,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -27740,7 +27740,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27778,13 +27778,13 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1584,
+        "F\u00e4lle_Meldedatum": 1586,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
-        "Inzidenz_RKI": 1069.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 903,
-        "Krh_I_belegt": 178,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27794,7 +27794,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.44,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.02.2022"
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1800,
+        "F\u00e4lle_Meldedatum": 1803,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 956.3,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1346,
+        "F\u00e4lle_Meldedatum": 1354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1014.5,
@@ -27892,9 +27892,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1190,
+        "F\u00e4lle_Meldedatum": 1202,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1151.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 945,
@@ -27919,28 +27919,28 @@
         "Datum": "04.03.2022",
         "Fallzahl": 133074,
         "ObjectId": 728,
-        "Sterbefall": 1601,
-        "Genesungsfall": 117556,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4667,
-        "Zuwachs_Fallzahl": 1091,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 900,
         "BelegteBetten": null,
-        "Inzidenz": 1330.68716548727,
+        "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 921,
+        "F\u00e4lle_Meldedatum": 951,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1176,
-        "Fallzahl_aktiv": 13917,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 981,
         "Krh_I_belegt": 172,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 189,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 637,
+        "F\u00e4lle_Meldedatum": 726,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1228.3,
@@ -28006,7 +28006,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646524800000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1161.2,
@@ -28022,7 +28022,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.19,
+        "H_Inzidenz": 6.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.03.2022"
@@ -28035,7 +28035,7 @@
         "ObjectId": 731,
         "Sterbefall": 1601,
         "Genesungsfall": 119998,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4677,
         "Zuwachs_Fallzahl": 1821,
         "Zuwachs_Sterbefall": 0,
@@ -28044,13 +28044,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1365.35076690973,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 67,
-        "Zeitraum": "28.02.2022 - 06.03.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1017,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 1220,
         "Fallzahl_aktiv": 13296,
-        "Krh_N_belegt": 956,
-        "Krh_I_belegt": 136,
+        "Krh_N_belegt": 1013,
+        "Krh_I_belegt": 178,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 364,
         "Krh_I": null,
@@ -28058,13 +28058,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 5115,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 5.74,
-        "H_Zeitraum": "28.02.2022 - 06.03.2022",
-        "H_Datum": "06.03.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.03.2022",
+        "Fallzahl": 136420,
+        "ObjectId": 732,
+        "Sterbefall": 1601,
+        "Genesungsfall": 121173,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4699,
+        "Zuwachs_Fallzahl": 1525,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 22,
+        "Zuwachs_Genesung": 1175,
+        "BelegteBetten": null,
+        "Inzidenz": 1303.02812601027,
+        "Datum_neu": 1646697600000,
+        "F\u00e4lle_Meldedatum": 341,
+        "Zeitraum": "01.03.2022 - 07.03.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1121.8,
+        "Fallzahl_aktiv": 13646,
+        "Krh_N_belegt": 1013,
+        "Krh_I_belegt": 178,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 350,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 5143,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.74,
+        "H_Zeitraum": "28.02.2022 - 06.03.2022",
+        "H_Datum": "07.03.2022",
+        "Datum_Bett": "07.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
