### PR TITLE
New data set: 2022-04-20T103003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-19T102304Z.json
+pjson/2022-04-20T103003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-19T102304Z.json pjson/2022-04-20T103003Z.json```:
```
--- pjson/2022-04-19T102304Z.json	2022-04-19 10:23:04.378743810 +0000
+++ pjson/2022-04-20T103003Z.json	2022-04-20 10:30:04.072170766 +0000
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26258,7 +26258,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642550400000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 683,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -27246,7 +27246,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644796800000,
-        "F\u00e4lle_Meldedatum": 1484,
+        "F\u00e4lle_Meldedatum": 1485,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1161,
+        "F\u00e4lle_Meldedatum": 1162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1482,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2866,
+        "F\u00e4lle_Meldedatum": 2865,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2599,
+        "F\u00e4lle_Meldedatum": 2598,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2801,
+        "F\u00e4lle_Meldedatum": 2802,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3062,
+        "F\u00e4lle_Meldedatum": 3064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2136,
+        "F\u00e4lle_Meldedatum": 2137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1973,
+        "F\u00e4lle_Meldedatum": 1974,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2201,
+        "F\u00e4lle_Meldedatum": 2202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28956,7 +28956,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648684800000,
-        "F\u00e4lle_Meldedatum": 1290,
+        "F\u00e4lle_Meldedatum": 1289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1060,
+        "F\u00e4lle_Meldedatum": 1061,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1308,
+        "F\u00e4lle_Meldedatum": 1309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29410,15 +29410,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1957,
         "BelegteBetten": null,
-        "Inzidenz": 1134.55943101405,
+        "Inzidenz": null,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1258,
+        "F\u00e4lle_Meldedatum": 1260,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 900.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1170,
-        "Krh_I_belegt": 164,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29428,7 +29428,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.04.2022"
@@ -29450,13 +29450,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1111.03128704336,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 730,
+        "F\u00e4lle_Meldedatum": 743,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 938.3,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1166,
-        "Krh_I_belegt": 171,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29466,7 +29466,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
+        "H_Inzidenz": 8.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.04.2022"
@@ -29477,34 +29477,34 @@
         "Datum": "14.04.2022",
         "Fallzahl": 195840,
         "ObjectId": 769,
-        "Sterbefall": 1669,
-        "Genesungsfall": 181679,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5266,
-        "Zuwachs_Fallzahl": 885,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1302,
         "BelegteBetten": null,
         "Inzidenz": 1054.45597902224,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 675,
+        "F\u00e4lle_Meldedatum": 726,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 938.5,
-        "Fallzahl_aktiv": 12492,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1018,
+        "Krh_I_belegt": 162,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -418,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.2,
+        "H_Inzidenz": 7.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.04.2022"
@@ -29516,7 +29516,7 @@
         "Fallzahl": 196396,
         "ObjectId": 770,
         "Sterbefall": null,
-        "Genesungsfall": 182698,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29526,13 +29526,13 @@
         "BelegteBetten": null,
         "Inzidenz": 902.151657746327,
         "Datum_neu": 1649980800000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 912.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": 1018,
+        "Krh_I_belegt": 162,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29542,7 +29542,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.99,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.04.2022"
@@ -29554,7 +29554,7 @@
         "Fallzahl": 196514,
         "ObjectId": 771,
         "Sterbefall": null,
-        "Genesungsfall": 183309,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29564,13 +29564,13 @@
         "BelegteBetten": null,
         "Inzidenz": 781.27806314882,
         "Datum_neu": 1650067200000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 752.9,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": 1018,
+        "Krh_I_belegt": 162,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29580,7 +29580,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.98,
+        "H_Inzidenz": 5.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.04.2022"
@@ -29592,7 +29592,7 @@
         "Fallzahl": 196616,
         "ObjectId": 772,
         "Sterbefall": null,
-        "Genesungsfall": 183533,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29602,23 +29602,23 @@
         "BelegteBetten": null,
         "Inzidenz": 739.250691475987,
         "Datum_neu": 1650153600000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 627.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": 1018,
+        "Krh_I_belegt": 162,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 5.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.04.2022"
@@ -29630,7 +29630,7 @@
         "Fallzahl": 196892,
         "ObjectId": 773,
         "Sterbefall": null,
-        "Genesungsfall": 185330,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29640,23 +29640,23 @@
         "BelegteBetten": null,
         "Inzidenz": 729.192858938899,
         "Datum_neu": 1650240000000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 623.7,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": 1018,
+        "Krh_I_belegt": 162,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.67,
+        "H_Inzidenz": 4.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.04.2022"
@@ -29669,7 +29669,7 @@
         "ObjectId": 774,
         "Sterbefall": 1671,
         "Genesungsfall": 186771,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5287,
         "Zuwachs_Fallzahl": 1628,
         "Zuwachs_Sterbefall": 2,
@@ -29678,13 +29678,13 @@
         "BelegteBetten": null,
         "Inzidenz": 597.363411042063,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 407,
-        "Zeitraum": "12.04.2022 - 18.04.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 1305,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 389.9,
         "Fallzahl_aktiv": 9026,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": 1018,
+        "Krh_I_belegt": 162,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 185,
         "Krh_I": null,
@@ -29694,10 +29694,48 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.75,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.04.2022",
+        "Fallzahl": 198937,
+        "ObjectId": 775,
+        "Sterbefall": 1676,
+        "Genesungsfall": 187856,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5334,
+        "Zuwachs_Fallzahl": 1469,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 47,
+        "Zuwachs_Genesung": 1085,
+        "BelegteBetten": null,
+        "Inzidenz": 670.103092783505,
+        "Datum_neu": 1650412800000,
+        "F\u00e4lle_Meldedatum": 204,
+        "Zeitraum": "13.04.2022 - 19.04.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 480,
+        "Fallzahl_aktiv": 9405,
+        "Krh_N_belegt": 1018,
+        "Krh_I_belegt": 162,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 379,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
         "H_Inzidenz": 2.51,
-        "H_Zeitraum": "11.04.2022 - 17.04.2022",
+        "H_Zeitraum": "13.04.2022 - 19.04.2022",
         "H_Datum": "14.04.2022",
-        "Datum_Bett": "18.04.2022"
+        "Datum_Bett": "19.04.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
