### PR TITLE
New data set: 2022-05-04T112303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-03T113303Z.json
+pjson/2022-05-04T112303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-03T113303Z.json pjson/2022-05-04T112303Z.json```:
```
--- pjson/2022-05-03T113303Z.json	2022-05-03 11:33:03.300386781 +0000
+++ pjson/2022-05-04T112303Z.json	2022-05-04 11:23:03.590735352 +0000
@@ -28728,7 +28728,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648166400000,
-        "F\u00e4lle_Meldedatum": 1780,
+        "F\u00e4lle_Meldedatum": 1781,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 829,
+        "F\u00e4lle_Meldedatum": 830,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1975,
+        "F\u00e4lle_Meldedatum": 1973,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28994,7 +28994,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 1010,
+        "F\u00e4lle_Meldedatum": 1009,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1439,
+        "F\u00e4lle_Meldedatum": 1440,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29196,7 +29196,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1062,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29260,7 +29260,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 885,
+        "F\u00e4lle_Meldedatum": 887,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -29376,7 +29376,7 @@
         "Datum_neu": 1649635200000,
         "F\u00e4lle_Meldedatum": 1314,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29414,7 +29414,7 @@
         "Datum_neu": 1649721600000,
         "F\u00e4lle_Meldedatum": 1261,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29450,9 +29450,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 744,
+        "F\u00e4lle_Meldedatum": 745,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29576,7 +29576,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29906,7 +29906,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1105,
+        "F\u00e4lle_Meldedatum": 1106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -29942,15 +29942,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1259,
         "BelegteBetten": null,
-        "Inzidenz": 855.634182262294,
+        "Inzidenz": null,
         "Datum_neu": 1650931200000,
         "F\u00e4lle_Meldedatum": 606,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 704.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 873,
-        "Krh_I_belegt": 123,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29960,7 +29960,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.04.2022"
@@ -29998,7 +29998,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.21,
+        "H_Inzidenz": 6.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.04.2022"
@@ -30020,9 +30020,9 @@
         "BelegteBetten": null,
         "Inzidenz": 710.15481877941,
         "Datum_neu": 1651104000000,
-        "F\u00e4lle_Meldedatum": 494,
+        "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 632.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 749,
@@ -30036,7 +30036,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.57,
+        "H_Inzidenz": 5.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.04.2022"
@@ -30058,9 +30058,9 @@
         "BelegteBetten": null,
         "Inzidenz": 655.375552282769,
         "Datum_neu": 1651190400000,
-        "F\u00e4lle_Meldedatum": 382,
+        "F\u00e4lle_Meldedatum": 383,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 583.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 726,
@@ -30074,7 +30074,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.2,
+        "H_Inzidenz": 5.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.04.2022"
@@ -30096,9 +30096,9 @@
         "BelegteBetten": null,
         "Inzidenz": 646.574948812817,
         "Datum_neu": 1651276800000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 578.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 726,
@@ -30112,7 +30112,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.36,
+        "H_Inzidenz": 4.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.04.2022"
@@ -30134,7 +30134,7 @@
         "BelegteBetten": null,
         "Inzidenz": 635.798699665936,
         "Datum_neu": 1651363200000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 99,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 542,
@@ -30150,7 +30150,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.04.2022"
@@ -30161,34 +30161,34 @@
         "Datum": "02.05.2022",
         "Fallzahl": 204822,
         "ObjectId": 787,
-        "Sterbefall": 1692,
-        "Genesungsfall": 195702,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5425,
-        "Zuwachs_Fallzahl": 532,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 380,
         "BelegteBetten": null,
         "Inzidenz": 582.276662236431,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 574,
+        "F\u00e4lle_Meldedatum": 680,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 499.3,
-        "Fallzahl_aktiv": 7428,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 662,
         "Krh_I_belegt": 104,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 151,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.5,
+        "H_Inzidenz": 4.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.05.2022"
@@ -30201,18 +30201,18 @@
         "ObjectId": 788,
         "Sterbefall": 1693,
         "Genesungsfall": 197080,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5445,
         "Zuwachs_Fallzahl": 907,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 20,
         "Zuwachs_Genesung": 1378,
         "BelegteBetten": null,
-        "Inzidenz": 512.590251086605,
+        "Inzidenz": 512.6,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 59,
-        "Zeitraum": "26.04.2022 - 02.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 538,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 405.9,
         "Fallzahl_aktiv": 6805,
         "Krh_N_belegt": 662,
@@ -30222,15 +30222,53 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 3.5,
-        "H_Zeitraum": "26.04.2022 - 02.05.2022",
-        "H_Datum": "02.05.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.05.2022",
+        "Fallzahl": 206214,
+        "ObjectId": 789,
+        "Sterbefall": 1696,
+        "Genesungsfall": 197915,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5462,
+        "Zuwachs_Fallzahl": 636,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 835,
+        "BelegteBetten": null,
+        "Inzidenz": 525.70135421531,
+        "Datum_neu": 1651622400000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "27.04.2022 - 03.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 450.7,
+        "Fallzahl_aktiv": 6603,
+        "Krh_N_belegt": 687,
+        "Krh_I_belegt": 104,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -202,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.91,
+        "H_Zeitraum": "26.04.2022 - 02.05.2022",
+        "H_Datum": "03.05.2023",
+        "Datum_Bett": "03.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
