### PR TITLE
New data set: 2022-05-03T113303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-02T102504Z.json
+pjson/2022-05-03T113303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-02T102504Z.json pjson/2022-05-03T113303Z.json```:
```
--- pjson/2022-05-02T102504Z.json	2022-05-02 10:25:04.208976161 +0000
+++ pjson/2022-05-03T113303Z.json	2022-05-03 11:33:03.300386781 +0000
@@ -29792,7 +29792,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 500,
+        "F\u00e4lle_Meldedatum": 501,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -29904,15 +29904,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1296,
         "BelegteBetten": null,
-        "Inzidenz": 742.124357915155,
+        "Inzidenz": null,
         "Datum_neu": 1650844800000,
         "F\u00e4lle_Meldedatum": 1105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 602.6,
+        "Hosp_Meldedatum": 16,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 865,
-        "Krh_I_belegt": 128,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29922,7 +29922,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.05,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.04.2022"
@@ -29946,7 +29946,7 @@
         "Datum_neu": 1650931200000,
         "F\u00e4lle_Meldedatum": 606,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 704.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 873,
@@ -29982,7 +29982,7 @@
         "BelegteBetten": null,
         "Inzidenz": 753.080211214483,
         "Datum_neu": 1651017600000,
-        "F\u00e4lle_Meldedatum": 571,
+        "F\u00e4lle_Meldedatum": 572,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 667,
@@ -30020,7 +30020,7 @@
         "BelegteBetten": null,
         "Inzidenz": 710.15481877941,
         "Datum_neu": 1651104000000,
-        "F\u00e4lle_Meldedatum": 481,
+        "F\u00e4lle_Meldedatum": 494,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 632.8,
@@ -30047,28 +30047,28 @@
         "Datum": "29.04.2022",
         "Fallzahl": 204290,
         "ObjectId": 784,
-        "Sterbefall": 1691,
-        "Genesungsfall": 194888,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5421,
-        "Zuwachs_Fallzahl": 471,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 245,
         "BelegteBetten": null,
         "Inzidenz": 655.375552282769,
         "Datum_neu": 1651190400000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 382,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 583.9,
-        "Fallzahl_aktiv": 7711,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 726,
         "Krh_I_belegt": 99,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 221,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -30086,7 +30086,7 @@
         "Fallzahl": 204671,
         "ObjectId": 785,
         "Sterbefall": null,
-        "Genesungsfall": 195146,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30094,11 +30094,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 258,
         "BelegteBetten": null,
-        "Inzidenz": 638.13355364776,
+        "Inzidenz": 646.574948812817,
         "Datum_neu": 1651276800000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 578.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 726,
@@ -30124,7 +30124,7 @@
         "Fallzahl": 204318,
         "ObjectId": 786,
         "Sterbefall": null,
-        "Genesungsfall": 195322,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30132,11 +30132,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 176,
         "BelegteBetten": null,
-        "Inzidenz": 620.891555012752,
+        "Inzidenz": 635.798699665936,
         "Datum_neu": 1651363200000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 542,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 726,
@@ -30146,7 +30146,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30163,7 +30163,7 @@
         "ObjectId": 787,
         "Sterbefall": 1692,
         "Genesungsfall": 195702,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5425,
         "Zuwachs_Fallzahl": 532,
         "Zuwachs_Sterbefall": 1,
@@ -30172,13 +30172,13 @@
         "BelegteBetten": null,
         "Inzidenz": 582.276662236431,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 21,
-        "Zeitraum": "25.04.2022 - 01.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 574,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 499.3,
         "Fallzahl_aktiv": 7428,
-        "Krh_N_belegt": 726,
-        "Krh_I_belegt": 99,
+        "Krh_N_belegt": 662,
+        "Krh_I_belegt": 104,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 151,
         "Krh_I": null,
@@ -30189,10 +30189,48 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 3.5,
-        "H_Zeitraum": "25.04.2022 - 01.05.2022",
-        "H_Datum": "29.04.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.05.2022",
+        "Fallzahl": 205578,
+        "ObjectId": 788,
+        "Sterbefall": 1693,
+        "Genesungsfall": 197080,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5445,
+        "Zuwachs_Fallzahl": 907,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 1378,
+        "BelegteBetten": null,
+        "Inzidenz": 512.590251086605,
+        "Datum_neu": 1651536000000,
+        "F\u00e4lle_Meldedatum": 59,
+        "Zeitraum": "26.04.2022 - 02.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 405.9,
+        "Fallzahl_aktiv": 6805,
+        "Krh_N_belegt": 662,
+        "Krh_I_belegt": 104,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -472,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.5,
+        "H_Zeitraum": "26.04.2022 - 02.05.2022",
+        "H_Datum": "02.05.2022",
+        "Datum_Bett": "02.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
