### PR TITLE
New data set: 2022-03-09T115404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-08T113104Z.json
+pjson/2022-03-09T115404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-08T113104Z.json pjson/2022-03-09T115404Z.json```:
```
--- pjson/2022-03-08T113104Z.json	2022-03-08 11:31:04.181583097 +0000
+++ pjson/2022-03-09T115404Z.json	2022-03-09 11:54:04.425922667 +0000
@@ -13414,7 +13414,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1613347200000,
-        "F\u00e4lle_Meldedatum": 75,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -14060,7 +14060,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614816000000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -14136,7 +14136,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614988800000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -14782,7 +14782,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616457600000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 171,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -15998,7 +15998,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619222400000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -23636,7 +23636,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636588800000,
-        "F\u00e4lle_Meldedatum": 1038,
+        "F\u00e4lle_Meldedatum": 1039,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1495,
+        "F\u00e4lle_Meldedatum": 1496,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1244,
+        "F\u00e4lle_Meldedatum": 1243,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 489,
+        "F\u00e4lle_Meldedatum": 490,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1350,
+        "F\u00e4lle_Meldedatum": 1353,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 870,
+        "F\u00e4lle_Meldedatum": 871,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27398,7 +27398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 898,
+        "F\u00e4lle_Meldedatum": 899,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 513,
+        "F\u00e4lle_Meldedatum": 514,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27474,7 +27474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 435,
+        "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1481,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -27550,7 +27550,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1191,
+        "F\u00e4lle_Meldedatum": 1188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27588,7 +27588,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1417,
+        "F\u00e4lle_Meldedatum": 1416,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -27626,7 +27626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1197,
+        "F\u00e4lle_Meldedatum": 1198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27714,7 +27714,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27752,7 +27752,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27778,7 +27778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1586,
+        "F\u00e4lle_Meldedatum": 1581,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -27790,7 +27790,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27816,13 +27816,13 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1803,
+        "F\u00e4lle_Meldedatum": 1804,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 956.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 960,
-        "Krh_I_belegt": 169,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27832,7 +27832,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.02,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.02.2022"
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1354,
+        "F\u00e4lle_Meldedatum": 1357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1014.5,
@@ -27870,7 +27870,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.73,
+        "H_Inzidenz": 9.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.03.2022"
@@ -27892,7 +27892,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1202,
+        "F\u00e4lle_Meldedatum": 1208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1151.1,
@@ -27908,7 +27908,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.53,
+        "H_Inzidenz": 9.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.03.2022"
@@ -27930,7 +27930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 951,
+        "F\u00e4lle_Meldedatum": 968,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1176,
@@ -27946,7 +27946,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.96,
+        "H_Inzidenz": 8.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.03.2022"
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 726,
+        "F\u00e4lle_Meldedatum": 784,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1228.3,
@@ -27984,7 +27984,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.1,
+        "H_Inzidenz": 8.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.03.2022"
@@ -28006,9 +28006,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646524800000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 351,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1161.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 956,
@@ -28022,7 +28022,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.26,
+        "H_Inzidenz": 7.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.03.2022"
@@ -28033,34 +28033,34 @@
         "Datum": "07.03.2022",
         "Fallzahl": 134895,
         "ObjectId": 731,
-        "Sterbefall": 1601,
-        "Genesungsfall": 119998,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4677,
-        "Zuwachs_Fallzahl": 1821,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1457,
         "BelegteBetten": null,
-        "Inzidenz": 1365.35076690973,
+        "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 1017,
+        "F\u00e4lle_Meldedatum": 1894,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1220,
-        "Fallzahl_aktiv": 13296,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1013,
         "Krh_I_belegt": 178,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 364,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": 7.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.03.2022"
@@ -28073,36 +28073,74 @@
         "ObjectId": 732,
         "Sterbefall": 1601,
         "Genesungsfall": 121173,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4699,
         "Zuwachs_Fallzahl": 1525,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 22,
         "Zuwachs_Genesung": 1175,
         "BelegteBetten": null,
-        "Inzidenz": 1303.02812601027,
+        "Inzidenz": 1303,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 341,
-        "Zeitraum": "01.03.2022 - 07.03.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1371,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 1121.8,
         "Fallzahl_aktiv": 13646,
-        "Krh_N_belegt": 1013,
-        "Krh_I_belegt": 178,
+        "Krh_N_belegt": 1042,
+        "Krh_I_belegt": 167,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 350,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 5143,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
-        "H_Zeitraum": "28.02.2022 - 06.03.2022",
-        "H_Datum": "07.03.2022",
+        "H_Inzidenz": 6.73,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.03.2022",
+        "Fallzahl": 138894,
+        "ObjectId": 733,
+        "Sterbefall": 1605,
+        "Genesungsfall": 122601,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4722,
+        "Zuwachs_Fallzahl": 2474,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 1428,
+        "BelegteBetten": null,
+        "Inzidenz": 1424.79974137002,
+        "Datum_neu": 1646784000000,
+        "F\u00e4lle_Meldedatum": 328,
+        "Zeitraum": "02.03.2022 - 08.03.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1179.6,
+        "Fallzahl_aktiv": 14688,
+        "Krh_N_belegt": 1042,
+        "Krh_I_belegt": 167,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1042,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 5269,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.69,
+        "H_Zeitraum": "02.03.2022 - 08.03.2022",
+        "H_Datum": "08.03.2023",
+        "Datum_Bett": "08.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
