### PR TITLE
New data set: 2022-04-06T103703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-05T112104Z.json
+pjson/2022-04-06T103703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-05T112104Z.json pjson/2022-04-06T103703Z.json```:
```
--- pjson/2022-04-05T112104Z.json	2022-04-05 11:21:04.381011896 +0000
+++ pjson/2022-04-06T103703Z.json	2022-04-06 10:37:04.122078679 +0000
@@ -14858,7 +14858,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -15428,7 +15428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617926400000,
-        "F\u00e4lle_Meldedatum": 183,
+        "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 941,
+        "F\u00e4lle_Meldedatum": 942,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 800,
+        "F\u00e4lle_Meldedatum": 799,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2035,
+        "F\u00e4lle_Meldedatum": 2036,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2100,
+        "F\u00e4lle_Meldedatum": 2101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28160,7 +28160,7 @@
         "Datum_neu": 1646870400000,
         "F\u00e4lle_Meldedatum": 1804,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28198,7 +28198,7 @@
         "Datum_neu": 1646956800000,
         "F\u00e4lle_Meldedatum": 1927,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2692,
+        "F\u00e4lle_Meldedatum": 2693,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28502,7 +28502,7 @@
         "Datum_neu": 1647648000000,
         "F\u00e4lle_Meldedatum": 1525,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3052,
+        "F\u00e4lle_Meldedatum": 3055,
         "Zeitraum": null,
         "Hosp_Meldedatum": 39,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2947,
+        "F\u00e4lle_Meldedatum": 2952,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -28652,9 +28652,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2127,
+        "F\u00e4lle_Meldedatum": 2130,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2207,
+        "F\u00e4lle_Meldedatum": 2204,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1781,
+        "F\u00e4lle_Meldedatum": 1783,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28740,7 +28740,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 4,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28766,9 +28766,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 827,
+        "F\u00e4lle_Meldedatum": 829,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2364,
+        "F\u00e4lle_Meldedatum": 2369,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
@@ -28878,15 +28878,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2567,
         "BelegteBetten": null,
-        "Inzidenz": 1715.57886418334,
+        "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1958,
+        "F\u00e4lle_Meldedatum": 1954,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 1408.6,
+        "Hosp_Meldedatum": 11,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1519,
-        "Krh_I_belegt": 186,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28896,7 +28896,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.65,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.03.2022"
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1673.37188835806,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2198,
+        "F\u00e4lle_Meldedatum": 2201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1345.7,
@@ -28934,7 +28934,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.93,
+        "H_Inzidenz": 12.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.03.2022"
@@ -28956,9 +28956,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1993.06727971551,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1275,
+        "F\u00e4lle_Meldedatum": 1278,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 1603.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1464,
@@ -28972,7 +28972,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.34,
+        "H_Inzidenz": 11.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.03.2022"
@@ -28994,9 +28994,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1912.06580696146,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 991,
+        "F\u00e4lle_Meldedatum": 1004,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1736.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1400,
@@ -29010,7 +29010,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.75,
+        "H_Inzidenz": 10.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.03.2022"
@@ -29032,7 +29032,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1627.75243363627,
         "Datum_neu": 1648857600000,
-        "F\u00e4lle_Meldedatum": 559,
+        "F\u00e4lle_Meldedatum": 588,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1633.1,
@@ -29048,7 +29048,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.86,
+        "H_Inzidenz": 10.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.04.2022"
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1514.42221344157,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1541,
@@ -29086,7 +29086,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.29,
+        "H_Inzidenz": 10.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.04.2022"
@@ -29097,26 +29097,26 @@
         "Datum": "04.04.2022",
         "Fallzahl": 185004,
         "ObjectId": 759,
-        "Sterbefall": 1645,
-        "Genesungsfall": 163447,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5120,
-        "Zuwachs_Fallzahl": 1528,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3010,
         "BelegteBetten": null,
         "Inzidenz": 1658.64434785732,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1262,
+        "F\u00e4lle_Meldedatum": 1787,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 1608.5,
-        "Fallzahl_aktiv": 19912,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1374,
         "Krh_I_belegt": 201,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1482,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29124,7 +29124,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.75,
+        "H_Inzidenz": 9.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.04.2022"
@@ -29137,7 +29137,7 @@
         "ObjectId": 760,
         "Sterbefall": 1651,
         "Genesungsfall": 166380,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5151,
         "Zuwachs_Fallzahl": 1554,
         "Zuwachs_Sterbefall": 6,
@@ -29146,13 +29146,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1503.64596429469,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 119,
-        "Zeitraum": "29.03.2022 - 04.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1319,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 1270.9,
         "Fallzahl_aktiv": 18527,
-        "Krh_N_belegt": 1374,
-        "Krh_I_belegt": 201,
+        "Krh_N_belegt": 1383,
+        "Krh_I_belegt": 181,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -1385,
         "Krh_I": null,
@@ -29160,13 +29160,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 8679,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.43,
-        "H_Zeitraum": "29.03.2022 - 04.04.2022",
-        "H_Datum": "04.04.2022",
+        "H_Inzidenz": 8.16,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "04.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "06.04.2022",
+        "Fallzahl": 188598,
+        "ObjectId": 761,
+        "Sterbefall": 1652,
+        "Genesungsfall": 168520,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5168,
+        "Zuwachs_Fallzahl": 2040,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 2140,
+        "BelegteBetten": null,
+        "Inzidenz": 1502.74794353245,
+        "Datum_neu": 1649203200000,
+        "F\u00e4lle_Meldedatum": 189,
+        "Zeitraum": "30.03.2022 - 05.04.2022",
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": 1331.5,
+        "Fallzahl_aktiv": 18426,
+        "Krh_N_belegt": 1383,
+        "Krh_I_belegt": 181,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -101,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8806,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.7,
+        "H_Zeitraum": "30.03.2022 - 05.04.2022",
+        "H_Datum": "05.04.2022",
+        "Datum_Bett": "05.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
