### PR TITLE
New data set: 2022-03-22T113702Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-21T120502Z.json
+pjson/2022-03-22T113702Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-21T120502Z.json pjson/2022-03-22T113702Z.json```:
```
--- pjson/2022-03-21T120502Z.json	2022-03-21 12:05:02.965255822 +0000
+++ pjson/2022-03-22T113702Z.json	2022-03-22 11:37:03.088999004 +0000
@@ -25726,7 +25726,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641340800000,
-        "F\u00e4lle_Meldedatum": 340,
+        "F\u00e4lle_Meldedatum": 339,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1802,
+        "F\u00e4lle_Meldedatum": 1803,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1482,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 943,
+        "F\u00e4lle_Meldedatum": 944,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1159,
+        "F\u00e4lle_Meldedatum": 1160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27398,7 +27398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 902,
+        "F\u00e4lle_Meldedatum": 903,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 799,
+        "F\u00e4lle_Meldedatum": 800,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1356,
+        "F\u00e4lle_Meldedatum": 1360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27930,7 +27930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 978,
+        "F\u00e4lle_Meldedatum": 979,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27968,9 +27968,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 790,
+        "F\u00e4lle_Meldedatum": 791,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2037,
+        "F\u00e4lle_Meldedatum": 2034,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2091,
+        "F\u00e4lle_Meldedatum": 2093,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28158,7 +28158,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1800,
+        "F\u00e4lle_Meldedatum": 1796,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1927,
+        "F\u00e4lle_Meldedatum": 1923,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 381,
+        "F\u00e4lle_Meldedatum": 382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28308,15 +28308,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1564,
         "BelegteBetten": null,
-        "Inzidenz": 1836.81166708574,
+        "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2828,
+        "F\u00e4lle_Meldedatum": 2845,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
-        "Inzidenz_RKI": 1636.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1254,
-        "Krh_I_belegt": 155,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28326,7 +28326,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.03.2022"
@@ -28348,9 +28348,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1781.67319228421,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2551,
+        "F\u00e4lle_Meldedatum": 2571,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1637.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1312,
@@ -28364,7 +28364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.71,
+        "H_Inzidenz": 12.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.03.2022"
@@ -28386,9 +28386,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1987.85875929451,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2718,
+        "F\u00e4lle_Meldedatum": 2777,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1717.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1372,
@@ -28402,7 +28402,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.07,
+        "H_Inzidenz": 11.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.03.2022"
@@ -28424,9 +28424,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2018.93027766802,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2409,
+        "F\u00e4lle_Meldedatum": 2608,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": 1827,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1362,
@@ -28440,7 +28440,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.23,
+        "H_Inzidenz": 10.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.03.2022"
@@ -28451,34 +28451,34 @@
         "Datum": "18.03.2022",
         "Fallzahl": 155843,
         "ObjectId": 742,
-        "Sterbefall": 1619,
-        "Genesungsfall": 132433,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4841,
-        "Zuwachs_Fallzahl": 2733,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 990,
         "BelegteBetten": null,
         "Inzidenz": 2193.50551384748,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 1146,
+        "F\u00e4lle_Meldedatum": 2449,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1851.6,
-        "Fallzahl_aktiv": 21791,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1385,
         "Krh_I_belegt": 166,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1740,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.34,
+        "H_Inzidenz": 10.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.03.2022"
@@ -28490,7 +28490,7 @@
         "Fallzahl": 157845,
         "ObjectId": 743,
         "Sterbefall": null,
-        "Genesungsfall": 133249,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -28500,9 +28500,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1890.1541003628,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 352,
+        "F\u00e4lle_Meldedatum": 918,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1997.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1380,
@@ -28516,7 +28516,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.26,
+        "H_Inzidenz": 9.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.03.2022"
@@ -28528,7 +28528,7 @@
         "Fallzahl": 157880,
         "ObjectId": 744,
         "Sterbefall": null,
-        "Genesungsfall": 133630,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -28538,9 +28538,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1732.6412586659,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 1932.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1371,
@@ -28550,11 +28550,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.49,
+        "H_Inzidenz": 9.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.03.2022"
@@ -28567,7 +28567,7 @@
         "ObjectId": 745,
         "Sterbefall": 1620,
         "Genesungsfall": 135642,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4860,
         "Zuwachs_Fallzahl": 3220,
         "Zuwachs_Sterbefall": 1,
@@ -28576,27 +28576,65 @@
         "BelegteBetten": null,
         "Inzidenz": 2166.38528682783,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 168,
-        "Zeitraum": "14.03.2022 - 20.03.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 625,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 1988.8,
         "Fallzahl_aktiv": 21801,
-        "Krh_N_belegt": 1371,
-        "Krh_I_belegt": 152,
+        "Krh_N_belegt": 1462,
+        "Krh_I_belegt": 178,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 1207,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
-        "Mutation": 6830,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.83,
-        "H_Zeitraum": "14.03.2022 - 20.03.2022",
-        "H_Datum": "20.03.2022",
+        "H_Inzidenz": 8.53,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.03.2022",
+        "Fallzahl": 162046,
+        "ObjectId": 746,
+        "Sterbefall": 1623,
+        "Genesungsfall": 137695,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4914,
+        "Zuwachs_Fallzahl": 2983,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 54,
+        "Zuwachs_Genesung": 2053,
+        "BelegteBetten": null,
+        "Inzidenz": 2160.6379539495,
+        "Datum_neu": 1647907200000,
+        "F\u00e4lle_Meldedatum": 335,
+        "Zeitraum": "15.03.2022 - 21.03.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1904.6,
+        "Fallzahl_aktiv": 22728,
+        "Krh_N_belegt": 1462,
+        "Krh_I_belegt": 178,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 927,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 6954,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.9,
+        "H_Zeitraum": "15.03.2022 - 21.03.2022",
+        "H_Datum": "21.03.2022",
+        "Datum_Bett": "21.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
