### PR TITLE
New data set: 2022-04-08T104404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-07T105704Z.json
+pjson/2022-04-08T104404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-07T105704Z.json pjson/2022-04-08T104404Z.json```:
```
--- pjson/2022-04-07T105704Z.json	2022-04-07 10:57:04.406911958 +0000
+++ pjson/2022-04-08T104404Z.json	2022-04-08 10:44:05.046311015 +0000
@@ -14212,7 +14212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1615161600000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -14630,7 +14630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1615,
+        "F\u00e4lle_Meldedatum": 1616,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1927,
+        "F\u00e4lle_Meldedatum": 1928,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 388,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2795,
+        "F\u00e4lle_Meldedatum": 2797,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2597,
+        "F\u00e4lle_Meldedatum": 2596,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3064,
+        "F\u00e4lle_Meldedatum": 3067,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2967,
+        "F\u00e4lle_Meldedatum": 2968,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28652,9 +28652,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2135,
+        "F\u00e4lle_Meldedatum": 2139,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28690,9 +28690,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2206,
+        "F\u00e4lle_Meldedatum": 2209,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1773,
+        "F\u00e4lle_Meldedatum": 1777,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 830,
+        "F\u00e4lle_Meldedatum": 831,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28804,9 +28804,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 422,
+        "F\u00e4lle_Meldedatum": 424,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28842,9 +28842,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2368,
+        "F\u00e4lle_Meldedatum": 2365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1957,
+        "F\u00e4lle_Meldedatum": 1963,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2208,
+        "F\u00e4lle_Meldedatum": 2206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28954,15 +28954,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2651,
         "BelegteBetten": null,
-        "Inzidenz": 1993.06727971551,
+        "Inzidenz": null,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1281,
+        "F\u00e4lle_Meldedatum": 1283,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 1603.8,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1464,
-        "Krh_I_belegt": 188,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -28972,7 +28972,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.03.2022"
@@ -28994,7 +28994,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1912.06580696146,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 1008,
+        "F\u00e4lle_Meldedatum": 1010,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 1736.3,
@@ -29010,7 +29010,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.29,
+        "H_Inzidenz": 11.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.03.2022"
@@ -29048,7 +29048,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.75,
+        "H_Inzidenz": 10.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.04.2022"
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1514.42221344157,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1541,
@@ -29082,11 +29082,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.48,
+        "H_Inzidenz": 10.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.04.2022"
@@ -29108,9 +29108,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1658.64434785732,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1804,
+        "F\u00e4lle_Meldedatum": 1807,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 1608.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1374,
@@ -29124,7 +29124,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.11,
+        "H_Inzidenz": 10.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.04.2022"
@@ -29146,9 +29146,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1503.64596429469,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1416,
+        "F\u00e4lle_Meldedatum": 1437,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1270.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1383,
@@ -29162,7 +29162,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.73,
+        "H_Inzidenz": 8.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.04.2022"
@@ -29173,34 +29173,34 @@
         "Datum": "06.04.2022",
         "Fallzahl": 188598,
         "ObjectId": 761,
-        "Sterbefall": 1652,
-        "Genesungsfall": 168520,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5168,
-        "Zuwachs_Fallzahl": 2040,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2140,
         "BelegteBetten": null,
         "Inzidenz": 1502.74794353245,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 958,
+        "F\u00e4lle_Meldedatum": 1036,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1331.5,
-        "Fallzahl_aktiv": 18426,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1326,
         "Krh_I_belegt": 180,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -101,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
+        "H_Inzidenz": 8.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.04.2022"
@@ -29211,38 +29211,76 @@
         "Datum": "07.04.2022",
         "Fallzahl": 189674,
         "ObjectId": 762,
-        "Sterbefall": 1653,
-        "Genesungsfall": 170711,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 5184,
-        "Zuwachs_Fallzahl": 1076,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2191,
         "BelegteBetten": null,
         "Inzidenz": 1302.84852185783,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 111,
-        "Zeitraum": "31.03.2022 - 06.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 987,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 1161.8,
-        "Fallzahl_aktiv": 17310,
-        "Krh_N_belegt": 1326,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1257,
         "Krh_I_belegt": 180,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1116,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 8893,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.19,
-        "H_Zeitraum": "31.03.2022 - 06.04.2022",
-        "H_Datum": "06.04.2022",
+        "H_Inzidenz": 7.27,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.04.2022",
+        "Fallzahl": 190794,
+        "ObjectId": 763,
+        "Sterbefall": 1656,
+        "Genesungsfall": 172493,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5197,
+        "Zuwachs_Fallzahl": 1120,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 1782,
+        "BelegteBetten": null,
+        "Inzidenz": 1269.26254535005,
+        "Datum_neu": 1649376000000,
+        "F\u00e4lle_Meldedatum": 112,
+        "Zeitraum": "01.04.2022 - 07.04.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 1114.8,
+        "Fallzahl_aktiv": 16645,
+        "Krh_N_belegt": 1257,
+        "Krh_I_belegt": 180,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -665,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 8970,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.4,
+        "H_Zeitraum": "01.04.2022 - 07.04.2022",
+        "H_Datum": "07.04.2022",
+        "Datum_Bett": "07.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
