### PR TITLE
New data set: 2022-04-29T100304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-28T112004Z.json
+pjson/2022-04-29T100304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-28T112004Z.json pjson/2022-04-29T100304Z.json```:
```
--- pjson/2022-04-28T112004Z.json	2022-04-28 11:20:04.615281005 +0000
+++ pjson/2022-04-29T100304Z.json	2022-04-29 10:03:04.291713186 +0000
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1062,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29234,7 +29234,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1313,
+        "F\u00e4lle_Meldedatum": 1314,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29602,7 +29602,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650153600000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -29678,7 +29678,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1403,
+        "F\u00e4lle_Meldedatum": 1405,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -29716,7 +29716,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 832,
+        "F\u00e4lle_Meldedatum": 834,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29728,11 +29728,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.04.2022"
@@ -29752,15 +29752,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1064,
         "BelegteBetten": null,
-        "Inzidenz": 695.78648658357,
+        "Inzidenz": null,
         "Datum_neu": 1650499200000,
         "F\u00e4lle_Meldedatum": 804,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 578.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 951,
-        "Krh_I_belegt": 143,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29770,7 +29770,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.04.2022"
@@ -29808,7 +29808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": 5.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.04.2022"
@@ -29832,7 +29832,7 @@
         "Datum_neu": 1650672000000,
         "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 677.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 938,
@@ -29842,11 +29842,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": 6.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.04.2022"
@@ -29884,7 +29884,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
+        "H_Inzidenz": 6.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.04.2022"
@@ -29906,7 +29906,7 @@
         "BelegteBetten": null,
         "Inzidenz": 742.124357915155,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1102,
+        "F\u00e4lle_Meldedatum": 1105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 602.6,
@@ -29922,7 +29922,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.68,
+        "H_Inzidenz": 7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.04.2022"
@@ -29944,7 +29944,7 @@
         "BelegteBetten": null,
         "Inzidenz": 855.634182262294,
         "Datum_neu": 1650931200000,
-        "F\u00e4lle_Meldedatum": 603,
+        "F\u00e4lle_Meldedatum": 604,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 704.7,
@@ -29960,7 +29960,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.42,
+        "H_Inzidenz": 7.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.04.2022"
@@ -29971,34 +29971,34 @@
         "Datum": "27.04.2022",
         "Fallzahl": 203238,
         "ObjectId": 782,
-        "Sterbefall": 1685,
-        "Genesungsfall": 193802,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5402,
-        "Zuwachs_Fallzahl": 652,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 708,
         "BelegteBetten": null,
         "Inzidenz": 753.080211214483,
         "Datum_neu": 1651017600000,
-        "F\u00e4lle_Meldedatum": 506,
+        "F\u00e4lle_Meldedatum": 561,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 667,
-        "Fallzahl_aktiv": 7751,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 819,
         "Krh_I_belegt": 104,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -57,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": 6.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.04.2022"
@@ -30011,7 +30011,7 @@
         "ObjectId": 783,
         "Sterbefall": 1686,
         "Genesungsfall": 194643,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5414,
         "Zuwachs_Fallzahl": 581,
         "Zuwachs_Sterbefall": 1,
@@ -30020,13 +30020,13 @@
         "BelegteBetten": null,
         "Inzidenz": 710.15481877941,
         "Datum_neu": 1651104000000,
-        "F\u00e4lle_Meldedatum": 61,
-        "Zeitraum": "21.04.2022 - 27.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 440,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 632.8,
         "Fallzahl_aktiv": 7490,
-        "Krh_N_belegt": 819,
-        "Krh_I_belegt": 104,
+        "Krh_N_belegt": 749,
+        "Krh_I_belegt": 97,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -261,
         "Krh_I": null,
@@ -30036,11 +30036,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.91,
-        "H_Zeitraum": "21.04.2022 - 27.04.2022",
-        "H_Datum": "27.04.2022",
+        "H_Inzidenz": 5.47,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.04.2022",
+        "Fallzahl": 204290,
+        "ObjectId": 784,
+        "Sterbefall": 1691,
+        "Genesungsfall": 194888,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5421,
+        "Zuwachs_Fallzahl": 471,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 245,
+        "BelegteBetten": null,
+        "Inzidenz": 655.375552282769,
+        "Datum_neu": 1651190400000,
+        "F\u00e4lle_Meldedatum": 28,
+        "Zeitraum": "22.04.2022 - 28.04.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 583.9,
+        "Fallzahl_aktiv": 7711,
+        "Krh_N_belegt": 749,
+        "Krh_I_belegt": 97,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 221,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.73,
+        "H_Zeitraum": "22.04.2022 - 28.04.2022",
+        "H_Datum": "28.04.2022",
+        "Datum_Bett": "28.04.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
