### PR TITLE
New data set: 2022-04-12T101903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-11T100303Z.json
+pjson/2022-04-12T101903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-11T100303Z.json pjson/2022-04-12T101903Z.json```:
```
--- pjson/2022-04-11T100303Z.json	2022-04-11 10:03:03.920506098 +0000
+++ pjson/2022-04-12T101903Z.json	2022-04-12 10:19:03.214080846 +0000
@@ -9350,7 +9350,7 @@
         "Datum_neu": 1604102400000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9388,7 +9388,7 @@
         "Datum_neu": 1604188800000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9426,7 +9426,7 @@
         "Datum_neu": 1604275200000,
         "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9464,7 +9464,7 @@
         "Datum_neu": 1604361600000,
         "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9540,7 +9540,7 @@
         "Datum_neu": 1604534400000,
         "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9578,7 +9578,7 @@
         "Datum_neu": 1604620800000,
         "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9616,7 +9616,7 @@
         "Datum_neu": 1604707200000,
         "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9654,7 +9654,7 @@
         "Datum_neu": 1604793600000,
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9730,7 +9730,7 @@
         "Datum_neu": 1604966400000,
         "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9768,7 +9768,7 @@
         "Datum_neu": 1605052800000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9806,7 +9806,7 @@
         "Datum_neu": 1605139200000,
         "F\u00e4lle_Meldedatum": 197,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -9844,7 +9844,7 @@
         "Datum_neu": 1605225600000,
         "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20446,7 +20446,7 @@
         "Datum_neu": 1629331200000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20484,7 +20484,7 @@
         "Datum_neu": 1629417600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20674,7 +20674,7 @@
         "Datum_neu": 1629849600000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20978,7 +20978,7 @@
         "Datum_neu": 1630540800000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21054,7 +21054,7 @@
         "Datum_neu": 1630713600000,
         "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21130,7 +21130,7 @@
         "Datum_neu": 1630886400000,
         "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21168,7 +21168,7 @@
         "Datum_neu": 1630972800000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21396,7 +21396,7 @@
         "Datum_neu": 1631491200000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21510,7 +21510,7 @@
         "Datum_neu": 1631750400000,
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21662,7 +21662,7 @@
         "Datum_neu": 1632096000000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21700,7 +21700,7 @@
         "Datum_neu": 1632182400000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21738,7 +21738,7 @@
         "Datum_neu": 1632268800000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22308,7 +22308,7 @@
         "Datum_neu": 1633564800000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22346,7 +22346,7 @@
         "Datum_neu": 1633651200000,
         "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22460,7 +22460,7 @@
         "Datum_neu": 1633910400000,
         "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22574,7 +22574,7 @@
         "Datum_neu": 1634169600000,
         "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22726,7 +22726,7 @@
         "Datum_neu": 1634515200000,
         "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22840,7 +22840,7 @@
         "Datum_neu": 1634774400000,
         "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22878,7 +22878,7 @@
         "Datum_neu": 1634860800000,
         "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22992,7 +22992,7 @@
         "Datum_neu": 1635120000000,
         "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23030,7 +23030,7 @@
         "Datum_neu": 1635206400000,
         "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23258,7 +23258,7 @@
         "Datum_neu": 1635724800000,
         "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23296,7 +23296,7 @@
         "Datum_neu": 1635811200000,
         "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23372,7 +23372,7 @@
         "Datum_neu": 1635984000000,
         "F\u00e4lle_Meldedatum": 685,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23410,7 +23410,7 @@
         "Datum_neu": 1636070400000,
         "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23448,7 +23448,7 @@
         "Datum_neu": 1636156800000,
         "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23486,7 +23486,7 @@
         "Datum_neu": 1636243200000,
         "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23524,7 +23524,7 @@
         "Datum_neu": 1636329600000,
         "F\u00e4lle_Meldedatum": 715,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23600,7 +23600,7 @@
         "Datum_neu": 1636502400000,
         "F\u00e4lle_Meldedatum": 972,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23676,7 +23676,7 @@
         "Datum_neu": 1636675200000,
         "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23714,7 +23714,7 @@
         "Datum_neu": 1636761600000,
         "F\u00e4lle_Meldedatum": 492,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23790,7 +23790,7 @@
         "Datum_neu": 1636934400000,
         "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23904,7 +23904,7 @@
         "Datum_neu": 1637193600000,
         "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23942,7 +23942,7 @@
         "Datum_neu": 1637280000000,
         "F\u00e4lle_Meldedatum": 1481,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24018,7 +24018,7 @@
         "Datum_neu": 1637452800000,
         "F\u00e4lle_Meldedatum": 400,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24056,7 +24056,7 @@
         "Datum_neu": 1637539200000,
         "F\u00e4lle_Meldedatum": 1381,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 39,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24094,7 +24094,7 @@
         "Datum_neu": 1637625600000,
         "F\u00e4lle_Meldedatum": 1661,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24132,7 +24132,7 @@
         "Datum_neu": 1637712000000,
         "F\u00e4lle_Meldedatum": 1085,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24208,7 +24208,7 @@
         "Datum_neu": 1637884800000,
         "F\u00e4lle_Meldedatum": 1195,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24246,7 +24246,7 @@
         "Datum_neu": 1637971200000,
         "F\u00e4lle_Meldedatum": 770,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24284,7 +24284,7 @@
         "Datum_neu": 1638057600000,
         "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24322,7 +24322,7 @@
         "Datum_neu": 1638144000000,
         "F\u00e4lle_Meldedatum": 882,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24360,7 +24360,7 @@
         "Datum_neu": 1638230400000,
         "F\u00e4lle_Meldedatum": 1327,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24398,7 +24398,7 @@
         "Datum_neu": 1638316800000,
         "F\u00e4lle_Meldedatum": 1117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24436,7 +24436,7 @@
         "Datum_neu": 1638403200000,
         "F\u00e4lle_Meldedatum": 885,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24474,7 +24474,7 @@
         "Datum_neu": 1638489600000,
         "F\u00e4lle_Meldedatum": 1004,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24512,7 +24512,7 @@
         "Datum_neu": 1638576000000,
         "F\u00e4lle_Meldedatum": 535,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24550,7 +24550,7 @@
         "Datum_neu": 1638662400000,
         "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24588,7 +24588,7 @@
         "Datum_neu": 1638748800000,
         "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 42,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24626,7 +24626,7 @@
         "Datum_neu": 1638835200000,
         "F\u00e4lle_Meldedatum": 1254,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24664,7 +24664,7 @@
         "Datum_neu": 1638921600000,
         "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 46,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24702,7 +24702,7 @@
         "Datum_neu": 1639008000000,
         "F\u00e4lle_Meldedatum": 889,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24740,7 +24740,7 @@
         "Datum_neu": 1639094400000,
         "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24778,7 +24778,7 @@
         "Datum_neu": 1639180800000,
         "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24816,7 +24816,7 @@
         "Datum_neu": 1639267200000,
         "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24854,7 +24854,7 @@
         "Datum_neu": 1639353600000,
         "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24892,7 +24892,7 @@
         "Datum_neu": 1639440000000,
         "F\u00e4lle_Meldedatum": 1054,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24930,7 +24930,7 @@
         "Datum_neu": 1639526400000,
         "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24968,7 +24968,7 @@
         "Datum_neu": 1639612800000,
         "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25006,7 +25006,7 @@
         "Datum_neu": 1639699200000,
         "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25120,7 +25120,7 @@
         "Datum_neu": 1639958400000,
         "F\u00e4lle_Meldedatum": 552,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 45,
