### PR TITLE
New data set: 2022-05-05T102004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-04T112303Z.json
+pjson/2022-05-05T102004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-04T112303Z.json pjson/2022-05-05T102004Z.json```:
```
--- pjson/2022-05-04T112303Z.json	2022-05-04 11:23:03.590735352 +0000
+++ pjson/2022-05-05T102004Z.json	2022-05-05 10:20:04.905401438 +0000
@@ -28006,7 +28006,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646524800000,
-        "F\u00e4lle_Meldedatum": 373,
+        "F\u00e4lle_Meldedatum": 374,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2970,
+        "F\u00e4lle_Meldedatum": 2971,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -29716,7 +29716,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 834,
+        "F\u00e4lle_Meldedatum": 835,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29868,7 +29868,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650758400000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -29906,7 +29906,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1106,
+        "F\u00e4lle_Meldedatum": 1107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -29980,15 +29980,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 708,
         "BelegteBetten": null,
-        "Inzidenz": 753.080211214483,
+        "Inzidenz": null,
         "Datum_neu": 1651017600000,
         "F\u00e4lle_Meldedatum": 572,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 667,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 819,
-        "Krh_I_belegt": 104,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -29998,7 +29998,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.04.2022"
@@ -30036,7 +30036,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": 5.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.04.2022"
@@ -30074,7 +30074,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.52,
+        "H_Inzidenz": 5.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.04.2022"
@@ -30112,7 +30112,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.88,
+        "H_Inzidenz": 5.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.04.2022"
@@ -30150,7 +30150,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 5.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.04.2022"
@@ -30172,9 +30172,9 @@
         "BelegteBetten": null,
         "Inzidenz": 582.276662236431,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 680,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 499.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 662,
@@ -30188,7 +30188,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 4.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.05.2022"
@@ -30199,26 +30199,26 @@
         "Datum": "03.05.2022",
         "Fallzahl": 205578,
         "ObjectId": 788,
-        "Sterbefall": 1693,
-        "Genesungsfall": 197080,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5445,
-        "Zuwachs_Fallzahl": 907,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1378,
         "BelegteBetten": null,
         "Inzidenz": 512.6,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 538,
+        "F\u00e4lle_Meldedatum": 559,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 405.9,
-        "Fallzahl_aktiv": 6805,
-        "Krh_N_belegt": 662,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 687,
         "Krh_I_belegt": 104,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -472,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30226,7 +30226,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.5,
+        "H_Inzidenz": 4.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.05.2022"
@@ -30237,26 +30237,26 @@
         "Datum": "04.05.2022",
         "Fallzahl": 206214,
         "ObjectId": 789,
-        "Sterbefall": 1696,
-        "Genesungsfall": 197915,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 5462,
-        "Zuwachs_Fallzahl": 636,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 835,
         "BelegteBetten": null,
         "Inzidenz": 525.70135421531,
         "Datum_neu": 1651622400000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "27.04.2022 - 03.05.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 282,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 450.7,
-        "Fallzahl_aktiv": 6603,
-        "Krh_N_belegt": 687,
-        "Krh_I_belegt": 104,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 691,
+        "Krh_I_belegt": 103,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -202,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30264,11 +30264,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.91,
-        "H_Zeitraum": "26.04.2022 - 02.05.2022",
-        "H_Datum": "03.05.2023",
+        "H_Inzidenz": 3.62,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.05.2022",
+        "Fallzahl": 206582,
+        "ObjectId": 790,
+        "Sterbefall": 1696,
+        "Genesungsfall": 198719,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5468,
+        "Zuwachs_Fallzahl": 368,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 804,
+        "BelegteBetten": null,
+        "Inzidenz": 478.645066273932,
+        "Datum_neu": 1651708800000,
+        "F\u00e4lle_Meldedatum": 66,
+        "Zeitraum": "28.04.2022 - 04.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 435.1,
+        "Fallzahl_aktiv": 6167,
+        "Krh_N_belegt": 691,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -436,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.98,
+        "H_Zeitraum": "28.04.2022 - 04.05.2022",
+        "H_Datum": "04.05.2022",
+        "Datum_Bett": "04.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
