### PR TITLE
New data set: 2022-04-05T112104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-04T104703Z.json
+pjson/2022-04-05T112104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-04T104703Z.json pjson/2022-04-05T112104Z.json```:
```
--- pjson/2022-04-04T104703Z.json	2022-04-04 10:47:04.138995289 +0000
+++ pjson/2022-04-05T112104Z.json	2022-04-05 11:21:04.381011896 +0000
@@ -14744,7 +14744,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -15428,7 +15428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 182,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1253,
+        "F\u00e4lle_Meldedatum": 1254,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -27816,9 +27816,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1828,
+        "F\u00e4lle_Meldedatum": 1829,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27856,7 +27856,7 @@
         "Datum_neu": 1646179200000,
         "F\u00e4lle_Meldedatum": 1364,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27932,7 +27932,7 @@
         "Datum_neu": 1646352000000,
         "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28046,7 +28046,7 @@
         "Datum_neu": 1646611200000,
         "F\u00e4lle_Meldedatum": 2035,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28084,7 +28084,7 @@
         "Datum_neu": 1646697600000,
         "F\u00e4lle_Meldedatum": 2082,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2099,
+        "F\u00e4lle_Meldedatum": 2100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28158,9 +28158,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1802,
+        "F\u00e4lle_Meldedatum": 1804,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1926,
+        "F\u00e4lle_Meldedatum": 1927,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2860,
+        "F\u00e4lle_Meldedatum": 2861,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2595,
+        "F\u00e4lle_Meldedatum": 2596,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2691,
+        "F\u00e4lle_Meldedatum": 2692,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,9 +28462,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2589,
+        "F\u00e4lle_Meldedatum": 2590,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1523,
+        "F\u00e4lle_Meldedatum": 1525,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -28538,9 +28538,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 365,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28576,9 +28576,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3044,
+        "F\u00e4lle_Meldedatum": 3052,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28614,9 +28614,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2951,
+        "F\u00e4lle_Meldedatum": 2947,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2128,
+        "F\u00e4lle_Meldedatum": 2127,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2206,
+        "F\u00e4lle_Meldedatum": 2207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1775,
+        "F\u00e4lle_Meldedatum": 1781,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28740,7 +28740,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 826,
+        "F\u00e4lle_Meldedatum": 827,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -28804,7 +28804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28840,15 +28840,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2830,
         "BelegteBetten": null,
-        "Inzidenz": 1889.7948920579,
+        "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2363,
+        "F\u00e4lle_Meldedatum": 2364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
-        "Inzidenz_RKI": 1666,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1493,
-        "Krh_I_belegt": 181,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28858,7 +28858,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.99,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.03.2022"
@@ -28880,9 +28880,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1715.57886418334,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1946,
+        "F\u00e4lle_Meldedatum": 1958,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 1408.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1519,
@@ -28896,7 +28896,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.28,
+        "H_Inzidenz": 12.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.03.2022"
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1673.37188835806,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2190,
+        "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1345.7,
@@ -28934,7 +28934,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.39,
+        "H_Inzidenz": 11.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.03.2022"
@@ -28956,7 +28956,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1993.06727971551,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1254,
+        "F\u00e4lle_Meldedatum": 1275,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1603.8,
@@ -28968,11 +28968,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.7,
+        "H_Inzidenz": 11.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.03.2022"
@@ -28983,34 +28983,34 @@
         "Datum": "01.04.2022",
         "Fallzahl": 183476,
         "ObjectId": 756,
-        "Sterbefall": 1645,
-        "Genesungsfall": 158487,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5094,
-        "Zuwachs_Fallzahl": 1830,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2593,
         "BelegteBetten": null,
         "Inzidenz": 1912.06580696146,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 956,
+        "F\u00e4lle_Meldedatum": 991,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1736.3,
-        "Fallzahl_aktiv": 23344,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1400,
         "Krh_I_belegt": 187,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -769,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.01,
+        "H_Inzidenz": 10.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.03.2022"
@@ -29022,7 +29022,7 @@
         "Fallzahl": 184608,
         "ObjectId": 757,
         "Sterbefall": null,
-        "Genesungsfall": 160077,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29032,9 +29032,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1627.75243363627,
         "Datum_neu": 1648857600000,
-        "F\u00e4lle_Meldedatum": 485,
+        "F\u00e4lle_Meldedatum": 559,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1633.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1332,
@@ -29048,7 +29048,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.6,
+        "H_Inzidenz": 9.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.04.2022"
@@ -29060,7 +29060,7 @@
         "Fallzahl": 184608,
         "ObjectId": 758,
         "Sterbefall": null,
-        "Genesungsfall": 160437,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29070,9 +29070,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1514.42221344157,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1541,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1324,
@@ -29086,7 +29086,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
+        "H_Inzidenz": 9.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.04.2022"
@@ -29099,7 +29099,7 @@
         "ObjectId": 759,
         "Sterbefall": 1645,
         "Genesungsfall": 163447,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5120,
         "Zuwachs_Fallzahl": 1528,
         "Zuwachs_Sterbefall": 0,
@@ -29108,13 +29108,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1658.64434785732,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 96,
-        "Zeitraum": "28.03.2022 - 03.04.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1262,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1608.5,
         "Fallzahl_aktiv": 19912,
-        "Krh_N_belegt": 1324,
-        "Krh_I_belegt": 195,
+        "Krh_N_belegt": 1374,
+        "Krh_I_belegt": 201,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -1482,
         "Krh_I": null,
@@ -29122,13 +29122,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 8592,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7,
-        "H_Zeitraum": "28.03.2022 - 03.04.2022",
-        "H_Datum": "03.04.2022",
+        "H_Inzidenz": 8.75,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.04.2022",
+        "Fallzahl": 186558,
+        "ObjectId": 760,
+        "Sterbefall": 1651,
+        "Genesungsfall": 166380,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5151,
+        "Zuwachs_Fallzahl": 1554,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 31,
+        "Zuwachs_Genesung": 2933,
+        "BelegteBetten": null,
+        "Inzidenz": 1503.64596429469,
+        "Datum_neu": 1649116800000,
+        "F\u00e4lle_Meldedatum": 119,
+        "Zeitraum": "29.03.2022 - 04.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1270.9,
+        "Fallzahl_aktiv": 18527,
+        "Krh_N_belegt": 1374,
+        "Krh_I_belegt": 201,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1385,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8679,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.43,
+        "H_Zeitraum": "29.03.2022 - 04.04.2022",
+        "H_Datum": "04.04.2022",
+        "Datum_Bett": "04.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
