### PR TITLE
New data set: 2022-03-23T111502Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-22T113702Z.json
+pjson/2022-03-23T111502Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-22T113702Z.json pjson/2022-03-23T111502Z.json```:
```
--- pjson/2022-03-22T113702Z.json	2022-03-22 11:37:03.088999004 +0000
+++ pjson/2022-03-23T111502Z.json	2022-03-23 11:15:02.875564825 +0000
@@ -10146,7 +10146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605916800000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -13794,7 +13794,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614211200000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -14364,7 +14364,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615507200000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -23838,7 +23838,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 7,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24484,7 +24484,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 12,
+        "SterbeF_Sterbedatum": 13,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -24978,7 +24978,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 6,
+        "SterbeF_Sterbedatum": 7,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -25042,7 +25042,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639785600000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 683,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 958,
+        "F\u00e4lle_Meldedatum": 959,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1243,
+        "F\u00e4lle_Meldedatum": 1246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27514,7 +27514,7 @@
         "Datum_neu": 1645401600000,
         "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1827,
+        "F\u00e4lle_Meldedatum": 1828,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 791,
+        "F\u00e4lle_Meldedatum": 790,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2093,
+        "F\u00e4lle_Meldedatum": 2095,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1923,
+        "F\u00e4lle_Meldedatum": 1925,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1111,
+        "F\u00e4lle_Meldedatum": 1109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 382,
+        "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2845,
+        "F\u00e4lle_Meldedatum": 2850,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -28346,15 +28346,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1810,
         "BelegteBetten": null,
-        "Inzidenz": 1781.67319228421,
+        "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2571,
+        "F\u00e4lle_Meldedatum": 2577,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 1637.5,
+        "Hosp_Meldedatum": 18,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1312,
-        "Krh_I_belegt": 171,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28364,7 +28364,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.03,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.03.2022"
@@ -28386,9 +28386,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1987.85875929451,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2777,
+        "F\u00e4lle_Meldedatum": 2778,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1717.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1372,
@@ -28402,7 +28402,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.41,
+        "H_Inzidenz": 11.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.03.2022"
@@ -28424,9 +28424,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2018.93027766802,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2608,
+        "F\u00e4lle_Meldedatum": 2648,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1827,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1362,
@@ -28436,11 +28436,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.75,
+        "H_Inzidenz": 11.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.03.2022"
@@ -28462,9 +28462,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2193.50551384748,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2449,
+        "F\u00e4lle_Meldedatum": 2561,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 1851.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1385,
@@ -28478,7 +28478,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.3,
+        "H_Inzidenz": 10.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.03.2022"
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1890.1541003628,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 918,
+        "F\u00e4lle_Meldedatum": 1444,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1997.4,
@@ -28516,7 +28516,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.66,
+        "H_Inzidenz": 10.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.03.2022"
@@ -28538,9 +28538,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1732.6412586659,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1932.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1371,
@@ -28554,7 +28554,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.05,
+        "H_Inzidenz": 10.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.03.2022"
@@ -28565,34 +28565,34 @@
         "Datum": "21.03.2022",
         "Fallzahl": 159063,
         "ObjectId": 745,
-        "Sterbefall": 1620,
-        "Genesungsfall": 135642,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4860,
-        "Zuwachs_Fallzahl": 3220,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2012,
         "BelegteBetten": null,
         "Inzidenz": 2166.38528682783,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 625,
+        "F\u00e4lle_Meldedatum": 1689,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": 1988.8,
-        "Fallzahl_aktiv": 21801,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1462,
         "Krh_I_belegt": 178,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1207,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.53,
+        "H_Inzidenz": 9.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.03.2022"
@@ -28605,7 +28605,7 @@
         "ObjectId": 746,
         "Sterbefall": 1623,
         "Genesungsfall": 137695,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4914,
         "Zuwachs_Fallzahl": 2983,
         "Zuwachs_Sterbefall": 3,
@@ -28614,13 +28614,13 @@
         "BelegteBetten": null,
         "Inzidenz": 2160.6379539495,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 335,
-        "Zeitraum": "15.03.2022 - 21.03.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1066,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1904.6,
         "Fallzahl_aktiv": 22728,
-        "Krh_N_belegt": 1462,
-        "Krh_I_belegt": 178,
+        "Krh_N_belegt": 1577,
+        "Krh_I_belegt": 194,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 927,
         "Krh_I": null,
@@ -28628,13 +28628,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 6954,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.9,
-        "H_Zeitraum": "15.03.2022 - 21.03.2022",
-        "H_Datum": "21.03.2022",
+        "H_Inzidenz": 9.32,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.03.2022",
+        "Fallzahl": 165040,
+        "ObjectId": 747,
+        "Sterbefall": 1625,
+        "Genesungsfall": 139787,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4937,
+        "Zuwachs_Fallzahl": 2994,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 2092,
+        "BelegteBetten": null,
+        "Inzidenz": 2234.45526060563,
+        "Datum_neu": 1647993600000,
+        "F\u00e4lle_Meldedatum": 327,
+        "Zeitraum": "16.03.2022 - 22.03.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1965.2,
+        "Fallzahl_aktiv": 23628,
+        "Krh_N_belegt": 1577,
+        "Krh_I_belegt": 194,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 900,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 7152,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.89,
+        "H_Zeitraum": "16.03.2022 - 22.03.2022",
+        "H_Datum": "22.03.2022",
+        "Datum_Bett": "22.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
