### PR TITLE
New data set: 2022-04-22T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-21T101505Z.json
+pjson/2022-04-22T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-21T101505Z.json pjson/2022-04-22T101303Z.json```:
```
--- pjson/2022-04-21T101505Z.json	2022-04-21 10:15:05.976920630 +0000
+++ pjson/2022-04-22T101303Z.json	2022-04-22 10:13:04.110795100 +0000
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -27550,7 +27550,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645488000000,
-        "F\u00e4lle_Meldedatum": 1193,
+        "F\u00e4lle_Meldedatum": 1192,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2039,
+        "F\u00e4lle_Meldedatum": 2040,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2598,
+        "F\u00e4lle_Meldedatum": 2596,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3064,
+        "F\u00e4lle_Meldedatum": 3065,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1781,
+        "F\u00e4lle_Meldedatum": 1779,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 829,
+        "F\u00e4lle_Meldedatum": 828,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2364,
+        "F\u00e4lle_Meldedatum": 2365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2202,
+        "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1811,
+        "F\u00e4lle_Meldedatum": 1810,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29184,7 +29184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1062,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1311,
+        "F\u00e4lle_Meldedatum": 1312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29486,15 +29486,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1302,
         "BelegteBetten": null,
-        "Inzidenz": 1054.45597902224,
+        "Inzidenz": null,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 775,
+        "F\u00e4lle_Meldedatum": 779,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 938.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29504,7 +29504,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.26,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.04.2022"
@@ -29526,7 +29526,7 @@
         "BelegteBetten": null,
         "Inzidenz": 902.151657746327,
         "Datum_neu": 1649980800000,
-        "F\u00e4lle_Meldedatum": 233,
+        "F\u00e4lle_Meldedatum": 232,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 912.4,
@@ -29542,7 +29542,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.49,
+        "H_Inzidenz": 7.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.04.2022"
@@ -29564,7 +29564,7 @@
         "BelegteBetten": null,
         "Inzidenz": 781.27806314882,
         "Datum_neu": 1650067200000,
-        "F\u00e4lle_Meldedatum": 248,
+        "F\u00e4lle_Meldedatum": 254,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 752.9,
@@ -29580,7 +29580,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.68,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.04.2022"
@@ -29602,7 +29602,7 @@
         "BelegteBetten": null,
         "Inzidenz": 739.250691475987,
         "Datum_neu": 1650153600000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 627.4,
@@ -29618,7 +29618,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.19,
+        "H_Inzidenz": 6.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.04.2022"
@@ -29656,7 +29656,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.67,
+        "H_Inzidenz": 5.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.04.2022"
@@ -29678,9 +29678,9 @@
         "BelegteBetten": null,
         "Inzidenz": 597.363411042063,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1358,
+        "F\u00e4lle_Meldedatum": 1377,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 389.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1018,
@@ -29694,7 +29694,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": 4.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.04.2022"
@@ -29705,34 +29705,34 @@
         "Datum": "20.04.2022",
         "Fallzahl": 198937,
         "ObjectId": 775,
-        "Sterbefall": 1676,
-        "Genesungsfall": 187856,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5334,
-        "Zuwachs_Fallzahl": 1469,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 47,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1085,
         "BelegteBetten": null,
         "Inzidenz": 670.103092783505,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 731,
+        "F\u00e4lle_Meldedatum": 797,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 480,
-        "Fallzahl_aktiv": 9405,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1058,
         "Krh_I_belegt": 159,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 379,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": 4.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.04.2022"
@@ -29745,7 +29745,7 @@
         "ObjectId": 776,
         "Sterbefall": 1677,
         "Genesungsfall": 188920,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5360,
         "Zuwachs_Fallzahl": 845,
         "Zuwachs_Sterbefall": 1,
@@ -29754,27 +29754,65 @@
         "BelegteBetten": null,
         "Inzidenz": 695.78648658357,
         "Datum_neu": 1650499200000,
-        "F\u00e4lle_Meldedatum": 157,
-        "Zeitraum": "14.04.2022 - 20.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 691,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 578.2,
         "Fallzahl_aktiv": 9185,
-        "Krh_N_belegt": 1058,
-        "Krh_I_belegt": 159,
+        "Krh_N_belegt": 951,
+        "Krh_I_belegt": 143,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -220,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
-        "H_Zeitraum": "14.04.2022 - 20.04.2022",
-        "H_Datum": "20.04.2022",
+        "H_Inzidenz": 4.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.04.2022",
+        "Fallzahl": 200432,
+        "ObjectId": 777,
+        "Sterbefall": 1678,
+        "Genesungsfall": 189803,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5365,
+        "Zuwachs_Fallzahl": 650,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 883,
+        "BelegteBetten": null,
+        "Inzidenz": 697.223319803154,
+        "Datum_neu": 1650585600000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "15.04.2022 - 21.04.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 573,
+        "Fallzahl_aktiv": 8951,
+        "Krh_N_belegt": 951,
+        "Krh_I_belegt": 143,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -234,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.99,
+        "H_Zeitraum": "15.04.2022 - 21.04.2022",
+        "H_Datum": "21.04.2022",
+        "Datum_Bett": "21.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
