### PR TITLE
New data set: 2022-03-18T113404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-17T113403Z.json
+pjson/2022-03-18T113404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-17T113403Z.json pjson/2022-03-18T113404Z.json```:
```
--- pjson/2022-03-17T113403Z.json	2022-03-17 11:34:03.999269492 +0000
+++ pjson/2022-03-18T113404Z.json	2022-03-18 11:34:04.343033051 +0000
@@ -14212,7 +14212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -26524,7 +26524,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 1145,
+        "F\u00e4lle_Meldedatum": 1144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1804,
+        "F\u00e4lle_Meldedatum": 1803,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 942,
+        "F\u00e4lle_Meldedatum": 943,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27588,7 +27588,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1417,
+        "F\u00e4lle_Meldedatum": 1419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -27626,7 +27626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1199,
+        "F\u00e4lle_Meldedatum": 1198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1810,
+        "F\u00e4lle_Meldedatum": 1817,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1358,
+        "F\u00e4lle_Meldedatum": 1356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27892,7 +27892,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1205,
+        "F\u00e4lle_Meldedatum": 1204,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -27930,7 +27930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 979,
+        "F\u00e4lle_Meldedatum": 978,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 791,
+        "F\u00e4lle_Meldedatum": 790,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2043,
+        "F\u00e4lle_Meldedatum": 2038,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28156,25 +28156,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1192,
         "BelegteBetten": null,
-        "Inzidenz": 1612.30647652574,
+        "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1796,
+        "F\u00e4lle_Meldedatum": 1797,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 1403.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1098,
-        "Krh_I_belegt": 179,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.51,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.03.2022"
@@ -28196,9 +28196,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1726.89392578756,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1905,
+        "F\u00e4lle_Meldedatum": 1921,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1511.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1132,
@@ -28212,7 +28212,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.96,
+        "H_Inzidenz": 10.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.03.2022"
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1606.9183519523,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1103,
+        "F\u00e4lle_Meldedatum": 1110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 1669.5,
@@ -28250,7 +28250,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.18,
+        "H_Inzidenz": 10.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.03.2022"
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1519.45112971012,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 379,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1590,
@@ -28288,7 +28288,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.23,
+        "H_Inzidenz": 10.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.03.2022"
@@ -28310,9 +28310,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1836.81166708574,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2712,
+        "F\u00e4lle_Meldedatum": 2806,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 1636.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1254,
@@ -28322,11 +28322,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.33,
+        "H_Inzidenz": 10.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.03.2022"
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1781.67319228421,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2261,
+        "F\u00e4lle_Meldedatum": 2505,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1637.5,
@@ -28364,7 +28364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.92,
+        "H_Inzidenz": 11.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.03.2022"
@@ -28375,34 +28375,34 @@
         "Datum": "16.03.2022",
         "Fallzahl": 150829,
         "ObjectId": 740,
-        "Sterbefall": 1614,
-        "Genesungsfall": 130248,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4804,
-        "Zuwachs_Fallzahl": 3275,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1368,
         "BelegteBetten": null,
         "Inzidenz": 1987.85875929451,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 1095,
+        "F\u00e4lle_Meldedatum": 2580,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1717.5,
-        "Fallzahl_aktiv": 18967,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1372,
         "Krh_I_belegt": 159,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1904,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.59,
+        "H_Inzidenz": 10.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.03.2022"
@@ -28415,7 +28415,7 @@
         "ObjectId": 741,
         "Sterbefall": 1616,
         "Genesungsfall": 131443,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4830,
         "Zuwachs_Fallzahl": 2281,
         "Zuwachs_Sterbefall": 2,
@@ -28424,12 +28424,12 @@
         "BelegteBetten": null,
         "Inzidenz": 2018.93027766802,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 266,
-        "Zeitraum": "10.03.2022 - 16.03.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 912,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1827,
         "Fallzahl_aktiv": 20051,
-        "Krh_N_belegt": 1372,
+        "Krh_N_belegt": 1362,
         "Krh_I_belegt": 159,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 1084,
@@ -28438,13 +28438,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 6411,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
-        "H_Zeitraum": "10.03.2022 - 16.03.2022",
-        "H_Datum": "16.03.2022",
+        "H_Inzidenz": 9.47,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.03.2022",
+        "Fallzahl": 155843,
+        "ObjectId": 742,
+        "Sterbefall": 1619,
+        "Genesungsfall": 132433,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4841,
+        "Zuwachs_Fallzahl": 2733,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 990,
+        "BelegteBetten": null,
+        "Inzidenz": 2193.50551384748,
+        "Datum_neu": 1647561600000,
+        "F\u00e4lle_Meldedatum": 232,
+        "Zeitraum": "11.03.2022 - 17.03.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1851.6,
+        "Fallzahl_aktiv": 21791,
+        "Krh_N_belegt": 1362,
+        "Krh_I_belegt": 159,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1740,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 6565,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.89,
+        "H_Zeitraum": "11.03.2022 - 17.03.2022",
+        "H_Datum": "17.03.2022",
+        "Datum_Bett": "17.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
