### PR TITLE
New data set: 2022-04-07T105704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-06T103703Z.json
+pjson/2022-04-07T105704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-06T103703Z.json pjson/2022-04-07T105704Z.json```:
```
--- pjson/2022-04-06T103703Z.json	2022-04-06 10:37:04.122078679 +0000
+++ pjson/2022-04-07T105704Z.json	2022-04-07 10:57:04.406911958 +0000
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 301,
+        "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26182,7 +26182,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642377600000,
-        "F\u00e4lle_Meldedatum": 701,
+        "F\u00e4lle_Meldedatum": 702,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2082,
+        "F\u00e4lle_Meldedatum": 2083,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2101,
+        "F\u00e4lle_Meldedatum": 2102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28158,7 +28158,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1804,
+        "F\u00e4lle_Meldedatum": 1805,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1110,
+        "F\u00e4lle_Meldedatum": 1112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 385,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28310,9 +28310,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2861,
+        "F\u00e4lle_Meldedatum": 2862,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2596,
+        "F\u00e4lle_Meldedatum": 2599,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2793,
+        "F\u00e4lle_Meldedatum": 2795,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2693,
+        "F\u00e4lle_Meldedatum": 2697,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2590,
+        "F\u00e4lle_Meldedatum": 2597,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1525,
+        "F\u00e4lle_Meldedatum": 1529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 370,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -28576,9 +28576,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3055,
+        "F\u00e4lle_Meldedatum": 3064,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28614,9 +28614,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2952,
+        "F\u00e4lle_Meldedatum": 2967,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28652,9 +28652,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2130,
+        "F\u00e4lle_Meldedatum": 2135,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28690,9 +28690,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2204,
+        "F\u00e4lle_Meldedatum": 2206,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1783,
+        "F\u00e4lle_Meldedatum": 1773,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 829,
+        "F\u00e4lle_Meldedatum": 830,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28804,7 +28804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 422,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28842,9 +28842,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2369,
+        "F\u00e4lle_Meldedatum": 2368,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1954,
+        "F\u00e4lle_Meldedatum": 1957,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28916,15 +28916,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2784,
         "BelegteBetten": null,
-        "Inzidenz": 1673.37188835806,
+        "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2201,
+        "F\u00e4lle_Meldedatum": 2208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 1345.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1511,
-        "Krh_I_belegt": 188,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28934,7 +28934,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.1,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.03.2022"
@@ -28956,9 +28956,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1993.06727971551,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1278,
+        "F\u00e4lle_Meldedatum": 1281,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1603.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1464,
@@ -28972,7 +28972,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.54,
+        "H_Inzidenz": 11.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.03.2022"
@@ -28994,7 +28994,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1912.06580696146,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 1004,
+        "F\u00e4lle_Meldedatum": 1008,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1736.3,
@@ -29010,7 +29010,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.99,
+        "H_Inzidenz": 11.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.03.2022"
@@ -29032,7 +29032,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1627.75243363627,
         "Datum_neu": 1648857600000,
-        "F\u00e4lle_Meldedatum": 588,
+        "F\u00e4lle_Meldedatum": 591,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1633.1,
@@ -29048,7 +29048,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.33,
+        "H_Inzidenz": 10.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.04.2022"
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1514.42221344157,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1541,
@@ -29086,7 +29086,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.03,
+        "H_Inzidenz": 10.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.04.2022"
@@ -29108,9 +29108,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1658.64434785732,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1787,
+        "F\u00e4lle_Meldedatum": 1804,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1608.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1374,
@@ -29120,11 +29120,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.66,
+        "H_Inzidenz": 10.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.04.2022"
@@ -29135,26 +29135,26 @@
         "Datum": "05.04.2022",
         "Fallzahl": 186558,
         "ObjectId": 760,
-        "Sterbefall": 1651,
-        "Genesungsfall": 166380,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5151,
-        "Zuwachs_Fallzahl": 1554,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 31,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2933,
         "BelegteBetten": null,
         "Inzidenz": 1503.64596429469,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1319,
+        "F\u00e4lle_Meldedatum": 1416,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1270.9,
-        "Fallzahl_aktiv": 18527,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1383,
         "Krh_I_belegt": 181,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1385,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29162,7 +29162,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.16,
+        "H_Inzidenz": 8.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.04.2022"
@@ -29175,7 +29175,7 @@
         "ObjectId": 761,
         "Sterbefall": 1652,
         "Genesungsfall": 168520,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5168,
         "Zuwachs_Fallzahl": 2040,
         "Zuwachs_Sterbefall": 1,
@@ -29184,13 +29184,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1502.74794353245,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 189,
-        "Zeitraum": "30.03.2022 - 05.04.2022",
-        "Hosp_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 958,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1331.5,
         "Fallzahl_aktiv": 18426,
-        "Krh_N_belegt": 1383,
-        "Krh_I_belegt": 181,
+        "Krh_N_belegt": 1326,
+        "Krh_I_belegt": 180,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -101,
         "Krh_I": null,
@@ -29198,13 +29198,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 8806,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.7,
-        "H_Zeitraum": "30.03.2022 - 05.04.2022",
-        "H_Datum": "05.04.2022",
+        "H_Inzidenz": 7.74,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.04.2022",
+        "Fallzahl": 189674,
+        "ObjectId": 762,
+        "Sterbefall": 1653,
+        "Genesungsfall": 170711,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5184,
+        "Zuwachs_Fallzahl": 1076,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 2191,
+        "BelegteBetten": null,
+        "Inzidenz": 1302.84852185783,
+        "Datum_neu": 1649289600000,
+        "F\u00e4lle_Meldedatum": 111,
+        "Zeitraum": "31.03.2022 - 06.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 1161.8,
+        "Fallzahl_aktiv": 17310,
+        "Krh_N_belegt": 1326,
+        "Krh_I_belegt": 180,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1116,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8893,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.19,
+        "H_Zeitraum": "31.03.2022 - 06.04.2022",
+        "H_Datum": "06.04.2022",
+        "Datum_Bett": "06.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