+        "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25158,7 +25158,7 @@
         "Datum_neu": 1640044800000,
         "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25196,7 +25196,7 @@
         "Datum_neu": 1640131200000,
         "F\u00e4lle_Meldedatum": 423,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25234,7 +25234,7 @@
         "Datum_neu": 1640217600000,
         "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25272,7 +25272,7 @@
         "Datum_neu": 1640304000000,
         "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25310,7 +25310,7 @@
         "Datum_neu": 1640390400000,
         "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25348,7 +25348,7 @@
         "Datum_neu": 1640476800000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25386,7 +25386,7 @@
         "Datum_neu": 1640563200000,
         "F\u00e4lle_Meldedatum": 544,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25424,7 +25424,7 @@
         "Datum_neu": 1640649600000,
         "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25462,7 +25462,7 @@
         "Datum_neu": 1640736000000,
         "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25500,7 +25500,7 @@
         "Datum_neu": 1640822400000,
         "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25538,7 +25538,7 @@
         "Datum_neu": 1640908800000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25576,7 +25576,7 @@
         "Datum_neu": 1640995200000,
         "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25690,7 +25690,7 @@
         "Datum_neu": 1641254400000,
         "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25728,7 +25728,7 @@
         "Datum_neu": 1641340800000,
         "F\u00e4lle_Meldedatum": 339,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25766,7 +25766,7 @@
         "Datum_neu": 1641427200000,
         "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25918,7 +25918,7 @@
         "Datum_neu": 1641772800000,
         "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26032,7 +26032,7 @@
         "Datum_neu": 1642032000000,
         "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26070,7 +26070,7 @@
         "Datum_neu": 1642118400000,
         "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26184,7 +26184,7 @@
         "Datum_neu": 1642377600000,
         "F\u00e4lle_Meldedatum": 702,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26298,7 +26298,7 @@
         "Datum_neu": 1642636800000,
         "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26336,7 +26336,7 @@
         "Datum_neu": 1642723200000,
         "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26374,7 +26374,7 @@
         "Datum_neu": 1642809600000,
         "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26564,7 +26564,7 @@
         "Datum_neu": 1643241600000,
         "F\u00e4lle_Meldedatum": 942,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26602,7 +26602,7 @@
         "Datum_neu": 1643328000000,
         "F\u00e4lle_Meldedatum": 1006,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26716,7 +26716,7 @@
         "Datum_neu": 1643587200000,
         "F\u00e4lle_Meldedatum": 1500,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26868,7 +26868,7 @@
         "Datum_neu": 1643932800000,
         "F\u00e4lle_Meldedatum": 1103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26982,7 +26982,7 @@
         "Datum_neu": 1644192000000,
         "F\u00e4lle_Meldedatum": 1802,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27020,7 +27020,7 @@
         "Datum_neu": 1644278400000,
         "F\u00e4lle_Meldedatum": 1770,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27058,7 +27058,7 @@
         "Datum_neu": 1644364800000,
         "F\u00e4lle_Meldedatum": 1616,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27248,7 +27248,7 @@
         "Datum_neu": 1644796800000,
         "F\u00e4lle_Meldedatum": 1485,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27286,7 +27286,7 @@
         "Datum_neu": 1644883200000,
         "F\u00e4lle_Meldedatum": 1249,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27400,7 +27400,7 @@
         "Datum_neu": 1645142400000,
         "F\u00e4lle_Meldedatum": 903,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27514,7 +27514,7 @@
         "Datum_neu": 1645401600000,
         "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27628,7 +27628,7 @@
         "Datum_neu": 1645660800000,
         "F\u00e4lle_Meldedatum": 1198,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27666,7 +27666,7 @@
         "Datum_neu": 1645747200000,
         "F\u00e4lle_Meldedatum": 799,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27780,7 +27780,7 @@
         "Datum_neu": 1646006400000,
         "F\u00e4lle_Meldedatum": 1589,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27894,7 +27894,7 @@
         "Datum_neu": 1646265600000,
         "F\u00e4lle_Meldedatum": 1205,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28160,7 +28160,7 @@
         "Datum_neu": 1646870400000,
         "F\u00e4lle_Meldedatum": 1806,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28198,7 +28198,7 @@
         "Datum_neu": 1646956800000,
         "F\u00e4lle_Meldedatum": 1928,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28312,7 +28312,7 @@
         "Datum_neu": 1647216000000,
         "F\u00e4lle_Meldedatum": 2862,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28348,9 +28348,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2599,
