### PR TITLE
New data set: 2022-05-02T102504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-04-29T100304Z.json
+pjson/2022-05-02T102504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-04-29T100304Z.json pjson/2022-05-02T102504Z.json```:
```
--- pjson/2022-04-29T100304Z.json	2022-04-29 10:03:04.291713186 +0000
+++ pjson/2022-05-02T102504Z.json	2022-05-02 10:25:04.208976161 +0000
@@ -27892,7 +27892,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1205,
+        "F\u00e4lle_Meldedatum": 1206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2597,
+        "F\u00e4lle_Meldedatum": 2598,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2198,
+        "F\u00e4lle_Meldedatum": 2199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 828,
+        "F\u00e4lle_Meldedatum": 829,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28804,7 +28804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 425,
+        "F\u00e4lle_Meldedatum": 426,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -29790,15 +29790,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 883,
         "BelegteBetten": null,
-        "Inzidenz": 697.223319803154,
+        "Inzidenz": null,
         "Datum_neu": 1650585600000,
         "F\u00e4lle_Meldedatum": 500,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 573,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 938,
-        "Krh_I_belegt": 136,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29808,7 +29808,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.99,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.04.2022"
@@ -29828,15 +29828,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 470,
         "BelegteBetten": null,
-        "Inzidenz": 659.865656093969,
+        "Inzidenz": null,
         "Datum_neu": 1650672000000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 677.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 938,
-        "Krh_I_belegt": 136,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29846,7 +29846,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.04.2022"
@@ -29866,15 +29866,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 278,
         "BelegteBetten": null,
-        "Inzidenz": 618.736305183376,
+        "Inzidenz": null,
         "Datum_neu": 1650758400000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 631.8,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 938,
-        "Krh_I_belegt": 136,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29884,7 +29884,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.85,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.04.2022"
@@ -29908,7 +29908,7 @@
         "Datum_neu": 1650844800000,
         "F\u00e4lle_Meldedatum": 1105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 602.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
@@ -29922,7 +29922,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7,
+        "H_Inzidenz": 7.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.04.2022"
@@ -29944,7 +29944,7 @@
         "BelegteBetten": null,
         "Inzidenz": 855.634182262294,
         "Datum_neu": 1650931200000,
-        "F\u00e4lle_Meldedatum": 604,
+        "F\u00e4lle_Meldedatum": 606,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 704.7,
@@ -29960,7 +29960,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
+        "H_Inzidenz": 7.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.04.2022"
@@ -29982,7 +29982,7 @@
         "BelegteBetten": null,
         "Inzidenz": 753.080211214483,
         "Datum_neu": 1651017600000,
-        "F\u00e4lle_Meldedatum": 561,
+        "F\u00e4lle_Meldedatum": 571,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 667,
@@ -29998,7 +29998,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.16,
+        "H_Inzidenz": 6.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.04.2022"
@@ -30009,34 +30009,34 @@
         "Datum": "28.04.2022",
         "Fallzahl": 203819,
         "ObjectId": 783,
-        "Sterbefall": 1686,
-        "Genesungsfall": 194643,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5414,
-        "Zuwachs_Fallzahl": 581,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 841,
         "BelegteBetten": null,
         "Inzidenz": 710.15481877941,
         "Datum_neu": 1651104000000,
-        "F\u00e4lle_Meldedatum": 440,
+        "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 632.8,
-        "Fallzahl_aktiv": 7490,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 749,
         "Krh_I_belegt": 97,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -261,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.47,
+        "H_Inzidenz": 5.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.04.2022"
@@ -30049,7 +30049,7 @@
         "ObjectId": 784,
         "Sterbefall": 1691,
         "Genesungsfall": 194888,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5421,
         "Zuwachs_Fallzahl": 471,
         "Zuwachs_Sterbefall": 5,
@@ -30058,13 +30058,13 @@
         "BelegteBetten": null,
         "Inzidenz": 655.375552282769,
         "Datum_neu": 1651190400000,
-        "F\u00e4lle_Meldedatum": 28,
-        "Zeitraum": "22.04.2022 - 28.04.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 349,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 583.9,
         "Fallzahl_aktiv": 7711,
-        "Krh_N_belegt": 749,
-        "Krh_I_belegt": 97,
+        "Krh_N_belegt": 726,
+        "Krh_I_belegt": 99,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 221,
         "Krh_I": null,
@@ -30074,11 +30074,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.73,
-        "H_Zeitraum": "22.04.2022 - 28.04.2022",
-        "H_Datum": "28.04.2022",
+        "H_Inzidenz": 5.2,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.04.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.04.2022",
+        "Fallzahl": 204671,
+        "ObjectId": 785,
+        "Sterbefall": null,
+        "Genesungsfall": 195146,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 258,
+        "BelegteBetten": null,
+        "Inzidenz": 638.13355364776,
+        "Datum_neu": 1651276800000,
+        "F\u00e4lle_Meldedatum": 107,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 578.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 726,
+        "Krh_I_belegt": 99,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.36,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "29.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.05.2022",
+        "Fallzahl": 204318,
+        "ObjectId": 786,
+        "Sterbefall": null,
+        "Genesungsfall": 195322,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 176,
+        "BelegteBetten": null,
+        "Inzidenz": 620.891555012752,
+        "Datum_neu": 1651363200000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 542,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 726,
+        "Krh_I_belegt": 99,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.92,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.04.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.05.2022",
+        "Fallzahl": 204822,
+        "ObjectId": 787,
+        "Sterbefall": 1692,
+        "Genesungsfall": 195702,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5425,
+        "Zuwachs_Fallzahl": 532,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 380,
+        "BelegteBetten": null,
+        "Inzidenz": 582.276662236431,
+        "Datum_neu": 1651449600000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "25.04.2022 - 01.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 499.3,
+        "Fallzahl_aktiv": 7428,
+        "Krh_N_belegt": 726,
+        "Krh_I_belegt": 99,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 151,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.5,
+        "H_Zeitraum": "25.04.2022 - 01.05.2022",
+        "H_Datum": "29.04.2022",
+        "Datum_Bett": "01.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
