### PR TITLE
New data set: 2022-04-25T102604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-22T101303Z.json
+pjson/2022-04-25T102604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-22T101303Z.json pjson/2022-04-25T102604Z.json```:
```
--- pjson/2022-04-22T101303Z.json	2022-04-22 10:13:04.110795100 +0000
+++ pjson/2022-04-25T102604Z.json	2022-04-25 10:26:04.354311318 +0000
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1348,
+        "F\u00e4lle_Meldedatum": 1349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 391,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28576,7 +28576,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647820800000,
-        "F\u00e4lle_Meldedatum": 3065,
+        "F\u00e4lle_Meldedatum": 3064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2137,
+        "F\u00e4lle_Meldedatum": 2136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2199,
+        "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1779,
+        "F\u00e4lle_Meldedatum": 1781,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2365,
+        "F\u00e4lle_Meldedatum": 2364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1441,
+        "F\u00e4lle_Meldedatum": 1440,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29184,7 +29184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1065,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1061,
+        "F\u00e4lle_Meldedatum": 1062,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29300,7 +29300,7 @@
         "Datum_neu": 1649462400000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29310,7 +29310,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29336,7 +29336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649548800000,
-        "F\u00e4lle_Meldedatum": 272,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -29348,7 +29348,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1312,
+        "F\u00e4lle_Meldedatum": 1313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29488,7 +29488,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 779,
+        "F\u00e4lle_Meldedatum": 784,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29524,15 +29524,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1019,
         "BelegteBetten": null,
-        "Inzidenz": 902.151657746327,
+        "Inzidenz": null,
         "Datum_neu": 1649980800000,
-        "F\u00e4lle_Meldedatum": 232,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 912.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29542,7 +29542,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.04.2022"
@@ -29562,15 +29562,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 611,
         "BelegteBetten": null,
-        "Inzidenz": 781.27806314882,
+        "Inzidenz": null,
         "Datum_neu": 1650067200000,
-        "F\u00e4lle_Meldedatum": 254,
+        "F\u00e4lle_Meldedatum": 259,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 752.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29580,7 +29580,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.04.2022"
@@ -29600,15 +29600,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 224,
         "BelegteBetten": null,
-        "Inzidenz": 739.250691475987,
+        "Inzidenz": null,
         "Datum_neu": 1650153600000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 627.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29618,7 +29618,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.41,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.04.2022"
@@ -29640,9 +29640,9 @@
         "BelegteBetten": null,
         "Inzidenz": 729.192858938899,
         "Datum_neu": 1650240000000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 379,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 623.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1094,
@@ -29652,11 +29652,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.92,
+        "H_Inzidenz": 6.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.04.2022"
@@ -29678,9 +29678,9 @@
         "BelegteBetten": null,
         "Inzidenz": 597.363411042063,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1377,
+        "F\u00e4lle_Meldedatum": 1401,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": 389.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1018,
@@ -29694,7 +29694,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.93,
+        "H_Inzidenz": 5.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.04.2022"
@@ -29716,7 +29716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 670.103092783505,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 797,
+        "F\u00e4lle_Meldedatum": 825,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 480,
@@ -29728,11 +29728,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.91,
+        "H_Inzidenz": 5.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.04.2022"
@@ -29743,26 +29743,26 @@
         "Datum": "21.04.2022",
         "Fallzahl": 199782,
         "ObjectId": 776,
-        "Sterbefall": 1677,
-        "Genesungsfall": 188920,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5360,
-        "Zuwachs_Fallzahl": 845,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1064,
         "BelegteBetten": null,
         "Inzidenz": 695.78648658357,
         "Datum_neu": 1650499200000,
-        "F\u00e4lle_Meldedatum": 691,
+        "F\u00e4lle_Meldedatum": 795,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 578.2,
-        "Fallzahl_aktiv": 9185,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 951,
         "Krh_I_belegt": 143,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -220,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29770,7 +29770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": 5.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.04.2022"
@@ -29783,7 +29783,7 @@
         "ObjectId": 777,
         "Sterbefall": 1678,
         "Genesungsfall": 189803,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5365,
         "Zuwachs_Fallzahl": 650,
         "Zuwachs_Sterbefall": 1,
@@ -29792,27 +29792,141 @@
         "BelegteBetten": null,
         "Inzidenz": 697.223319803154,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "15.04.2022 - 21.04.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 459,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 573,
         "Fallzahl_aktiv": 8951,
-        "Krh_N_belegt": 951,
-        "Krh_I_belegt": 143,
+        "Krh_N_belegt": 938,
+        "Krh_I_belegt": 136,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -234,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.99,
-        "H_Zeitraum": "15.04.2022 - 21.04.2022",
-        "H_Datum": "21.04.2022",
+        "H_Inzidenz": 4.73,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.04.2022",
+        "Fallzahl": 200457,
+        "ObjectId": 778,
+        "Sterbefall": null,
+        "Genesungsfall": 190273,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 470,
+        "BelegteBetten": null,
+        "Inzidenz": 659.865656093969,
+        "Datum_neu": 1650672000000,
+        "F\u00e4lle_Meldedatum": 125,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 677.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 938,
+        "Krh_I_belegt": 136,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.04.2022",
+        "Fallzahl": 200483,
+        "ObjectId": 779,
+        "Sterbefall": null,
+        "Genesungsfall": 190551,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 278,
+        "BelegteBetten": null,
+        "Inzidenz": 618.736305183376,
+        "Datum_neu": 1650758400000,
+        "F\u00e4lle_Meldedatum": 148,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 631.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 938,
+        "Krh_I_belegt": 136,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.26,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.04.2022",
+        "Fallzahl": 201356,
+        "ObjectId": 780,
+        "Sterbefall": 1683,
+        "Genesungsfall": 191847,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5370,
+        "Zuwachs_Fallzahl": 924,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 1296,
+        "BelegteBetten": null,
+        "Inzidenz": 742.124357915155,
+        "Datum_neu": 1650844800000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "18.04.2022 - 24.04.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 602.6,
+        "Fallzahl_aktiv": 7826,
+        "Krh_N_belegt": 938,
+        "Krh_I_belegt": 136,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -377,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.04,
+        "H_Zeitraum": "18.04.2022 - 24.04.2022",
+        "H_Datum": "22.04.2022",
+        "Datum_Bett": "24.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
