### PR TITLE
New data set: 2022-03-10T113104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-09T115404Z.json
+pjson/2022-03-10T113104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-09T115404Z.json pjson/2022-03-10T113104Z.json```:
```
--- pjson/2022-03-09T115404Z.json	2022-03-09 11:54:04.425922667 +0000
+++ pjson/2022-03-10T113104Z.json	2022-03-10 11:31:04.192585475 +0000
@@ -23752,7 +23752,7 @@
         "Datum_neu": 1636848000000,
         "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23904,7 +23904,7 @@
         "Datum_neu": 1637193600000,
         "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24056,7 +24056,7 @@
         "Datum_neu": 1637539200000,
         "F\u00e4lle_Meldedatum": 1381,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24170,7 +24170,7 @@
         "Datum_neu": 1637798400000,
         "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24208,7 +24208,7 @@
         "Datum_neu": 1637884800000,
         "F\u00e4lle_Meldedatum": 1195,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24322,7 +24322,7 @@
         "Datum_neu": 1638144000000,
         "F\u00e4lle_Meldedatum": 882,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24360,7 +24360,7 @@
         "Datum_neu": 1638230400000,
         "F\u00e4lle_Meldedatum": 1327,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24436,7 +24436,7 @@
         "Datum_neu": 1638403200000,
         "F\u00e4lle_Meldedatum": 885,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24626,7 +24626,7 @@
         "Datum_neu": 1638835200000,
         "F\u00e4lle_Meldedatum": 1253,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24664,7 +24664,7 @@
         "Datum_neu": 1638921600000,
         "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24892,7 +24892,7 @@
         "Datum_neu": 1639440000000,
         "F\u00e4lle_Meldedatum": 1054,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24930,7 +24930,7 @@
         "Datum_neu": 1639526400000,
         "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25120,7 +25120,7 @@
         "Datum_neu": 1639958400000,
         "F\u00e4lle_Meldedatum": 552,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 44,
+        "Hosp_Meldedatum": 45,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25310,7 +25310,7 @@
         "Datum_neu": 1640390400000,
         "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25614,7 +25614,7 @@
         "Datum_neu": 1641081600000,
         "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25766,7 +25766,7 @@
         "Datum_neu": 1641427200000,
         "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25956,7 +25956,7 @@
         "Datum_neu": 1641859200000,
         "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26032,7 +26032,7 @@
         "Datum_neu": 1642032000000,
         "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26144,7 +26144,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642291200000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1318,
+        "F\u00e4lle_Meldedatum": 1319,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26868,7 +26868,7 @@
         "Datum_neu": 1643932800000,
         "F\u00e4lle_Meldedatum": 1103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26904,7 +26904,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644019200000,
-        "F\u00e4lle_Meldedatum": 490,
+        "F\u00e4lle_Meldedatum": 491,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -27134,7 +27134,7 @@
         "Datum_neu": 1644537600000,
         "F\u00e4lle_Meldedatum": 957,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27248,7 +27248,7 @@
         "Datum_neu": 1644796800000,
         "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1239,
+        "F\u00e4lle_Meldedatum": 1240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27436,7 +27436,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645228800000,
-        "F\u00e4lle_Meldedatum": 514,
+        "F\u00e4lle_Meldedatum": 513,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27474,7 +27474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 436,
+        "F\u00e4lle_Meldedatum": 435,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -27550,7 +27550,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1188,
+        "F\u00e4lle_Meldedatum": 1189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27626,7 +27626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1198,
+        "F\u00e4lle_Meldedatum": 1196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27702,7 +27702,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645833600000,
-        "F\u00e4lle_Meldedatum": 583,
+        "F\u00e4lle_Meldedatum": 584,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27740,7 +27740,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 294,
+        "F\u00e4lle_Meldedatum": 295,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27778,7 +27778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1581,
+        "F\u00e4lle_Meldedatum": 1583,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1804,
+        "F\u00e4lle_Meldedatum": 1806,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27828,7 +27828,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27854,13 +27854,13 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1357,
+        "F\u00e4lle_Meldedatum": 1361,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 1014.5,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 920,
-        "Krh_I_belegt": 184,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -27870,7 +27870,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.27,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.03.2022"
@@ -27892,9 +27892,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1208,
+        "F\u00e4lle_Meldedatum": 1210,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 1151.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 945,
@@ -27908,7 +27908,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.22,
+        "H_Inzidenz": 9.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.03.2022"
@@ -27930,9 +27930,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 968,
+        "F\u00e4lle_Meldedatum": 974,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1176,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 981,
@@ -27946,7 +27946,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.92,
+        "H_Inzidenz": 9.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.03.2022"
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 784,
+        "F\u00e4lle_Meldedatum": 793,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1228.3,
@@ -27984,7 +27984,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.31,
+        "H_Inzidenz": 8.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.03.2022"
@@ -28006,7 +28006,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646524800000,
-        "F\u00e4lle_Meldedatum": 351,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1161.2,
@@ -28022,7 +28022,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.86,
+        "H_Inzidenz": 8.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.03.2022"
@@ -28044,9 +28044,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 1894,
+        "F\u00e4lle_Meldedatum": 2024,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 1220,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1013,
@@ -28060,7 +28060,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
+        "H_Inzidenz": 8.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.03.2022"
@@ -28071,34 +28071,34 @@
         "Datum": "08.03.2022",
         "Fallzahl": 136420,
         "ObjectId": 732,
-        "Sterbefall": 1601,
-        "Genesungsfall": 121173,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4699,
-        "Zuwachs_Fallzahl": 1525,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 22,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1175,
         "BelegteBetten": null,
         "Inzidenz": 1303,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 1371,
+        "F\u00e4lle_Meldedatum": 2002,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 1121.8,
-        "Fallzahl_aktiv": 13646,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1042,
         "Krh_I_belegt": 167,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 350,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.73,
+        "H_Inzidenz": 7.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.03.2022"
@@ -28111,7 +28111,7 @@
         "ObjectId": 733,
         "Sterbefall": 1605,
         "Genesungsfall": 122601,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4722,
         "Zuwachs_Fallzahl": 2474,
         "Zuwachs_Sterbefall": 4,
@@ -28120,13 +28120,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1424.79974137002,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 328,
-        "Zeitraum": "02.03.2022 - 08.03.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1609,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1179.6,
         "Fallzahl_aktiv": 14688,
-        "Krh_N_belegt": 1042,
-        "Krh_I_belegt": 167,
+        "Krh_N_belegt": 1062,
+        "Krh_I_belegt": 180,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 1042,
         "Krh_I": null,
@@ -28134,13 +28134,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 5269,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
-        "H_Zeitraum": "02.03.2022 - 08.03.2022",
-        "H_Datum": "08.03.2023",
+        "H_Inzidenz": 7.62,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.03.2022",
+        "Fallzahl": 141272,
+        "ObjectId": 734,
+        "Sterbefall": 1606,
+        "Genesungsfall": 123793,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4741,
+        "Zuwachs_Fallzahl": 2378,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 1192,
+        "BelegteBetten": null,
+        "Inzidenz": 1612.30647652574,
+        "Datum_neu": 1646870400000,
+        "F\u00e4lle_Meldedatum": 293,
+        "Zeitraum": "03.03.2022 - 09.03.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1403.2,
+        "Fallzahl_aktiv": 15873,
+        "Krh_N_belegt": 1062,
+        "Krh_I_belegt": 180,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1185,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 5451,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.33,
+        "H_Zeitraum": "03.03.2022 - 09.03.2022",
+        "H_Datum": "09.03.2022",
+        "Datum_Bett": "09.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
