### PR TITLE
New data set: 2022-03-28T104404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-25T110903Z.json
+pjson/2022-03-28T104404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-25T110903Z.json pjson/2022-03-28T104404Z.json```:
```
--- pjson/2022-03-25T110903Z.json	2022-03-25 11:09:03.263126096 +0000
+++ pjson/2022-03-28T104404Z.json	2022-03-28 10:44:04.428831544 +0000
@@ -14820,7 +14820,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1006,
+        "F\u00e4lle_Meldedatum": 1007,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1484,
+        "F\u00e4lle_Meldedatum": 1485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1361,
+        "F\u00e4lle_Meldedatum": 1363,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 790,
+        "F\u00e4lle_Meldedatum": 791,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2035,
+        "F\u00e4lle_Meldedatum": 2034,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2079,
+        "F\u00e4lle_Meldedatum": 2080,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2097,
+        "F\u00e4lle_Meldedatum": 2096,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28158,7 +28158,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1799,
+        "F\u00e4lle_Meldedatum": 1800,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1928,
+        "F\u00e4lle_Meldedatum": 1927,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1110,
+        "F\u00e4lle_Meldedatum": 1109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 385,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28310,9 +28310,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2854,
+        "F\u00e4lle_Meldedatum": 2857,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2591,
+        "F\u00e4lle_Meldedatum": 2590,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2776,
+        "F\u00e4lle_Meldedatum": 2784,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28424,9 +28424,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2650,
+        "F\u00e4lle_Meldedatum": 2649,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28460,15 +28460,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 990,
         "BelegteBetten": null,
-        "Inzidenz": 2193.50551384748,
+        "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2602,
+        "F\u00e4lle_Meldedatum": 2609,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
-        "Inzidenz_RKI": 1851.6,
+        "Hosp_Meldedatum": 21,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1385,
-        "Krh_I_belegt": 166,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28478,7 +28478,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.03.2022"
@@ -28498,15 +28498,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 816,
         "BelegteBetten": null,
-        "Inzidenz": 1890.1541003628,
+        "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1507,
+        "F\u00e4lle_Meldedatum": 1509,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 1997.4,
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1380,
-        "Krh_I_belegt": 171,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28516,7 +28516,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.03.2022"
@@ -28536,15 +28536,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 381,
         "BelegteBetten": null,
-        "Inzidenz": 1732.6412586659,
+        "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 348,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 1932.5,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1371,
-        "Krh_I_belegt": 152,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28554,7 +28554,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.19,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.03.2022"
@@ -28576,9 +28576,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2166.38528682783,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3031,
+        "F\u00e4lle_Meldedatum": 3069,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 1988.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1462,
@@ -28592,7 +28592,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.97,
+        "H_Inzidenz": 11.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.03.2022"
@@ -28614,9 +28614,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2160.6379539495,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2722,
+        "F\u00e4lle_Meldedatum": 2950,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1904.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1577,
@@ -28626,11 +28626,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.19,
+        "H_Inzidenz": 11.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.03.2022"
@@ -28652,9 +28652,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2234.45526060563,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 1091,
+        "F\u00e4lle_Meldedatum": 2037,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1965.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1566,
@@ -28664,11 +28664,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.55,
+        "H_Inzidenz": 11.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.03.2022"
@@ -28679,34 +28679,34 @@
         "Datum": "24.03.2022",
         "Fallzahl": 167684,
         "ObjectId": 748,
-        "Sterbefall": 1628,
-        "Genesungsfall": 141591,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4958,
-        "Zuwachs_Fallzahl": 2644,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1804,
         "BelegteBetten": null,
         "Inzidenz": 2206.25740867129,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 790,
+        "F\u00e4lle_Meldedatum": 1392,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1880.3,
-        "Fallzahl_aktiv": 24465,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1496,
         "Krh_I_belegt": 192,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 837,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.01,
+        "H_Inzidenz": 11.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.03.2022"
@@ -28719,7 +28719,7 @@
         "ObjectId": 749,
         "Sterbefall": 1629,
         "Genesungsfall": 143516,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 4969,
         "Zuwachs_Fallzahl": 2421,
         "Zuwachs_Sterbefall": 1,
@@ -28728,13 +28728,13 @@
         "BelegteBetten": null,
         "Inzidenz": 2171.59380724882,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 274,
-        "Zeitraum": "18.03.2022 - 24.03.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 644,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1881.8,
         "Fallzahl_aktiv": 24960,
-        "Krh_N_belegt": 1496,
-        "Krh_I_belegt": 192,
+        "Krh_N_belegt": 1469,
+        "Krh_I_belegt": 194,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 495,
         "Krh_I": null,
@@ -28742,13 +28742,127 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 7402,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.21,
-        "H_Zeitraum": "18.03.2022 - 24.03.2022",
-        "H_Datum": "24.03.2022",
+        "H_Inzidenz": 10.3,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.03.2022",
+        "Fallzahl": 171437,
+        "ObjectId": 750,
+        "Sterbefall": null,
+        "Genesungsfall": 144657,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1141,
+        "BelegteBetten": null,
+        "Inzidenz": 1753.47534034987,
+        "Datum_neu": 1648252800000,
+        "F\u00e4lle_Meldedatum": 187,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 1855.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1492,
+        "Krh_I_belegt": 190,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.17,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.03.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.03.2022",
+        "Fallzahl": 171478,
+        "ObjectId": 751,
+        "Sterbefall": null,
+        "Genesungsfall": 145062,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 405,
+        "BelegteBetten": null,
+        "Inzidenz": 1532.20302453393,
+        "Datum_neu": 1648339200000,
+        "F\u00e4lle_Meldedatum": 243,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 1632.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1488,
+        "Krh_I_belegt": 191,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.58,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.03.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.03.2022",
+        "Fallzahl": 172759,
+        "ObjectId": 752,
+        "Sterbefall": 1632,
+        "Genesungsfall": 147892,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5000,
+        "Zuwachs_Fallzahl": 2654,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 31,
+        "Zuwachs_Genesung": 4376,
+        "BelegteBetten": null,
+        "Inzidenz": 1889.7948920579,
+        "Datum_neu": 1648425600000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "21.03.2022 - 27.03.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1666,
+        "Fallzahl_aktiv": 23235,
+        "Krh_N_belegt": 1488,
+        "Krh_I_belegt": 191,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1725,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 7675,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.01,
+        "H_Zeitraum": "21.03.2022 - 27.03.2022",
+        "H_Datum": "27.03.2022",
+        "Datum_Bett": "27.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