+        "F\u00e4lle_Meldedatum": 2600,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28386,9 +28386,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2798,
+        "F\u00e4lle_Meldedatum": 2802,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2699,
+        "F\u00e4lle_Meldedatum": 2701,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,9 +28462,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2596,
+        "F\u00e4lle_Meldedatum": 2595,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1529,
+        "F\u00e4lle_Meldedatum": 1528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28540,7 +28540,7 @@
         "Datum_neu": 1647734400000,
         "F\u00e4lle_Meldedatum": 374,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28576,9 +28576,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3067,
+        "F\u00e4lle_Meldedatum": 3063,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 38,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2969,
+        "F\u00e4lle_Meldedatum": 2971,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2139,
+        "F\u00e4lle_Meldedatum": 2138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28690,9 +28690,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2208,
+        "F\u00e4lle_Meldedatum": 2204,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28728,9 +28728,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1780,
+        "F\u00e4lle_Meldedatum": 1781,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28804,9 +28804,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 424,
+        "F\u00e4lle_Meldedatum": 425,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28842,9 +28842,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2366,
+        "F\u00e4lle_Meldedatum": 2365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1970,
+        "F\u00e4lle_Meldedatum": 1971,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28920,7 +28920,7 @@
         "Datum_neu": 1648598400000,
         "F\u00e4lle_Meldedatum": 2206,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28958,7 +28958,7 @@
         "Datum_neu": 1648684800000,
         "F\u00e4lle_Meldedatum": 1288,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28994,9 +28994,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 1007,
