### PR TITLE
New data set: 2022-04-13T101403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-12T101903Z.json
+pjson/2022-04-13T101403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-12T101903Z.json pjson/2022-04-13T101403Z.json```:
```
--- pjson/2022-04-12T101903Z.json	2022-04-12 10:19:03.214080846 +0000
+++ pjson/2022-04-13T101403Z.json	2022-04-13 10:14:03.591116183 +0000
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1319,
+        "F\u00e4lle_Meldedatum": 1318,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -26980,7 +26980,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644192000000,
-        "F\u00e4lle_Meldedatum": 1802,
+        "F\u00e4lle_Meldedatum": 1803,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1354,
+        "F\u00e4lle_Meldedatum": 1355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27132,7 +27132,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644537600000,
-        "F\u00e4lle_Meldedatum": 959,
+        "F\u00e4lle_Meldedatum": 960,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 799,
+        "F\u00e4lle_Meldedatum": 800,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1112,
+        "F\u00e4lle_Meldedatum": 1110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2862,
+        "F\u00e4lle_Meldedatum": 2864,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2600,
+        "F\u00e4lle_Meldedatum": 2599,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2802,
+        "F\u00e4lle_Meldedatum": 2801,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2138,
+        "F\u00e4lle_Meldedatum": 2139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2204,
+        "F\u00e4lle_Meldedatum": 2202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1781,
+        "F\u00e4lle_Meldedatum": 1782,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 829,
+        "F\u00e4lle_Meldedatum": 827,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28778,7 +28778,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1971,
+        "F\u00e4lle_Meldedatum": 1972,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2206,
+        "F\u00e4lle_Meldedatum": 2204,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28930,7 +28930,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -28956,7 +28956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1288,
+        "F\u00e4lle_Meldedatum": 1289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28968,7 +28968,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 6,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29006,7 +29006,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29044,7 +29044,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -29108,9 +29108,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1807,
+        "F\u00e4lle_Meldedatum": 1808,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29144,15 +29144,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2951,
         "BelegteBetten": null,
-        "Inzidenz": 1503.64596429469,
+        "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1445,
+        "F\u00e4lle_Meldedatum": 1442,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 1270.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1383,
-        "Krh_I_belegt": 181,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29162,7 +29162,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.51,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.04.2022"
@@ -29186,7 +29186,7 @@
         "Datum_neu": 1649203200000,
         "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 1331.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1326,
@@ -29196,11 +29196,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.1,
+        "H_Inzidenz": 9.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.04.2022"
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1302.84852185783,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1055,
+        "F\u00e4lle_Meldedatum": 1057,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1161.8,
@@ -29238,7 +29238,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.21,
+        "H_Inzidenz": 8.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.04.2022"
@@ -29260,9 +29260,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1269.26254535005,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 875,
+        "F\u00e4lle_Meldedatum": 884,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1114.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1261,
@@ -29272,11 +29272,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.76,
+        "H_Inzidenz": 8.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.04.2022"
@@ -29298,7 +29298,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1252.73896332483,
         "Datum_neu": 1649462400000,
-        "F\u00e4lle_Meldedatum": 438,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 1108.9,
@@ -29310,11 +29310,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.3,
+        "H_Inzidenz": 7.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.04.2022"
@@ -29336,9 +29336,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1208.55634182262,
         "Datum_neu": 1649548800000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 269,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1083,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1169,
@@ -29352,7 +29352,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.9,
+        "H_Inzidenz": 7.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.04.2022"
@@ -29363,26 +29363,26 @@
         "Datum": "11.04.2022",
         "Fallzahl": 192120,
         "ObjectId": 766,
-        "Sterbefall": 1657,
-        "Genesungsfall": 176214,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5205,
-        "Zuwachs_Fallzahl": 1326,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2332,
         "BelegteBetten": null,
         "Inzidenz": 1196.34325945616,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1183,
+        "F\u00e4lle_Meldedatum": 1283,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 1160.9,
-        "Fallzahl_aktiv": 14249,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1216,
         "Krh_I_belegt": 171,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1007,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29390,7 +29390,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.7,
+        "H_Inzidenz": 7.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.04.2022"
@@ -29403,7 +29403,7 @@
         "ObjectId": 767,
         "Sterbefall": 1657,
         "Genesungsfall": 178171,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5228,
         "Zuwachs_Fallzahl": 1721,
         "Zuwachs_Sterbefall": 0,
@@ -29412,13 +29412,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1134.55943101405,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 275,
-        "Zeitraum": "05.04.2022 - 11.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 1181,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 900.5,
         "Fallzahl_aktiv": 14013,
-        "Krh_N_belegt": 1216,
-        "Krh_I_belegt": 171,
+        "Krh_N_belegt": 1170,
+        "Krh_I_belegt": 164,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -236,
         "Krh_I": null,
@@ -29426,13 +29426,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 9208,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.42,
-        "H_Zeitraum": "05.04.2022 - 11.04.2022",
-        "H_Datum": "11.04.2022",
+        "H_Inzidenz": 6.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.04.2022",
+        "Fallzahl": 194955,
+        "ObjectId": 768,
+        "Sterbefall": 1668,
+        "Genesungsfall": 180377,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5250,
+        "Zuwachs_Fallzahl": 1114,
+        "Zuwachs_Sterbefall": 11,
+        "Zuwachs_Krankenhauseinweisung": 22,
+        "Zuwachs_Genesung": 2206,
+        "BelegteBetten": null,
+        "Inzidenz": 1111.03128704336,
+        "Datum_neu": 1649808000000,
+        "F\u00e4lle_Meldedatum": 76,
+        "Zeitraum": "06.04.2022 - 12.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 938.3,
+        "Fallzahl_aktiv": 12910,
+        "Krh_N_belegt": 1170,
+        "Krh_I_belegt": 164,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1103,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": 9321,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.23,
+        "H_Zeitraum": "06.04.2022 - 12.04.2022",
+        "H_Datum": "12.04.2022",
+        "Datum_Bett": "12.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
