### PR TITLE
New data set: 2022-03-31T105004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-30T102704Z.json
+pjson/2022-03-31T105004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-30T102704Z.json pjson/2022-03-31T105004Z.json```:
```
--- pjson/2022-03-30T102704Z.json	2022-03-30 10:27:04.200998220 +0000
+++ pjson/2022-03-31T105004Z.json	2022-03-31 10:50:04.479694184 +0000
@@ -11324,7 +11324,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608595200000,
-        "F\u00e4lle_Meldedatum": 476,
+        "F\u00e4lle_Meldedatum": 477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -11362,7 +11362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1608681600000,
-        "F\u00e4lle_Meldedatum": 445,
+        "F\u00e4lle_Meldedatum": 444,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -15048,7 +15048,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617062400000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 221,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -24814,7 +24814,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639267200000,
-        "F\u00e4lle_Meldedatum": 156,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 424,
+        "F\u00e4lle_Meldedatum": 423,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1247,
+        "F\u00e4lle_Meldedatum": 1248,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 946,
+        "F\u00e4lle_Meldedatum": 951,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27702,7 +27702,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645833600000,
-        "F\u00e4lle_Meldedatum": 584,
+        "F\u00e4lle_Meldedatum": 585,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27740,7 +27740,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645920000000,
-        "F\u00e4lle_Meldedatum": 297,
+        "F\u00e4lle_Meldedatum": 298,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1829,
+        "F\u00e4lle_Meldedatum": 1828,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27930,7 +27930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 980,
+        "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2856,
+        "F\u00e4lle_Meldedatum": 2857,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2592,
+        "F\u00e4lle_Meldedatum": 2594,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2789,
+        "F\u00e4lle_Meldedatum": 2790,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2643,
+        "F\u00e4lle_Meldedatum": 2669,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2609,
+        "F\u00e4lle_Meldedatum": 2589,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28500,9 +28500,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1508,
+        "F\u00e4lle_Meldedatum": 1504,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28512,7 +28512,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28540,7 +28540,7 @@
         "Datum_neu": 1647734400000,
         "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3069,
+        "F\u00e4lle_Meldedatum": 3065,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2962,
+        "F\u00e4lle_Meldedatum": 2963,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -28650,15 +28650,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2092,
         "BelegteBetten": null,
-        "Inzidenz": 2234.45526060563,
+        "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2128,
+        "F\u00e4lle_Meldedatum": 2129,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 1965.2,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1566,
-        "Krh_I_belegt": 186,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28668,7 +28668,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.45,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.03.2022"
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2206.25740867129,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2191,
+        "F\u00e4lle_Meldedatum": 2201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 1880.3,
@@ -28702,11 +28702,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.42,
+        "H_Inzidenz": 12.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.03.2022"
@@ -28728,9 +28728,9 @@
         "BelegteBetten": null,
         "Inzidenz": 2171.59380724882,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1740,
+        "F\u00e4lle_Meldedatum": 1769,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1881.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1469,
@@ -28744,7 +28744,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.66,
+        "H_Inzidenz": 12.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.03.2022"
@@ -28766,9 +28766,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1753.47534034987,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 786,
+        "F\u00e4lle_Meldedatum": 819,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1855.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1492,
@@ -28782,7 +28782,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.14,
+        "H_Inzidenz": 11.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.03.2022"
@@ -28804,9 +28804,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1532.20302453393,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 345,
+        "F\u00e4lle_Meldedatum": 409,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1632.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1488,
@@ -28820,7 +28820,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.85,
+        "H_Inzidenz": 11.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.03.2022"
@@ -28842,9 +28842,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1889.7948920579,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 1223,
+        "F\u00e4lle_Meldedatum": 2340,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 1666,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1493,
@@ -28858,7 +28858,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.67,
+        "H_Inzidenz": 11.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.03.2022"
@@ -28869,26 +28869,26 @@
         "Datum": "29.03.2022",
         "Fallzahl": 175155,
         "ObjectId": 753,
-        "Sterbefall": 1637,
-        "Genesungsfall": 150459,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5024,
-        "Zuwachs_Fallzahl": 2396,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 24,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2567,
         "BelegteBetten": null,
         "Inzidenz": 1715.57886418334,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 904,
+        "F\u00e4lle_Meldedatum": 1882,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1408.6,
-        "Fallzahl_aktiv": 23059,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1519,
         "Krh_I_belegt": 186,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -176,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -28896,7 +28896,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.67,
+        "H_Inzidenz": 10.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.03.2022"
@@ -28909,7 +28909,7 @@
         "ObjectId": 754,
         "Sterbefall": 1637,
         "Genesungsfall": 153243,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5042,
         "Zuwachs_Fallzahl": 2840,
         "Zuwachs_Sterbefall": 0,
@@ -28918,13 +28918,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1673.37188835806,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 404,
-        "Zeitraum": "23.03.2022 - 29.03.2022",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 1677,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 1345.7,
         "Fallzahl_aktiv": 23115,
-        "Krh_N_belegt": 1519,
-        "Krh_I_belegt": 186,
+        "Krh_N_belegt": 1511,
+        "Krh_I_belegt": 188,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 56,
         "Krh_I": null,
@@ -28932,13 +28932,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 7971,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.07,
-        "H_Zeitraum": "23.03.2022 - 29.03.2022",
-        "H_Datum": "29.03.2022",
+        "H_Inzidenz": 9.39,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "31.03.2022",
+        "Fallzahl": 181646,
+        "ObjectId": 755,
+        "Sterbefall": 1639,
+        "Genesungsfall": 155894,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5073,
+        "Zuwachs_Fallzahl": 3651,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 31,
+        "Zuwachs_Genesung": 2651,
+        "BelegteBetten": null,
+        "Inzidenz": 1993.06727971551,
+        "Datum_neu": 1648684800000,
+        "F\u00e4lle_Meldedatum": 134,
+        "Zeitraum": "24.03.2022 - 30.03.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 1603.8,
+        "Fallzahl_aktiv": 24113,
+        "Krh_N_belegt": 1464,
+        "Krh_I_belegt": 188,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 998,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8311,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.62,
+        "H_Zeitraum": "24.03.2022 - 30.03.2022",
+        "H_Datum": "31.03.2022",
+        "Datum_Bett": "30.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
