### PR TITLE
New data set: 2022-04-01T104704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-03-31T105004Z.json
+pjson/2022-04-01T104704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-03-31T105004Z.json pjson/2022-04-01T104704Z.json```:
```
--- pjson/2022-03-31T105004Z.json	2022-03-31 10:50:04.479694184 +0000
+++ pjson/2022-04-01T104704Z.json	2022-04-01 10:47:04.300272531 +0000
@@ -9350,7 +9350,7 @@
         "Datum_neu": 1604102400000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9388,7 +9388,7 @@
         "Datum_neu": 1604188800000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9426,7 +9426,7 @@
         "Datum_neu": 1604275200000,
         "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9464,7 +9464,7 @@
         "Datum_neu": 1604361600000,
         "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9540,7 +9540,7 @@
         "Datum_neu": 1604534400000,
         "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9578,7 +9578,7 @@
         "Datum_neu": 1604620800000,
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9616,7 +9616,7 @@
         "Datum_neu": 1604707200000,
         "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9654,7 +9654,7 @@
         "Datum_neu": 1604793600000,
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9730,7 +9730,7 @@
         "Datum_neu": 1604966400000,
         "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9768,7 +9768,7 @@
         "Datum_neu": 1605052800000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9806,7 +9806,7 @@
         "Datum_neu": 1605139200000,
         "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9844,7 +9844,7 @@
         "Datum_neu": 1605225600000,
         "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25538,7 +25538,7 @@
         "Datum_neu": 1640908800000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26574,7 +26574,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1007,
+        "F\u00e4lle_Meldedatum": 1006,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1497,
+        "F\u00e4lle_Meldedatum": 1499,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -26992,7 +26992,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1248,
+        "F\u00e4lle_Meldedatum": 1249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2097,
+        "F\u00e4lle_Meldedatum": 2099,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28158,9 +28158,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1800,
+        "F\u00e4lle_Meldedatum": 1802,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28170,7 +28170,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2857,
+        "F\u00e4lle_Meldedatum": 2860,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2594,
+        "F\u00e4lle_Meldedatum": 2595,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28424,9 +28424,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2669,
+        "F\u00e4lle_Meldedatum": 2683,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2589,
+        "F\u00e4lle_Meldedatum": 2582,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1504,
+        "F\u00e4lle_Meldedatum": 1505,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -28540,7 +28540,7 @@
         "Datum_neu": 1647734400000,
         "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28550,7 +28550,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28576,9 +28576,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3065,
+        "F\u00e4lle_Meldedatum": 3063,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2963,
+        "F\u00e4lle_Meldedatum": 2962,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -28626,7 +28626,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28652,9 +28652,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2129,
+        "F\u00e4lle_Meldedatum": 2132,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28664,7 +28664,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28688,15 +28688,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1804,
         "BelegteBetten": null,
-        "Inzidenz": 2206.25740867129,
+        "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2201,
+        "F\u00e4lle_Meldedatum": 2205,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
-        "Inzidenz_RKI": 1880.3,
+        "Hosp_Meldedatum": 31,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1496,
-        "Krh_I_belegt": 192,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28706,7 +28706,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.84,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.03.2022"
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": 2171.59380724882,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1769,
+        "F\u00e4lle_Meldedatum": 1775,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 1881.8,
@@ -28740,11 +28740,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.18,
+        "H_Inzidenz": 12.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.03.2022"
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1753.47534034987,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 819,
+        "F\u00e4lle_Meldedatum": 824,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1855.5,
@@ -28782,7 +28782,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.88,
+        "H_Inzidenz": 12.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.03.2022"
@@ -28804,7 +28804,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1532.20302453393,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 409,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1632.2,
@@ -28816,11 +28816,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.81,
+        "H_Inzidenz": 12.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.03.2022"
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1889.7948920579,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2340,
+        "F\u00e4lle_Meldedatum": 2360,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": 1666,
@@ -28858,7 +28858,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.81,
+        "H_Inzidenz": 12.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.03.2022"
@@ -28880,9 +28880,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1715.57886418334,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1882,
+        "F\u00e4lle_Meldedatum": 1936,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1408.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1519,
@@ -28896,7 +28896,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.77,
+        "H_Inzidenz": 11.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.03.2022"
@@ -28907,34 +28907,34 @@
         "Datum": "30.03.2022",
         "Fallzahl": 177995,
         "ObjectId": 754,
-        "Sterbefall": 1637,
-        "Genesungsfall": 153243,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5042,
-        "Zuwachs_Fallzahl": 2840,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2784,
         "BelegteBetten": null,
         "Inzidenz": 1673.37188835806,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 1677,
+        "F\u00e4lle_Meldedatum": 2173,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1345.7,
-        "Fallzahl_aktiv": 23115,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1511,
         "Krh_I_belegt": 188,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 56,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.39,
+        "H_Inzidenz": 10.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.03.2022"
@@ -28947,7 +28947,7 @@
         "ObjectId": 755,
         "Sterbefall": 1639,
         "Genesungsfall": 155894,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5073,
         "Zuwachs_Fallzahl": 3651,
         "Zuwachs_Sterbefall": 2,
@@ -28956,9 +28956,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1993.06727971551,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 134,
-        "Zeitraum": "24.03.2022 - 30.03.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 1160,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1603.8,
         "Fallzahl_aktiv": 24113,
         "Krh_N_belegt": 1464,
@@ -28970,13 +28970,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 8311,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.62,
-        "H_Zeitraum": "24.03.2022 - 30.03.2022",
-        "H_Datum": "31.03.2022",
+        "H_Inzidenz": 9.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "30.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.04.2022",
+        "Fallzahl": 183476,
+        "ObjectId": 756,
+        "Sterbefall": 1645,
+        "Genesungsfall": 158487,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5094,
+        "Zuwachs_Fallzahl": 1830,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 2593,
+        "BelegteBetten": null,
+        "Inzidenz": 1912.06580696146,
+        "Datum_neu": 1648771200000,
+        "F\u00e4lle_Meldedatum": 192,
+        "Zeitraum": "25.03.2022 - 31.03.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1736.3,
+        "Fallzahl_aktiv": 23344,
+        "Krh_N_belegt": 1464,
+        "Krh_I_belegt": 188,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -769,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8424,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.99,
+        "H_Zeitraum": "25.03.2022 - 31.03.2022",
+        "H_Datum": "31.03.2022",
+        "Datum_Bett": "31.03.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
