### PR TITLE
New data set: 2022-04-27T103004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-27T101204Z.json
+pjson/2022-04-27T103004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-27T101204Z.json pjson/2022-04-27T103004Z.json```:
```
--- pjson/2022-04-27T101204Z.json	2022-04-27 10:12:04.796149052 +0000
+++ pjson/2022-04-27T103004Z.json	2022-04-27 10:30:05.140639399 +0000
@@ -29972,13 +29972,13 @@
         "Fallzahl": 203238,
         "ObjectId": 782,
         "Sterbefall": 1685,
-        "Genesungsfall": 193107,
+        "Genesungsfall": 193852,
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 5402,
         "Zuwachs_Fallzahl": 652,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 5,
-        "Zuwachs_Genesung": 1,
+        "Zuwachs_Genesung": 746,
         "BelegteBetten": null,
         "Inzidenz": 753.080211214483,
         "Datum_neu": 1651017600000,
@@ -29986,13 +29986,13 @@
         "Zeitraum": "20.04.2022 - 26.04.2022",
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 667,
-        "Fallzahl_aktiv": 8446,
+        "Fallzahl_aktiv": 7701,
         "Krh_N_belegt": 873,
         "Krh_I_belegt": 123,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 650,
+        "Fallzahl_aktiv_Zuwachs": -95,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
