### PR TITLE
New data set: 2022-04-28T112004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-27T101204Z.json
+pjson/2022-04-28T112004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-27T103004Z.json pjson/2022-04-28T112004Z.json```:
```
--- pjson/2022-04-27T103004Z.json	2022-04-27 10:30:05.140639399 +0000
+++ pjson/2022-04-28T112004Z.json	2022-04-28 11:20:04.615281005 +0000
@@ -27170,7 +27170,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644624000000,
-        "F\u00e4lle_Meldedatum": 872,
+        "F\u00e4lle_Meldedatum": 873,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -27626,7 +27626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1198,
+        "F\u00e4lle_Meldedatum": 1199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 800,
+        "F\u00e4lle_Meldedatum": 799,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2100,
+        "F\u00e4lle_Meldedatum": 2099,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2804,
+        "F\u00e4lle_Meldedatum": 2805,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2197,
+        "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1781,
+        "F\u00e4lle_Meldedatum": 1780,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1811,
+        "F\u00e4lle_Meldedatum": 1810,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1061,
+        "F\u00e4lle_Meldedatum": 1062,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29260,7 +29260,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 886,
+        "F\u00e4lle_Meldedatum": 885,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1312,
+        "F\u00e4lle_Meldedatum": 1313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29714,15 +29714,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1085,
         "BelegteBetten": null,
-        "Inzidenz": 670.103092783505,
+        "Inzidenz": null,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 829,
+        "F\u00e4lle_Meldedatum": 832,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 480,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1058,
-        "Krh_I_belegt": 159,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29732,7 +29732,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.77,
+        "H_Inzidenz": 5.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.04.2022"
@@ -29770,7 +29770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.64,
+        "H_Inzidenz": 5.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.04.2022"
@@ -29792,7 +29792,7 @@
         "BelegteBetten": null,
         "Inzidenz": 697.223319803154,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 499,
+        "F\u00e4lle_Meldedatum": 500,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 573,
@@ -29808,7 +29808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.62,
+        "H_Inzidenz": 5.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.04.2022"
@@ -29830,7 +29830,7 @@
         "BelegteBetten": null,
         "Inzidenz": 659.865656093969,
         "Datum_neu": 1650672000000,
-        "F\u00e4lle_Meldedatum": 200,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 677.4,
@@ -29846,7 +29846,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.26,
+        "H_Inzidenz": 6.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.04.2022"
@@ -29868,7 +29868,7 @@
         "BelegteBetten": null,
         "Inzidenz": 618.736305183376,
         "Datum_neu": 1650758400000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 631.8,
@@ -29884,7 +29884,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.36,
+        "H_Inzidenz": 6.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.04.2022"
@@ -29906,9 +29906,9 @@
         "BelegteBetten": null,
         "Inzidenz": 742.124357915155,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1094,
+        "F\u00e4lle_Meldedatum": 1102,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 602.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
@@ -29922,7 +29922,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.43,
+        "H_Inzidenz": 6.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.04.2022"
@@ -29933,34 +29933,34 @@
         "Datum": "26.04.2022",
         "Fallzahl": 202586,
         "ObjectId": 781,
-        "Sterbefall": 1684,
-        "Genesungsfall": 193106,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5397,
-        "Zuwachs_Fallzahl": 1230,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 27,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1259,
         "BelegteBetten": null,
         "Inzidenz": 855.634182262294,
         "Datum_neu": 1650931200000,
-        "F\u00e4lle_Meldedatum": 531,
+        "F\u00e4lle_Meldedatum": 603,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 704.7,
-        "Fallzahl_aktiv": 7796,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 873,
         "Krh_I_belegt": 123,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -30,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.7,
+        "H_Inzidenz": 7.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.04.2022"
@@ -29972,25 +29972,25 @@
         "Fallzahl": 203238,
         "ObjectId": 782,
         "Sterbefall": 1685,
-        "Genesungsfall": 193852,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 193802,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5402,
         "Zuwachs_Fallzahl": 652,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 5,
-        "Zuwachs_Genesung": 746,
+        "Zuwachs_Genesung": 708,
         "BelegteBetten": null,
         "Inzidenz": 753.080211214483,
         "Datum_neu": 1651017600000,
-        "F\u00e4lle_Meldedatum": 74,
-        "Zeitraum": "20.04.2022 - 26.04.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 506,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 667,
-        "Fallzahl_aktiv": 7701,
-        "Krh_N_belegt": 873,
-        "Krh_I_belegt": 123,
+        "Fallzahl_aktiv": 7751,
+        "Krh_N_belegt": 819,
+        "Krh_I_belegt": 104,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -95,
+        "Fallzahl_aktiv_Zuwachs": -57,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -29998,11 +29998,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.71,
-        "H_Zeitraum": "20.04.2022 - 26.04.2022",
-        "H_Datum": "26.04.2022",
+        "H_Inzidenz": 5.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.04.2022",
+        "Fallzahl": 203819,
+        "ObjectId": 783,
+        "Sterbefall": 1686,
+        "Genesungsfall": 194643,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5414,
+        "Zuwachs_Fallzahl": 581,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 841,
+        "BelegteBetten": null,
+        "Inzidenz": 710.15481877941,
+        "Datum_neu": 1651104000000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": "21.04.2022 - 27.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 632.8,
+        "Fallzahl_aktiv": 7490,
+        "Krh_N_belegt": 819,
+        "Krh_I_belegt": 104,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -261,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.91,
+        "H_Zeitraum": "21.04.2022 - 27.04.2022",
+        "H_Datum": "27.04.2022",
+        "Datum_Bett": "27.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
