### PR TITLE
New data set: 2022-03-25T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-24T111703Z.json
+pjson/2022-03-25T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-24T111703Z.json pjson/2022-03-25T110903Z.json```:
```
--- pjson/2022-03-24T111703Z.json	2022-03-24 11:17:03.838244101 +0000
+++ pjson/2022-03-25T110903Z.json	2022-03-25 11:09:03.263126096 +0000
@@ -10754,7 +10754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1607299200000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 385,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -14250,7 +14250,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615248000000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -14592,7 +14592,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616025600000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -14630,7 +14630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 657,
+        "F\u00e4lle_Meldedatum": 658,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1247,
+        "F\u00e4lle_Meldedatum": 1246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27474,7 +27474,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645315200000,
-        "F\u00e4lle_Meldedatum": 435,
+        "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1828,
+        "F\u00e4lle_Meldedatum": 1829,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1360,
+        "F\u00e4lle_Meldedatum": 1361,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27930,7 +27930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 979,
+        "F\u00e4lle_Meldedatum": 980,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27970,7 +27970,7 @@
         "Datum_neu": 1646438400000,
         "F\u00e4lle_Meldedatum": 790,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2034,
+        "F\u00e4lle_Meldedatum": 2035,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2078,
+        "F\u00e4lle_Meldedatum": 2079,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28158,7 +28158,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1798,
+        "F\u00e4lle_Meldedatum": 1799,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1925,
+        "F\u00e4lle_Meldedatum": 1928,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 384,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28312,7 +28312,7 @@
         "Datum_neu": 1647216000000,
         "F\u00e4lle_Meldedatum": 2854,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2588,
+        "F\u00e4lle_Meldedatum": 2591,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2772,
+        "F\u00e4lle_Meldedatum": 2776,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28422,15 +28422,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1195,
         "BelegteBetten": null,
-        "Inzidenz": 2018.93027766802,
+        "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2649,
+        "F\u00e4lle_Meldedatum": 2650,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 1827,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1362,
-        "Krh_I_belegt": 159,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28440,7 +28440,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.51,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.03.2022"
@@ -28462,9 +28462,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2193.50551384748,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2587,
+        "F\u00e4lle_Meldedatum": 2602,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1851.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1385,
@@ -28478,7 +28478,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.34,
+        "H_Inzidenz": 11.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.03.2022"
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1890.1541003628,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1494,
+        "F\u00e4lle_Meldedatum": 1507,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1997.4,
@@ -28516,7 +28516,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.26,
+        "H_Inzidenz": 11.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.03.2022"
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1732.6412586659,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 348,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1932.5,
@@ -28554,7 +28554,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.07,
+        "H_Inzidenz": 11.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.03.2022"
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2166.38528682783,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 2872,
+        "F\u00e4lle_Meldedatum": 3031,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": 1988.8,
@@ -28592,7 +28592,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.75,
+        "H_Inzidenz": 10.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.03.2022"
@@ -28614,9 +28614,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2160.6379539495,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 1419,
+        "F\u00e4lle_Meldedatum": 2722,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1904.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1577,
@@ -28626,11 +28626,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.53,
+        "H_Inzidenz": 11.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.03.2022"
@@ -28641,34 +28641,34 @@
         "Datum": "23.03.2022",
         "Fallzahl": 165040,
         "ObjectId": 747,
-        "Sterbefall": 1625,
-        "Genesungsfall": 139787,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4937,
-        "Zuwachs_Fallzahl": 2994,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2092,
         "BelegteBetten": null,
         "Inzidenz": 2234.45526060563,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 938,
+        "F\u00e4lle_Meldedatum": 1091,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1965.2,
-        "Fallzahl_aktiv": 23628,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1566,
         "Krh_I_belegt": 186,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 900,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.56,
+        "H_Inzidenz": 10.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.03.2022"
@@ -28681,7 +28681,7 @@
         "ObjectId": 748,
         "Sterbefall": 1628,
         "Genesungsfall": 141591,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4958,
         "Zuwachs_Fallzahl": 2644,
         "Zuwachs_Sterbefall": 3,
@@ -28690,13 +28690,13 @@
         "BelegteBetten": null,
         "Inzidenz": 2206.25740867129,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 333,
-        "Zeitraum": "17.03.2022 - 23.03.2022",
-        "Hosp_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 790,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1880.3,
         "Fallzahl_aktiv": 24465,
-        "Krh_N_belegt": 1566,
-        "Krh_I_belegt": 186,
+        "Krh_N_belegt": 1496,
+        "Krh_I_belegt": 192,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 837,
         "Krh_I": null,
@@ -28704,13 +28704,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 7291,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.36,
-        "H_Zeitraum": "17.03.2022 - 23.03.2022",
-        "H_Datum": "23.03.2022",
+        "H_Inzidenz": 10.01,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "23.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.03.2022",
+        "Fallzahl": 170105,
+        "ObjectId": 749,
+        "Sterbefall": 1629,
+        "Genesungsfall": 143516,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 4969,
+        "Zuwachs_Fallzahl": 2421,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 1925,
+        "BelegteBetten": null,
+        "Inzidenz": 2171.59380724882,
+        "Datum_neu": 1648166400000,
+        "F\u00e4lle_Meldedatum": 274,
+        "Zeitraum": "18.03.2022 - 24.03.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1881.8,
+        "Fallzahl_aktiv": 24960,
+        "Krh_N_belegt": 1496,
+        "Krh_I_belegt": 192,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 495,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 7402,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.21,
+        "H_Zeitraum": "18.03.2022 - 24.03.2022",
+        "H_Datum": "24.03.2022",
+        "Datum_Bett": "24.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