+        "F\u00e4lle_Meldedatum": 1011,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29032,7 +29032,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648857600000,
-        "F\u00e4lle_Meldedatum": 590,
+        "F\u00e4lle_Meldedatum": 589,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -29070,9 +29070,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29106,15 +29106,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 3030,
         "BelegteBetten": null,
-        "Inzidenz": 1658.64434785732,
+        "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1808,
+        "F\u00e4lle_Meldedatum": 1807,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 1608.5,
+        "Hosp_Meldedatum": 19,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1374,
-        "Krh_I_belegt": 201,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29124,7 +29124,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.57,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.04.2022"
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1503.64596429469,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1440,
+        "F\u00e4lle_Meldedatum": 1445,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 1270.9,
@@ -29162,7 +29162,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.42,
+        "H_Inzidenz": 9.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.04.2022"
@@ -29184,9 +29184,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1502.74794353245,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1049,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 1331.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1326,
@@ -29200,7 +29200,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9,
+        "H_Inzidenz": 9.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.04.2022"
@@ -29222,9 +29222,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1302.84852185783,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1046,
+        "F\u00e4lle_Meldedatum": 1055,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1161.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1257,
@@ -29238,7 +29238,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.13,
+        "H_Inzidenz": 8.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.04.2022"
@@ -29249,26 +29249,26 @@
         "Datum": "08.04.2022",
         "Fallzahl": 190794,
         "ObjectId": 763,
-        "Sterbefall": 1656,
-        "Genesungsfall": 172493,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5197,
-        "Zuwachs_Fallzahl": 1120,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1788,
         "BelegteBetten": null,
         "Inzidenz": 1269.26254535005,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 840,
+        "F\u00e4lle_Meldedatum": 875,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 1114.8,
-        "Fallzahl_aktiv": 16645,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1261,
         "Krh_I_belegt": 195,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -671,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29276,7 +29276,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.54,
+        "H_Inzidenz": 7.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.04.2022"
@@ -29298,9 +29298,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1252.73896332483,
         "Datum_neu": 1649462400000,
-        "F\u00e4lle_Meldedatum": 344,
+        "F\u00e4lle_Meldedatum": 438,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1108.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1179,
@@ -29314,7 +29314,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
+        "H_Inzidenz": 7.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.04.2022"
@@ -29336,9 +29336,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1208.55634182262,
         "Datum_neu": 1649548800000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 1083,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1169,
@@ -29352,7 +29352,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.97,
+        "H_Inzidenz": 6.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.04.2022"
@@ -29365,7 +29365,7 @@
         "ObjectId": 766,
         "Sterbefall": 1657,
         "Genesungsfall": 176214,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5205,
         "Zuwachs_Fallzahl": 1326,
         "Zuwachs_Sterbefall": 1,
@@ -29374,13 +29374,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1196.34325945616,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "04.04.2022 - 10.04.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1183,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 1160.9,
         "Fallzahl_aktiv": 14249,
-        "Krh_N_belegt": 1169,
-        "Krh_I_belegt": 167,
+        "Krh_N_belegt": 1216,
+        "Krh_I_belegt": 171,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -1007,
         "Krh_I": null,
@@ -29388,13 +29388,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 9109,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.5,
-        "H_Zeitraum": "04.04.2022 - 10.04.2022",
-        "H_Datum": "10.04.2022",
+        "H_Inzidenz": 6.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.04.2022",
+        "Fallzahl": 193841,
+        "ObjectId": 767,
+        "Sterbefall": 1657,
+        "Genesungsfall": 178171,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5228,
+        "Zuwachs_Fallzahl": 1721,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 1957,
+        "BelegteBetten": null,
+        "Inzidenz": 1134.55943101405,
+        "Datum_neu": 1649721600000,
+        "F\u00e4lle_Meldedatum": 275,
+        "Zeitraum": "05.04.2022 - 11.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 900.5,
+        "Fallzahl_aktiv": 14013,
+        "Krh_N_belegt": 1216,
+        "Krh_I_belegt": 171,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -236,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 9208,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.42,
+        "H_Zeitraum": "05.04.2022 - 11.04.2022",
+        "H_Datum": "11.04.2022",
+        "Datum_Bett": "11.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
