### PR TITLE
New data set: 2022-03-29T104203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-28T104404Z.json
+pjson/2022-03-29T104203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-28T104404Z.json pjson/2022-03-29T104203Z.json```:
```
--- pjson/2022-03-28T104404Z.json	2022-03-28 10:44:04.428831544 +0000
+++ pjson/2022-03-29T104203Z.json	2022-03-29 10:42:03.826059156 +0000
@@ -11438,7 +11438,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608854400000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -14478,7 +14478,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615766400000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26830,7 +26830,7 @@
         "Datum_neu": 1643846400000,
         "F\u00e4lle_Meldedatum": 1244,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27248,7 +27248,7 @@
         "Datum_neu": 1644796800000,
         "F\u00e4lle_Meldedatum": 1485,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1246,
+        "F\u00e4lle_Meldedatum": 1247,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27588,7 +27588,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645574400000,
-        "F\u00e4lle_Meldedatum": 1419,
+        "F\u00e4lle_Meldedatum": 1420,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2034,
+        "F\u00e4lle_Meldedatum": 2035,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2080,
+        "F\u00e4lle_Meldedatum": 2082,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2096,
+        "F\u00e4lle_Meldedatum": 2097,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2857,
+        "F\u00e4lle_Meldedatum": 2858,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -28348,9 +28348,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2590,
+        "F\u00e4lle_Meldedatum": 2591,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2784,
+        "F\u00e4lle_Meldedatum": 2790,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2649,
+        "F\u00e4lle_Meldedatum": 2641,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2609,
+        "F\u00e4lle_Meldedatum": 2608,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1509,
+        "F\u00e4lle_Meldedatum": 1510,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -28574,15 +28574,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2012,
         "BelegteBetten": null,
-        "Inzidenz": 2166.38528682783,
+        "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3069,
+        "F\u00e4lle_Meldedatum": 3070,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
-        "Inzidenz_RKI": 1988.8,
+        "Hosp_Meldedatum": 36,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1462,
-        "Krh_I_belegt": 178,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28592,7 +28592,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.03.2022"
@@ -28614,9 +28614,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2160.6379539495,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2950,
+        "F\u00e4lle_Meldedatum": 2959,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1904.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1577,
@@ -28630,7 +28630,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.91,
+        "H_Inzidenz": 12.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.03.2022"
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2234.45526060563,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2037,
+        "F\u00e4lle_Meldedatum": 2115,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1965.2,
@@ -28668,7 +28668,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.71,
+        "H_Inzidenz": 12.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.03.2022"
@@ -28690,9 +28690,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2206.25740867129,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 1392,
+        "F\u00e4lle_Meldedatum": 2151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 1880.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1496,
@@ -28706,7 +28706,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.59,
+        "H_Inzidenz": 11.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.03.2022"
@@ -28717,34 +28717,34 @@
         "Datum": "25.03.2022",
         "Fallzahl": 170105,
         "ObjectId": 749,
-        "Sterbefall": 1629,
-        "Genesungsfall": 143516,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 4969,
-        "Zuwachs_Fallzahl": 2421,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1925,
         "BelegteBetten": null,
         "Inzidenz": 2171.59380724882,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 644,
+        "F\u00e4lle_Meldedatum": 1278,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1881.8,
-        "Fallzahl_aktiv": 24960,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1469,
         "Krh_I_belegt": 194,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 495,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.3,
+        "H_Inzidenz": 10.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.03.2022"
@@ -28756,7 +28756,7 @@
         "Fallzahl": 171437,
         "ObjectId": 750,
         "Sterbefall": null,
-        "Genesungsfall": 144657,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -28766,9 +28766,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1753.47534034987,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 1855.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1492,
@@ -28778,11 +28778,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.17,
+        "H_Inzidenz": 10.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.03.2022"
@@ -28794,7 +28794,7 @@
         "Fallzahl": 171478,
         "ObjectId": 751,
         "Sterbefall": null,
-        "Genesungsfall": 145062,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -28804,9 +28804,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1532.20302453393,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 243,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1632.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1488,
@@ -28816,11 +28816,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.58,
+        "H_Inzidenz": 9.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.03.2022"
@@ -28833,36 +28833,74 @@
         "ObjectId": 752,
         "Sterbefall": 1632,
         "Genesungsfall": 147892,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5000,
         "Zuwachs_Fallzahl": 2654,
         "Zuwachs_Sterbefall": 3,
         "Zuwachs_Krankenhauseinweisung": 31,
-        "Zuwachs_Genesung": 4376,
+        "Zuwachs_Genesung": 2830,
         "BelegteBetten": null,
         "Inzidenz": 1889.7948920579,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 11,
-        "Zeitraum": "21.03.2022 - 27.03.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 483,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1666,
         "Fallzahl_aktiv": 23235,
-        "Krh_N_belegt": 1488,
-        "Krh_I_belegt": 191,
+        "Krh_N_belegt": 1493,
+        "Krh_I_belegt": 181,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1725,
+        "Fallzahl_aktiv_Zuwachs": -179,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 7675,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.01,
-        "H_Zeitraum": "21.03.2022 - 27.03.2022",
-        "H_Datum": "27.03.2022",
+        "H_Inzidenz": 9.12,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.03.2022",
+        "Fallzahl": 175155,
+        "ObjectId": 753,
+        "Sterbefall": 1637,
+        "Genesungsfall": 150459,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5024,
+        "Zuwachs_Fallzahl": 2396,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 24,
+        "Zuwachs_Genesung": 2567,
+        "BelegteBetten": null,
+        "Inzidenz": 1715.57886418334,
+        "Datum_neu": 1648512000000,
+        "F\u00e4lle_Meldedatum": 298,
+        "Zeitraum": "22.03.2022 - 28.03.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1408.6,
+        "Fallzahl_aktiv": 23059,
+        "Krh_N_belegt": 1493,
+        "Krh_I_belegt": 181,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -176,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 7844,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.63,
+        "H_Zeitraum": "22.03.2022 - 28.03.2022",
+        "H_Datum": "28.03.2022",
+        "Datum_Bett": "28.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
