### PR TITLE
New data set: 2022-04-21T101505Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-20T103003Z.json
+pjson/2022-04-21T101505Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-20T103003Z.json pjson/2022-04-21T101505Z.json```:
```
--- pjson/2022-04-20T103003Z.json	2022-04-20 10:30:04.072170766 +0000
+++ pjson/2022-04-21T101505Z.json	2022-04-21 10:15:05.976920630 +0000
@@ -25688,7 +25688,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2597,
+        "F\u00e4lle_Meldedatum": 2598,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2969,
+        "F\u00e4lle_Meldedatum": 2970,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2200,
+        "F\u00e4lle_Meldedatum": 2199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 828,
+        "F\u00e4lle_Meldedatum": 829,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2365,
+        "F\u00e4lle_Meldedatum": 2364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -28996,7 +28996,7 @@
         "Datum_neu": 1648771200000,
         "F\u00e4lle_Meldedatum": 1011,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1807,
+        "F\u00e4lle_Meldedatum": 1811,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1443,
+        "F\u00e4lle_Meldedatum": 1441,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29184,9 +29184,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1064,
+        "F\u00e4lle_Meldedatum": 1062,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29260,7 +29260,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 887,
+        "F\u00e4lle_Meldedatum": 886,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -29300,7 +29300,7 @@
         "Datum_neu": 1649462400000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29336,7 +29336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649548800000,
-        "F\u00e4lle_Meldedatum": 271,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1309,
+        "F\u00e4lle_Meldedatum": 1311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29412,9 +29412,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1260,
+        "F\u00e4lle_Meldedatum": 1261,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29448,15 +29448,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 2206,
         "BelegteBetten": null,
-        "Inzidenz": 1111.03128704336,
+        "Inzidenz": null,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 743,
+        "F\u00e4lle_Meldedatum": 744,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 938.3,
+        "Hosp_Meldedatum": 18,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29466,7 +29466,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.23,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.04.2022"
@@ -29488,13 +29488,13 @@
         "BelegteBetten": null,
         "Inzidenz": 1054.45597902224,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 726,
+        "F\u00e4lle_Meldedatum": 775,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 938.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1018,
-        "Krh_I_belegt": 162,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29504,7 +29504,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.86,
+        "H_Inzidenz": 8.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.04.2022"
@@ -29526,13 +29526,13 @@
         "BelegteBetten": null,
         "Inzidenz": 902.151657746327,
         "Datum_neu": 1649980800000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 912.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1018,
-        "Krh_I_belegt": 162,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29542,7 +29542,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": 7.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.04.2022"
@@ -29564,13 +29564,13 @@
         "BelegteBetten": null,
         "Inzidenz": 781.27806314882,
         "Datum_neu": 1650067200000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 248,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 752.9,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1018,
-        "Krh_I_belegt": 162,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29580,7 +29580,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.89,
+        "H_Inzidenz": 6.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.04.2022"
@@ -29602,13 +29602,13 @@
         "BelegteBetten": null,
         "Inzidenz": 739.250691475987,
         "Datum_neu": 1650153600000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 627.4,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1018,
-        "Krh_I_belegt": 162,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29618,7 +29618,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.3,
+        "H_Inzidenz": 6.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.04.2022"
@@ -29640,13 +29640,13 @@
         "BelegteBetten": null,
         "Inzidenz": 729.192858938899,
         "Datum_neu": 1650240000000,
-        "F\u00e4lle_Meldedatum": 358,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 623.7,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1018,
-        "Krh_I_belegt": 162,
+        "Krh_N_belegt": 1094,
+        "Krh_I_belegt": 170,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29656,7 +29656,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.73,
+        "H_Inzidenz": 5.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.04.2022"
@@ -29667,34 +29667,34 @@
         "Datum": "19.04.2022",
         "Fallzahl": 197468,
         "ObjectId": 774,
-        "Sterbefall": 1671,
-        "Genesungsfall": 186771,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5287,
-        "Zuwachs_Fallzahl": 1628,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1441,
         "BelegteBetten": null,
         "Inzidenz": 597.363411042063,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1305,
+        "F\u00e4lle_Meldedatum": 1358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": 389.9,
-        "Fallzahl_aktiv": 9026,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1018,
         "Krh_I_belegt": 162,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 185,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 4.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.04.2022"
@@ -29707,7 +29707,7 @@
         "ObjectId": 775,
         "Sterbefall": 1676,
         "Genesungsfall": 187856,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5334,
         "Zuwachs_Fallzahl": 1469,
         "Zuwachs_Sterbefall": 5,
@@ -29716,13 +29716,13 @@
         "BelegteBetten": null,
         "Inzidenz": 670.103092783505,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 204,
-        "Zeitraum": "13.04.2022 - 19.04.2022",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 731,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 480,
         "Fallzahl_aktiv": 9405,
-        "Krh_N_belegt": 1018,
-        "Krh_I_belegt": 162,
+        "Krh_N_belegt": 1058,
+        "Krh_I_belegt": 159,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 379,
         "Krh_I": null,
@@ -29732,11 +29732,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.51,
-        "H_Zeitraum": "13.04.2022 - 19.04.2022",
-        "H_Datum": "14.04.2022",
+        "H_Inzidenz": 4.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.04.2022",
+        "Fallzahl": 199782,
+        "ObjectId": 776,
+        "Sterbefall": 1677,
+        "Genesungsfall": 188920,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5360,
+        "Zuwachs_Fallzahl": 845,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 26,
+        "Zuwachs_Genesung": 1064,
+        "BelegteBetten": null,
+        "Inzidenz": 695.78648658357,
+        "Datum_neu": 1650499200000,
+        "F\u00e4lle_Meldedatum": 157,
+        "Zeitraum": "14.04.2022 - 20.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 578.2,
+        "Fallzahl_aktiv": 9185,
+        "Krh_N_belegt": 1058,
+        "Krh_I_belegt": 159,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -220,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.8,
+        "H_Zeitraum": "14.04.2022 - 20.04.2022",
+        "H_Datum": "20.04.2022",
+        "Datum_Bett": "20.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
