### PR TITLE
New data set: 2022-04-19T102304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-14T101704Z.json
+pjson/2022-04-19T102304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-14T101704Z.json pjson/2022-04-19T102304Z.json```:
```
--- pjson/2022-04-14T101704Z.json	2022-04-14 10:17:04.532069318 +0000
+++ pjson/2022-04-19T102304Z.json	2022-04-19 10:23:04.378743810 +0000
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1485,
+        "F\u00e4lle_Meldedatum": 1484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1827,
+        "F\u00e4lle_Meldedatum": 1826,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2038,
+        "F\u00e4lle_Meldedatum": 2039,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28158,7 +28158,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1806,
+        "F\u00e4lle_Meldedatum": 1807,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2864,
+        "F\u00e4lle_Meldedatum": 2866,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2598,
+        "F\u00e4lle_Meldedatum": 2599,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2703,
+        "F\u00e4lle_Meldedatum": 2704,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2594,
+        "F\u00e4lle_Meldedatum": 2597,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1528,
+        "F\u00e4lle_Meldedatum": 1529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3063,
+        "F\u00e4lle_Meldedatum": 3062,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2137,
+        "F\u00e4lle_Meldedatum": 2136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2364,
+        "F\u00e4lle_Meldedatum": 2365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2203,
+        "F\u00e4lle_Meldedatum": 2201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28956,7 +28956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1289,
+        "F\u00e4lle_Meldedatum": 1290,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1809,
+        "F\u00e4lle_Meldedatum": 1807,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29146,9 +29146,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1444,
+        "F\u00e4lle_Meldedatum": 1443,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29184,7 +29184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -29220,15 +29220,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2204,
         "BelegteBetten": null,
-        "Inzidenz": 1302.84852185783,
+        "Inzidenz": null,
         "Datum_neu": 1649289600000,
         "F\u00e4lle_Meldedatum": 1060,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 1161.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1257,
-        "Krh_I_belegt": 180,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29238,7 +29238,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.78,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.04.2022"
@@ -29258,15 +29258,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1788,
         "BelegteBetten": null,
-        "Inzidenz": 1269.26254535005,
+        "Inzidenz": null,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 886,
+        "F\u00e4lle_Meldedatum": 887,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 1114.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1261,
-        "Krh_I_belegt": 195,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29276,7 +29276,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.38,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.04.2022"
@@ -29296,15 +29296,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 842,
         "BelegteBetten": null,
-        "Inzidenz": 1252.73896332483,
+        "Inzidenz": null,
         "Datum_neu": 1649462400000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 1108.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1179,
-        "Krh_I_belegt": 187,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29314,7 +29314,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.96,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.04.2022"
@@ -29334,15 +29334,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 429,
         "BelegteBetten": null,
-        "Inzidenz": 1208.55634182262,
+        "Inzidenz": null,
         "Datum_neu": 1649548800000,
         "F\u00e4lle_Meldedatum": 271,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 1083,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1169,
-        "Krh_I_belegt": 167,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29352,7 +29352,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.04.2022"
@@ -29372,15 +29372,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2332,
         "BelegteBetten": null,
-        "Inzidenz": 1196.34325945616,
+        "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1297,
+        "F\u00e4lle_Meldedatum": 1308,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
-        "Inzidenz_RKI": 1160.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1216,
-        "Krh_I_belegt": 171,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29390,7 +29390,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.64,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.04.2022"
@@ -29412,9 +29412,9 @@
         "BelegteBetten": null,
         "Inzidenz": 1134.55943101405,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1254,
+        "F\u00e4lle_Meldedatum": 1258,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 900.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1170,
@@ -29428,7 +29428,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.56,
+        "H_Inzidenz": 7.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.04.2022"
@@ -29439,26 +29439,26 @@
         "Datum": "13.04.2022",
         "Fallzahl": 194955,
         "ObjectId": 768,
-        "Sterbefall": 1668,
-        "Genesungsfall": 180377,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5250,
-        "Zuwachs_Fallzahl": 1114,
-        "Zuwachs_Sterbefall": 11,
-        "Zuwachs_Krankenhauseinweisung": 22,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2206,
         "BelegteBetten": null,
         "Inzidenz": 1111.03128704336,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 655,
+        "F\u00e4lle_Meldedatum": 730,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 938.3,
-        "Fallzahl_aktiv": 12910,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1166,
         "Krh_I_belegt": 171,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1103,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29466,7 +29466,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 7.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.04.2022"
@@ -29479,7 +29479,7 @@
         "ObjectId": 769,
         "Sterbefall": 1669,
         "Genesungsfall": 181679,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5266,
         "Zuwachs_Fallzahl": 885,
         "Zuwachs_Sterbefall": 1,
@@ -29488,27 +29488,217 @@
         "BelegteBetten": null,
         "Inzidenz": 1054.45597902224,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 212,
-        "Zeitraum": "07.04.2022 - 13.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 675,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 938.5,
         "Fallzahl_aktiv": 12492,
-        "Krh_N_belegt": 1166,
-        "Krh_I_belegt": 171,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -418,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
-        "H_Zeitraum": "06.04.2022 - 12.04.2022",
-        "H_Datum": "13.04.2022",
+        "H_Inzidenz": 7.2,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.04.2022",
+        "Fallzahl": 196396,
+        "ObjectId": 770,
+        "Sterbefall": null,
+        "Genesungsfall": 182698,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1019,
+        "BelegteBetten": null,
+        "Inzidenz": 902.151657746327,
+        "Datum_neu": 1649980800000,
+        "F\u00e4lle_Meldedatum": 106,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 912.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.99,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "14.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.04.2022",
+        "Fallzahl": 196514,
+        "ObjectId": 771,
+        "Sterbefall": null,
+        "Genesungsfall": 183309,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 611,
+        "BelegteBetten": null,
+        "Inzidenz": 781.27806314882,
+        "Datum_neu": 1650067200000,
+        "F\u00e4lle_Meldedatum": 139,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 752.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.98,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "15.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.04.2022",
+        "Fallzahl": 196616,
+        "ObjectId": 772,
+        "Sterbefall": null,
+        "Genesungsfall": 183533,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 224,
+        "BelegteBetten": null,
+        "Inzidenz": 739.250691475987,
+        "Datum_neu": 1650153600000,
+        "F\u00e4lle_Meldedatum": 119,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 627.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.31,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "16.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.04.2022",
+        "Fallzahl": 196892,
+        "ObjectId": 773,
+        "Sterbefall": null,
+        "Genesungsfall": 185330,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1797,
+        "BelegteBetten": null,
+        "Inzidenz": 729.192858938899,
+        "Datum_neu": 1650240000000,
+        "F\u00e4lle_Meldedatum": 299,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 623.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.67,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.04.2022",
+        "Fallzahl": 197468,
+        "ObjectId": 774,
+        "Sterbefall": 1671,
+        "Genesungsfall": 186771,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5287,
+        "Zuwachs_Fallzahl": 1628,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 1441,
+        "BelegteBetten": null,
+        "Inzidenz": 597.363411042063,
+        "Datum_neu": 1650326400000,
+        "F\u00e4lle_Meldedatum": 407,
+        "Zeitraum": "12.04.2022 - 18.04.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 389.9,
+        "Fallzahl_aktiv": 9026,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 185,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.51,
+        "H_Zeitraum": "11.04.2022 - 17.04.2022",
+        "H_Datum": "14.04.2022",
+        "Datum_Bett": "18.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
