### PR TITLE
New data set: 2022-03-30T102704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-29T104203Z.json
+pjson/2022-03-30T102704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-29T104203Z.json pjson/2022-03-30T102704Z.json```:
```
--- pjson/2022-03-29T104203Z.json	2022-03-29 10:42:03.826059156 +0000
+++ pjson/2022-03-30T102704Z.json	2022-03-30 10:27:04.200998220 +0000
@@ -12350,7 +12350,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610928000000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -13832,7 +13832,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1614297600000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -14858,7 +14858,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -15048,7 +15048,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 944,
+        "F\u00e4lle_Meldedatum": 946,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1160,
+        "F\u00e4lle_Meldedatum": 1161,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 791,
+        "F\u00e4lle_Meldedatum": 793,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1927,
+        "F\u00e4lle_Meldedatum": 1926,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1109,
+        "F\u00e4lle_Meldedatum": 1110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2858,
+        "F\u00e4lle_Meldedatum": 2856,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2591,
+        "F\u00e4lle_Meldedatum": 2592,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2790,
+        "F\u00e4lle_Meldedatum": 2789,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2641,
+        "F\u00e4lle_Meldedatum": 2643,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2608,
+        "F\u00e4lle_Meldedatum": 2609,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1510,
+        "F\u00e4lle_Meldedatum": 1508,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28540,7 +28540,7 @@
         "Datum_neu": 1647734400000,
         "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3070,
+        "F\u00e4lle_Meldedatum": 3069,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -28612,15 +28612,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2053,
         "BelegteBetten": null,
-        "Inzidenz": 2160.6379539495,
+        "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2959,
+        "F\u00e4lle_Meldedatum": 2962,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 1904.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1577,
-        "Krh_I_belegt": 194,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28630,7 +28630,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.25,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.03.2022"
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2234.45526060563,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2115,
+        "F\u00e4lle_Meldedatum": 2128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1965.2,
@@ -28668,7 +28668,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.05,
+        "H_Inzidenz": 12.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.03.2022"
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2206.25740867129,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2151,
+        "F\u00e4lle_Meldedatum": 2191,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 1880.3,
@@ -28706,7 +28706,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.98,
+        "H_Inzidenz": 12.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.03.2022"
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2171.59380724882,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1278,
+        "F\u00e4lle_Meldedatum": 1740,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1881.8,
@@ -28744,7 +28744,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.92,
+        "H_Inzidenz": 11.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.03.2022"
@@ -28766,9 +28766,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1753.47534034987,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 286,
+        "F\u00e4lle_Meldedatum": 786,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1855.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1492,
@@ -28782,7 +28782,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.08,
+        "H_Inzidenz": 11.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.03.2022"
@@ -28804,9 +28804,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1532.20302453393,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 280,
+        "F\u00e4lle_Meldedatum": 345,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1632.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1488,
@@ -28820,7 +28820,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.47,
+        "H_Inzidenz": 10.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.03.2022"
@@ -28831,26 +28831,26 @@
         "Datum": "28.03.2022",
         "Fallzahl": 172759,
         "ObjectId": 752,
-        "Sterbefall": 1632,
-        "Genesungsfall": 147892,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5000,
-        "Zuwachs_Fallzahl": 2654,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 31,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2830,
         "BelegteBetten": null,
         "Inzidenz": 1889.7948920579,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 1223,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1666,
-        "Fallzahl_aktiv": 23235,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1493,
         "Krh_I_belegt": 181,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -179,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -28858,7 +28858,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.12,
+        "H_Inzidenz": 10.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.03.2022"
@@ -28871,7 +28871,7 @@
         "ObjectId": 753,
         "Sterbefall": 1637,
         "Genesungsfall": 150459,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5024,
         "Zuwachs_Fallzahl": 2396,
         "Zuwachs_Sterbefall": 5,
@@ -28880,13 +28880,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1715.57886418334,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 298,
-        "Zeitraum": "22.03.2022 - 28.03.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 904,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1408.6,
         "Fallzahl_aktiv": 23059,
-        "Krh_N_belegt": 1493,
-        "Krh_I_belegt": 181,
+        "Krh_N_belegt": 1519,
+        "Krh_I_belegt": 186,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -176,
         "Krh_I": null,
@@ -28894,13 +28894,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 7844,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.63,
-        "H_Zeitraum": "22.03.2022 - 28.03.2022",
-        "H_Datum": "28.03.2022",
+        "H_Inzidenz": 8.67,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.03.2022",
+        "Fallzahl": 177995,
+        "ObjectId": 754,
+        "Sterbefall": 1637,
+        "Genesungsfall": 153243,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5042,
+        "Zuwachs_Fallzahl": 2840,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 2784,
+        "BelegteBetten": null,
+        "Inzidenz": 1673.37188835806,
+        "Datum_neu": 1648598400000,
+        "F\u00e4lle_Meldedatum": 404,
+        "Zeitraum": "23.03.2022 - 29.03.2022",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 1345.7,
+        "Fallzahl_aktiv": 23115,
+        "Krh_N_belegt": 1519,
+        "Krh_I_belegt": 186,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 56,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 7971,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.07,
+        "H_Zeitraum": "23.03.2022 - 29.03.2022",
+        "H_Datum": "29.03.2022",
+        "Datum_Bett": "29.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
