### PR TITLE
New data set: 2022-03-24T111703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-23T111502Z.json
+pjson/2022-03-24T111703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-23T111502Z.json pjson/2022-03-24T111703Z.json```:
```
--- pjson/2022-03-23T111502Z.json	2022-03-23 11:15:02.875564825 +0000
+++ pjson/2022-03-24T111703Z.json	2022-03-24 11:17:03.838244101 +0000
@@ -23294,7 +23294,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635811200000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1347,
+        "F\u00e4lle_Meldedatum": 1348,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1246,
+        "F\u00e4lle_Meldedatum": 1247,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -27628,7 +27628,7 @@
         "Datum_neu": 1645660800000,
         "F\u00e4lle_Meldedatum": 1198,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27856,7 +27856,7 @@
         "Datum_neu": 1646179200000,
         "F\u00e4lle_Meldedatum": 1360,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2095,
+        "F\u00e4lle_Meldedatum": 2097,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28158,9 +28158,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1796,
+        "F\u00e4lle_Meldedatum": 1798,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1109,
+        "F\u00e4lle_Meldedatum": 1110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2850,
+        "F\u00e4lle_Meldedatum": 2854,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -28322,7 +28322,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28348,9 +28348,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2577,
+        "F\u00e4lle_Meldedatum": 2588,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28360,7 +28360,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28384,15 +28384,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1368,
         "BelegteBetten": null,
-        "Inzidenz": 1987.85875929451,
+        "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2778,
+        "F\u00e4lle_Meldedatum": 2772,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
-        "Inzidenz_RKI": 1717.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1372,
-        "Krh_I_belegt": 159,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28402,7 +28402,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.03.2022"
@@ -28424,9 +28424,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2018.93027766802,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2648,
+        "F\u00e4lle_Meldedatum": 2649,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 1827,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1362,
@@ -28440,7 +28440,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.22,
+        "H_Inzidenz": 11.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.03.2022"
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2193.50551384748,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2561,
+        "F\u00e4lle_Meldedatum": 2587,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 1851.6,
@@ -28478,7 +28478,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.97,
+        "H_Inzidenz": 11.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.03.2022"
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1890.1541003628,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1444,
+        "F\u00e4lle_Meldedatum": 1494,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1997.4,
@@ -28516,7 +28516,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.75,
+        "H_Inzidenz": 11.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.03.2022"
@@ -28538,9 +28538,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1732.6412586659,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1932.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1371,
@@ -28554,7 +28554,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.38,
+        "H_Inzidenz": 11.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.03.2022"
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2166.38528682783,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 1689,
+        "F\u00e4lle_Meldedatum": 2872,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": 1988.8,
@@ -28592,7 +28592,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.98,
+        "H_Inzidenz": 10.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.03.2022"
@@ -28603,34 +28603,34 @@
         "Datum": "22.03.2022",
         "Fallzahl": 162046,
         "ObjectId": 746,
-        "Sterbefall": 1623,
-        "Genesungsfall": 137695,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4914,
-        "Zuwachs_Fallzahl": 2983,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 54,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2053,
         "BelegteBetten": null,
         "Inzidenz": 2160.6379539495,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 1066,
+        "F\u00e4lle_Meldedatum": 1419,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1904.6,
-        "Fallzahl_aktiv": 22728,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1577,
         "Krh_I_belegt": 194,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 927,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.32,
+        "H_Inzidenz": 10.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.03.2022"
@@ -28643,7 +28643,7 @@
         "ObjectId": 747,
         "Sterbefall": 1625,
         "Genesungsfall": 139787,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4937,
         "Zuwachs_Fallzahl": 2994,
         "Zuwachs_Sterbefall": 2,
@@ -28652,13 +28652,13 @@
         "BelegteBetten": null,
         "Inzidenz": 2234.45526060563,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 327,
-        "Zeitraum": "16.03.2022 - 22.03.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 938,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1965.2,
         "Fallzahl_aktiv": 23628,
-        "Krh_N_belegt": 1577,
-        "Krh_I_belegt": 194,
+        "Krh_N_belegt": 1566,
+        "Krh_I_belegt": 186,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 900,
         "Krh_I": null,
@@ -28666,13 +28666,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 7152,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.89,
-        "H_Zeitraum": "16.03.2022 - 22.03.2022",
-        "H_Datum": "22.03.2022",
+        "H_Inzidenz": 9.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.03.2022",
+        "Fallzahl": 167684,
+        "ObjectId": 748,
+        "Sterbefall": 1628,
+        "Genesungsfall": 141591,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4958,
+        "Zuwachs_Fallzahl": 2644,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 1804,
+        "BelegteBetten": null,
+        "Inzidenz": 2206.25740867129,
+        "Datum_neu": 1648080000000,
+        "F\u00e4lle_Meldedatum": 333,
+        "Zeitraum": "17.03.2022 - 23.03.2022",
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 1880.3,
+        "Fallzahl_aktiv": 24465,
+        "Krh_N_belegt": 1566,
+        "Krh_I_belegt": 186,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 837,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 7291,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.36,
+        "H_Zeitraum": "17.03.2022 - 23.03.2022",
+        "H_Datum": "23.03.2022",
+        "Datum_Bett": "23.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
