### PR TITLE
New data set: 2022-04-04T104703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-01T104704Z.json
+pjson/2022-04-04T104703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-01T104704Z.json pjson/2022-04-04T104703Z.json```:
```
--- pjson/2022-04-01T104704Z.json	2022-04-01 10:47:04.300272531 +0000
+++ pjson/2022-04-04T104703Z.json	2022-04-04 10:47:04.138995289 +0000
@@ -14896,7 +14896,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616716800000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -15124,7 +15124,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617235200000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26574,7 +26574,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1499,
+        "F\u00e4lle_Meldedatum": 1500,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -26906,7 +26906,7 @@
         "Datum_neu": 1644019200000,
         "F\u00e4lle_Meldedatum": 491,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26992,7 +26992,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1363,
+        "F\u00e4lle_Meldedatum": 1364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28046,7 +28046,7 @@
         "Datum_neu": 1646611200000,
         "F\u00e4lle_Meldedatum": 2035,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28170,7 +28170,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2790,
+        "F\u00e4lle_Meldedatum": 2793,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2683,
+        "F\u00e4lle_Meldedatum": 2691,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2582,
+        "F\u00e4lle_Meldedatum": 2589,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1505,
+        "F\u00e4lle_Meldedatum": 1523,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -28538,9 +28538,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3063,
+        "F\u00e4lle_Meldedatum": 3044,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2962,
+        "F\u00e4lle_Meldedatum": 2951,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2132,
+        "F\u00e4lle_Meldedatum": 2128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28690,9 +28690,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2205,
+        "F\u00e4lle_Meldedatum": 2206,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28726,15 +28726,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1925,
         "BelegteBetten": null,
-        "Inzidenz": 2171.59380724882,
+        "Inzidenz": null,
         "Datum_neu": 1648166400000,
         "F\u00e4lle_Meldedatum": 1775,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 1881.8,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1469,
-        "Krh_I_belegt": 194,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28744,7 +28744,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.67,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.03.2022"
@@ -28764,15 +28764,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1141,
         "BelegteBetten": null,
-        "Inzidenz": 1753.47534034987,
+        "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 824,
+        "F\u00e4lle_Meldedatum": 826,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 1855.5,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1492,
-        "Krh_I_belegt": 190,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28782,7 +28782,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.47,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.03.2022"
@@ -28802,15 +28802,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 405,
         "BelegteBetten": null,
-        "Inzidenz": 1532.20302453393,
+        "Inzidenz": null,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 1632.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1488,
-        "Krh_I_belegt": 191,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28820,7 +28820,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.5,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.03.2022"
@@ -28842,9 +28842,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1889.7948920579,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2360,
+        "F\u00e4lle_Meldedatum": 2363,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 1666,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1493,
@@ -28858,7 +28858,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.55,
+        "H_Inzidenz": 12.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.03.2022"
@@ -28880,9 +28880,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1715.57886418334,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1936,
+        "F\u00e4lle_Meldedatum": 1946,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 1408.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1519,
@@ -28896,7 +28896,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.73,
+        "H_Inzidenz": 12.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.03.2022"
@@ -28918,9 +28918,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1673.37188835806,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2173,
+        "F\u00e4lle_Meldedatum": 2190,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1345.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1511,
@@ -28934,7 +28934,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.7,
+        "H_Inzidenz": 11.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.03.2022"
@@ -28945,34 +28945,34 @@
         "Datum": "31.03.2022",
         "Fallzahl": 181646,
         "ObjectId": 755,
-        "Sterbefall": 1639,
-        "Genesungsfall": 155894,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5073,
-        "Zuwachs_Fallzahl": 3651,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 31,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2651,
         "BelegteBetten": null,
         "Inzidenz": 1993.06727971551,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1160,
+        "F\u00e4lle_Meldedatum": 1254,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1603.8,
-        "Fallzahl_aktiv": 24113,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1464,
         "Krh_I_belegt": 188,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 998,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.56,
+        "H_Inzidenz": 10.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.03.2022"
@@ -28985,7 +28985,7 @@
         "ObjectId": 756,
         "Sterbefall": 1645,
         "Genesungsfall": 158487,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5094,
         "Zuwachs_Fallzahl": 1830,
         "Zuwachs_Sterbefall": 6,
@@ -28994,13 +28994,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1912.06580696146,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 192,
-        "Zeitraum": "25.03.2022 - 31.03.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 956,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1736.3,
         "Fallzahl_aktiv": 23344,
-        "Krh_N_belegt": 1464,
-        "Krh_I_belegt": 188,
+        "Krh_N_belegt": 1400,
+        "Krh_I_belegt": 187,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -769,
         "Krh_I": null,
@@ -29008,13 +29008,127 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 8424,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.99,
-        "H_Zeitraum": "25.03.2022 - 31.03.2022",
-        "H_Datum": "31.03.2022",
+        "H_Inzidenz": 10.01,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "31.03.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "02.04.2022",
+        "Fallzahl": 184608,
+        "ObjectId": 757,
+        "Sterbefall": null,
+        "Genesungsfall": 160077,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1590,
+        "BelegteBetten": null,
+        "Inzidenz": 1627.75243363627,
+        "Datum_neu": 1648857600000,
+        "F\u00e4lle_Meldedatum": 485,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 1633.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1332,
+        "Krh_I_belegt": 184,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "01.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.04.2022",
+        "Fallzahl": 184608,
+        "ObjectId": 758,
+        "Sterbefall": null,
+        "Genesungsfall": 160437,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 360,
+        "BelegteBetten": null,
+        "Inzidenz": 1514.42221344157,
+        "Datum_neu": 1648944000000,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1541,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1324,
+        "Krh_I_belegt": 195,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.74,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.04.2022",
+        "Fallzahl": 185004,
+        "ObjectId": 759,
+        "Sterbefall": 1645,
+        "Genesungsfall": 163447,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5120,
+        "Zuwachs_Fallzahl": 1528,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 26,
+        "Zuwachs_Genesung": 3010,
+        "BelegteBetten": null,
+        "Inzidenz": 1658.64434785732,
+        "Datum_neu": 1649030400000,
+        "F\u00e4lle_Meldedatum": 96,
+        "Zeitraum": "28.03.2022 - 03.04.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 1608.5,
+        "Fallzahl_aktiv": 19912,
+        "Krh_N_belegt": 1324,
+        "Krh_I_belegt": 195,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1482,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8592,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7,
+        "H_Zeitraum": "28.03.2022 - 03.04.2022",
+        "H_Datum": "03.04.2022",
+        "Datum_Bett": "03.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
