### PR TITLE
New data set: 2022-04-14T101704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-13T101403Z.json
+pjson/2022-04-14T101704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-13T101403Z.json pjson/2022-04-14T101704Z.json```:
```
--- pjson/2022-04-13T101403Z.json	2022-04-13 10:14:03.591116183 +0000
+++ pjson/2022-04-14T101704Z.json	2022-04-14 10:17:04.532069318 +0000
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2037,
+        "F\u00e4lle_Meldedatum": 2038,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 388,
+        "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2599,
+        "F\u00e4lle_Meldedatum": 2598,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2701,
+        "F\u00e4lle_Meldedatum": 2703,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2595,
+        "F\u00e4lle_Meldedatum": 2594,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 374,
+        "F\u00e4lle_Meldedatum": 375,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2971,
+        "F\u00e4lle_Meldedatum": 2969,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2139,
+        "F\u00e4lle_Meldedatum": 2137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2202,
+        "F\u00e4lle_Meldedatum": 2200,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1782,
+        "F\u00e4lle_Meldedatum": 1781,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 827,
+        "F\u00e4lle_Meldedatum": 828,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2365,
+        "F\u00e4lle_Meldedatum": 2364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1972,
+        "F\u00e4lle_Meldedatum": 1973,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2204,
+        "F\u00e4lle_Meldedatum": 2203,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1808,
+        "F\u00e4lle_Meldedatum": 1809,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1442,
+        "F\u00e4lle_Meldedatum": 1444,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -29182,15 +29182,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2150,
         "BelegteBetten": null,
-        "Inzidenz": 1502.74794353245,
+        "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1064,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 1331.5,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1326,
-        "Krh_I_belegt": 180,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29200,7 +29200,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.04.2022"
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1302.84852185783,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1057,
+        "F\u00e4lle_Meldedatum": 1060,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 1161.8,
@@ -29260,7 +29260,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1269.26254535005,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 884,
+        "F\u00e4lle_Meldedatum": 886,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 1114.8,
@@ -29300,7 +29300,7 @@
         "Datum_neu": 1649462400000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1108.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1179,
@@ -29336,7 +29336,7 @@
         "BelegteBetten": null,
         "Inzidenz": 1208.55634182262,
         "Datum_neu": 1649548800000,
-        "F\u00e4lle_Meldedatum": 269,
+        "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 1083,
@@ -29374,9 +29374,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1196.34325945616,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1283,
+        "F\u00e4lle_Meldedatum": 1297,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 1160.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1216,
@@ -29401,30 +29401,30 @@
         "Datum": "12.04.2022",
         "Fallzahl": 193841,
         "ObjectId": 767,
-        "Sterbefall": 1657,
-        "Genesungsfall": 178171,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5228,
-        "Zuwachs_Fallzahl": 1721,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1957,
         "BelegteBetten": null,
         "Inzidenz": 1134.55943101405,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1181,
+        "F\u00e4lle_Meldedatum": 1254,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 900.5,
-        "Fallzahl_aktiv": 14013,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1170,
         "Krh_I_belegt": 164,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -236,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29441,7 +29441,7 @@
         "ObjectId": 768,
         "Sterbefall": 1668,
         "Genesungsfall": 180377,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5250,
         "Zuwachs_Fallzahl": 1114,
         "Zuwachs_Sterbefall": 11,
@@ -29450,13 +29450,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1111.03128704336,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 76,
-        "Zeitraum": "06.04.2022 - 12.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 655,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 938.3,
         "Fallzahl_aktiv": 12910,
-        "Krh_N_belegt": 1170,
-        "Krh_I_belegt": 164,
+        "Krh_N_belegt": 1166,
+        "Krh_I_belegt": 171,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -1103,
         "Krh_I": null,
@@ -29464,13 +29464,51 @@
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
-        "Mutation": 9321,
+        "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 5.23,
-        "H_Zeitraum": "06.04.2022 - 12.04.2022",
-        "H_Datum": "12.04.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.04.2022",
+        "Fallzahl": 195840,
+        "ObjectId": 769,
+        "Sterbefall": 1669,
+        "Genesungsfall": 181679,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5266,
+        "Zuwachs_Fallzahl": 885,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 1302,
+        "BelegteBetten": null,
+        "Inzidenz": 1054.45597902224,
+        "Datum_neu": 1649894400000,
+        "F\u00e4lle_Meldedatum": 212,
+        "Zeitraum": "07.04.2022 - 13.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 938.5,
+        "Fallzahl_aktiv": 12492,
+        "Krh_N_belegt": 1166,
+        "Krh_I_belegt": 171,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -418,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.23,
+        "H_Zeitraum": "06.04.2022 - 12.04.2022",
+        "H_Datum": "13.04.2022",
+        "Datum_Bett": "13.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
