### PR TITLE
New data set: 2022-03-17T113403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-16T113503Z.json
+pjson/2022-03-17T113403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-16T113503Z.json pjson/2022-03-17T113403Z.json```:
```
--- pjson/2022-03-16T113503Z.json	2022-03-16 11:35:03.475073107 +0000
+++ pjson/2022-03-17T113403Z.json	2022-03-17 11:34:03.999269492 +0000
@@ -25878,7 +25878,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1498,
+        "F\u00e4lle_Meldedatum": 1497,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1803,
+        "F\u00e4lle_Meldedatum": 1804,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1242,
+        "F\u00e4lle_Meldedatum": 1243,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27588,7 +27588,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1416,
+        "F\u00e4lle_Meldedatum": 1417,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1809,
+        "F\u00e4lle_Meldedatum": 1810,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27892,7 +27892,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1204,
+        "F\u00e4lle_Meldedatum": 1205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -27930,7 +27930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 978,
+        "F\u00e4lle_Meldedatum": 979,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2042,
+        "F\u00e4lle_Meldedatum": 2043,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2080,
+        "F\u00e4lle_Meldedatum": 2078,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28118,15 +28118,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1428,
         "BelegteBetten": null,
-        "Inzidenz": 1424.79974137002,
+        "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2087,
+        "F\u00e4lle_Meldedatum": 2089,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 1179.6,
+        "Hosp_Meldedatum": 20,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1062,
-        "Krh_I_belegt": 180,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28136,7 +28136,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.12,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.03.2022"
@@ -28158,9 +28158,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1612.30647652574,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1794,
+        "F\u00e4lle_Meldedatum": 1796,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1403.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1098,
@@ -28174,7 +28174,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.12,
+        "H_Inzidenz": 9.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.03.2022"
@@ -28196,9 +28196,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1726.89392578756,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1896,
+        "F\u00e4lle_Meldedatum": 1905,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1511.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1132,
@@ -28212,7 +28212,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.56,
+        "H_Inzidenz": 9.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.03.2022"
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1606.9183519523,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1077,
+        "F\u00e4lle_Meldedatum": 1103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1669.5,
@@ -28250,7 +28250,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.79,
+        "H_Inzidenz": 10.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.03.2022"
@@ -28272,9 +28272,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1519.45112971012,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 347,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1590,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1143,
@@ -28288,7 +28288,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.76,
+        "H_Inzidenz": 10.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.03.2022"
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1836.81166708574,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2534,
+        "F\u00e4lle_Meldedatum": 2712,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 1636.4,
@@ -28322,11 +28322,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.64,
+        "H_Inzidenz": 10.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.03.2022"
@@ -28337,34 +28337,34 @@
         "Datum": "15.03.2022",
         "Fallzahl": 147554,
         "ObjectId": 739,
-        "Sterbefall": 1611,
-        "Genesungsfall": 128880,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4797,
-        "Zuwachs_Fallzahl": 1760,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1810,
         "BelegteBetten": null,
         "Inzidenz": 1781.67319228421,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 1333,
+        "F\u00e4lle_Meldedatum": 2261,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1637.5,
-        "Fallzahl_aktiv": 17063,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1312,
         "Krh_I_belegt": 171,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -51,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.81,
+        "H_Inzidenz": 10.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.03.2022"
@@ -28377,7 +28377,7 @@
         "ObjectId": 740,
         "Sterbefall": 1614,
         "Genesungsfall": 130248,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4804,
         "Zuwachs_Fallzahl": 3275,
         "Zuwachs_Sterbefall": 3,
@@ -28386,13 +28386,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1987.85875929451,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 249,
-        "Zeitraum": "09.03.2022 - 15.03.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 1095,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1717.5,
         "Fallzahl_aktiv": 18967,
-        "Krh_N_belegt": 1312,
-        "Krh_I_belegt": 171,
+        "Krh_N_belegt": 1372,
+        "Krh_I_belegt": 159,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 1904,
         "Krh_I": null,
@@ -28400,13 +28400,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 6300,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.89,
-        "H_Zeitraum": "09.03.2022 - 15.03.2022",
+        "H_Inzidenz": 9.59,
+        "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.03.2022",
+        "Fallzahl": 153110,
+        "ObjectId": 741,
+        "Sterbefall": 1616,
+        "Genesungsfall": 131443,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4830,
+        "Zuwachs_Fallzahl": 2281,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 26,
+        "Zuwachs_Genesung": 1195,
+        "BelegteBetten": null,
+        "Inzidenz": 2018.93027766802,
+        "Datum_neu": 1647475200000,
+        "F\u00e4lle_Meldedatum": 266,
+        "Zeitraum": "10.03.2022 - 16.03.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1827,
+        "Fallzahl_aktiv": 20051,
+        "Krh_N_belegt": 1372,
+        "Krh_I_belegt": 159,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1084,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 6411,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.74,
+        "H_Zeitraum": "10.03.2022 - 16.03.2022",
+        "H_Datum": "16.03.2022",
+        "Datum_Bett": "16.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
