### PR TITLE
New data set: 2022-04-27T101204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-26T102004Z.json
+pjson/2022-04-27T101204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-26T102004Z.json pjson/2022-04-27T101204Z.json```:
```
--- pjson/2022-04-26T102004Z.json	2022-04-26 10:20:04.785233641 +0000
+++ pjson/2022-04-27T101204Z.json	2022-04-27 10:12:04.796149052 +0000
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1827,
+        "F\u00e4lle_Meldedatum": 1828,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27968,7 +27968,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646438400000,
-        "F\u00e4lle_Meldedatum": 793,
+        "F\u00e4lle_Meldedatum": 792,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2103,
+        "F\u00e4lle_Meldedatum": 2100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28196,7 +28196,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646956800000,
-        "F\u00e4lle_Meldedatum": 1928,
+        "F\u00e4lle_Meldedatum": 1927,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2595,
+        "F\u00e4lle_Meldedatum": 2597,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1530,
+        "F\u00e4lle_Meldedatum": 1529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2198,
+        "F\u00e4lle_Meldedatum": 2197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1974,
+        "F\u00e4lle_Meldedatum": 1975,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28918,7 +28918,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648598400000,
-        "F\u00e4lle_Meldedatum": 2199,
+        "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28994,7 +28994,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 1011,
+        "F\u00e4lle_Meldedatum": 1010,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -29184,7 +29184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1065,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29336,7 +29336,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649548800000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -29450,7 +29450,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 745,
+        "F\u00e4lle_Meldedatum": 744,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29488,7 +29488,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 784,
+        "F\u00e4lle_Meldedatum": 785,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29526,7 +29526,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649980800000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -29676,15 +29676,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1441,
         "BelegteBetten": null,
-        "Inzidenz": 597.363411042063,
+        "Inzidenz": null,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1402,
+        "F\u00e4lle_Meldedatum": 1403,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
-        "Inzidenz_RKI": 389.9,
+        "Hosp_Meldedatum": 35,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1018,
-        "Krh_I_belegt": 162,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29694,7 +29694,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.4,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.04.2022"
@@ -29716,7 +29716,7 @@
         "BelegteBetten": null,
         "Inzidenz": 670.103092783505,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 828,
+        "F\u00e4lle_Meldedatum": 829,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 480,
@@ -29732,7 +29732,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.67,
+        "H_Inzidenz": 5.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.04.2022"
@@ -29754,7 +29754,7 @@
         "BelegteBetten": null,
         "Inzidenz": 695.78648658357,
         "Datum_neu": 1650499200000,
-        "F\u00e4lle_Meldedatum": 802,
+        "F\u00e4lle_Meldedatum": 804,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 578.2,
@@ -29770,7 +29770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.55,
+        "H_Inzidenz": 5.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.04.2022"
@@ -29792,7 +29792,7 @@
         "BelegteBetten": null,
         "Inzidenz": 697.223319803154,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 496,
+        "F\u00e4lle_Meldedatum": 499,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 573,
@@ -29808,7 +29808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.4,
+        "H_Inzidenz": 5.62,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.04.2022"
@@ -29830,7 +29830,7 @@
         "BelegteBetten": null,
         "Inzidenz": 659.865656093969,
         "Datum_neu": 1650672000000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 677.4,
@@ -29846,7 +29846,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.82,
+        "H_Inzidenz": 6.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.04.2022"
@@ -29868,7 +29868,7 @@
         "BelegteBetten": null,
         "Inzidenz": 618.736305183376,
         "Datum_neu": 1650758400000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 631.8,
@@ -29884,7 +29884,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.82,
+        "H_Inzidenz": 6.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.04.2022"
@@ -29895,34 +29895,34 @@
         "Datum": "25.04.2022",
         "Fallzahl": 201356,
         "ObjectId": 780,
-        "Sterbefall": 1683,
-        "Genesungsfall": 191847,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5370,
-        "Zuwachs_Fallzahl": 924,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1296,
         "BelegteBetten": null,
         "Inzidenz": 742.124357915155,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 824,
+        "F\u00e4lle_Meldedatum": 1094,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 602.6,
-        "Fallzahl_aktiv": 7826,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 128,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -377,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": 6.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.04.2022"
@@ -29935,7 +29935,7 @@
         "ObjectId": 781,
         "Sterbefall": 1684,
         "Genesungsfall": 193106,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5397,
         "Zuwachs_Fallzahl": 1230,
         "Zuwachs_Sterbefall": 1,
@@ -29944,13 +29944,13 @@
         "BelegteBetten": null,
         "Inzidenz": 855.634182262294,
         "Datum_neu": 1650931200000,
-        "F\u00e4lle_Meldedatum": 246,
-        "Zeitraum": "19.04.2022 - 25.04.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 531,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 704.7,
         "Fallzahl_aktiv": 7796,
-        "Krh_N_belegt": 865,
-        "Krh_I_belegt": 128,
+        "Krh_N_belegt": 873,
+        "Krh_I_belegt": 123,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -30,
         "Krh_I": null,
@@ -29960,11 +29960,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.5,
-        "H_Zeitraum": "19.04.2022 - 25.04.2022",
-        "H_Datum": "25.04.2022",
+        "H_Inzidenz": 6.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.04.2022",
+        "Fallzahl": 203238,
+        "ObjectId": 782,
+        "Sterbefall": 1685,
+        "Genesungsfall": 193107,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5402,
+        "Zuwachs_Fallzahl": 652,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 753.080211214483,
+        "Datum_neu": 1651017600000,
+        "F\u00e4lle_Meldedatum": 74,
+        "Zeitraum": "20.04.2022 - 26.04.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 667,
+        "Fallzahl_aktiv": 8446,
+        "Krh_N_belegt": 873,
+        "Krh_I_belegt": 123,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 650,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.71,
+        "H_Zeitraum": "20.04.2022 - 26.04.2022",
+        "H_Datum": "26.04.2022",
+        "Datum_Bett": "26.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
