### PR TITLE
New data set: 2022-04-26T102004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-25T102604Z.json
+pjson/2022-04-26T102004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-25T102604Z.json pjson/2022-04-26T102004Z.json```:
```
--- pjson/2022-04-25T102604Z.json	2022-04-25 10:26:04.354311318 +0000
+++ pjson/2022-04-26T102004Z.json	2022-04-26 10:20:04.785233641 +0000
@@ -26562,7 +26562,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643241600000,
-        "F\u00e4lle_Meldedatum": 942,
+        "F\u00e4lle_Meldedatum": 943,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1826,
+        "F\u00e4lle_Meldedatum": 1827,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2102,
+        "F\u00e4lle_Meldedatum": 2103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28310,7 +28310,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647216000000,
-        "F\u00e4lle_Meldedatum": 2865,
+        "F\u00e4lle_Meldedatum": 2866,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2802,
+        "F\u00e4lle_Meldedatum": 2804,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2704,
+        "F\u00e4lle_Meldedatum": 2705,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2596,
+        "F\u00e4lle_Meldedatum": 2595,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1529,
+        "F\u00e4lle_Meldedatum": 1530,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 375,
+        "F\u00e4lle_Meldedatum": 376,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2198,
+        "F\u00e4lle_Meldedatum": 2199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29032,7 +29032,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648857600000,
-        "F\u00e4lle_Meldedatum": 589,
+        "F\u00e4lle_Meldedatum": 588,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 212,
+        "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1810,
+        "F\u00e4lle_Meldedatum": 1811,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1440,
+        "F\u00e4lle_Meldedatum": 1439,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1062,
+        "F\u00e4lle_Meldedatum": 1061,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29262,7 +29262,7 @@
         "Datum_neu": 1649376000000,
         "F\u00e4lle_Meldedatum": 886,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29298,7 +29298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649462400000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1313,
+        "F\u00e4lle_Meldedatum": 1312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29414,7 +29414,7 @@
         "Datum_neu": 1649721600000,
         "F\u00e4lle_Meldedatum": 1261,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29450,7 +29450,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 744,
+        "F\u00e4lle_Meldedatum": 745,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29526,7 +29526,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649980800000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -29638,15 +29638,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1797,
         "BelegteBetten": null,
-        "Inzidenz": 729.192858938899,
+        "Inzidenz": null,
         "Datum_neu": 1650240000000,
-        "F\u00e4lle_Meldedatum": 379,
+        "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 623.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1094,
-        "Krh_I_belegt": 170,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29656,7 +29656,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.14,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.04.2022"
@@ -29678,9 +29678,9 @@
         "BelegteBetten": null,
         "Inzidenz": 597.363411042063,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1401,
+        "F\u00e4lle_Meldedatum": 1402,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 389.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1018,
@@ -29694,7 +29694,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.18,
+        "H_Inzidenz": 5.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.04.2022"
@@ -29716,7 +29716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 670.103092783505,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 825,
+        "F\u00e4lle_Meldedatum": 828,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 480,
@@ -29732,7 +29732,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.3,
+        "H_Inzidenz": 5.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.04.2022"
@@ -29754,7 +29754,7 @@
         "BelegteBetten": null,
         "Inzidenz": 695.78648658357,
         "Datum_neu": 1650499200000,
-        "F\u00e4lle_Meldedatum": 795,
+        "F\u00e4lle_Meldedatum": 802,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 578.2,
@@ -29770,7 +29770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.13,
+        "H_Inzidenz": 5.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.04.2022"
@@ -29781,26 +29781,26 @@
         "Datum": "22.04.2022",
         "Fallzahl": 200432,
         "ObjectId": 777,
-        "Sterbefall": 1678,
-        "Genesungsfall": 189803,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5365,
-        "Zuwachs_Fallzahl": 650,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 883,
         "BelegteBetten": null,
         "Inzidenz": 697.223319803154,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 459,
+        "F\u00e4lle_Meldedatum": 496,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 573,
-        "Fallzahl_aktiv": 8951,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 938,
         "Krh_I_belegt": 136,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -234,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29808,7 +29808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.73,
+        "H_Inzidenz": 5.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.04.2022"
@@ -29820,7 +29820,7 @@
         "Fallzahl": 200457,
         "ObjectId": 778,
         "Sterbefall": null,
-        "Genesungsfall": 190273,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29830,9 +29830,9 @@
         "BelegteBetten": null,
         "Inzidenz": 659.865656093969,
         "Datum_neu": 1650672000000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 677.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 938,
@@ -29846,7 +29846,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": 5.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.04.2022"
@@ -29858,7 +29858,7 @@
         "Fallzahl": 200483,
         "ObjectId": 779,
         "Sterbefall": null,
-        "Genesungsfall": 190551,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -29868,9 +29868,9 @@
         "BelegteBetten": null,
         "Inzidenz": 618.736305183376,
         "Datum_neu": 1650758400000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 631.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 938,
@@ -29884,7 +29884,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.26,
+        "H_Inzidenz": 5.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.04.2022"
@@ -29897,7 +29897,7 @@
         "ObjectId": 780,
         "Sterbefall": 1683,
         "Genesungsfall": 191847,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5370,
         "Zuwachs_Fallzahl": 924,
         "Zuwachs_Sterbefall": 5,
@@ -29906,27 +29906,65 @@
         "BelegteBetten": null,
         "Inzidenz": 742.124357915155,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "18.04.2022 - 24.04.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 824,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 602.6,
         "Fallzahl_aktiv": 7826,
-        "Krh_N_belegt": 938,
-        "Krh_I_belegt": 136,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 128,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -377,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.04,
-        "H_Zeitraum": "18.04.2022 - 24.04.2022",
-        "H_Datum": "22.04.2022",
+        "H_Inzidenz": 5.69,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.04.2022",
+        "Fallzahl": 202586,
+        "ObjectId": 781,
+        "Sterbefall": 1684,
+        "Genesungsfall": 193106,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5397,
+        "Zuwachs_Fallzahl": 1230,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 27,
+        "Zuwachs_Genesung": 1259,
+        "BelegteBetten": null,
+        "Inzidenz": 855.634182262294,
+        "Datum_neu": 1650931200000,
+        "F\u00e4lle_Meldedatum": 246,
+        "Zeitraum": "19.04.2022 - 25.04.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 704.7,
+        "Fallzahl_aktiv": 7796,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 128,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -30,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.5,
+        "H_Zeitraum": "19.04.2022 - 25.04.2022",
+        "H_Datum": "25.04.2022",
+        "Datum_Bett": "25.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
