### PR TITLE
New data set: 2022-05-06T101504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-05T102004Z.json
+pjson/2022-05-06T101504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-05T102004Z.json pjson/2022-05-06T101504Z.json```:
```
--- pjson/2022-05-05T102004Z.json	2022-05-05 10:20:04.905401438 +0000
+++ pjson/2022-05-06T101504Z.json	2022-05-06 10:15:04.259092709 +0000
@@ -30018,15 +30018,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 841,
         "BelegteBetten": null,
-        "Inzidenz": 710.15481877941,
+        "Inzidenz": null,
         "Datum_neu": 1651104000000,
         "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 632.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 749,
-        "Krh_I_belegt": 97,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30036,7 +30036,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.94,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.04.2022"
@@ -30058,7 +30058,7 @@
         "BelegteBetten": null,
         "Inzidenz": 655.375552282769,
         "Datum_neu": 1651190400000,
-        "F\u00e4lle_Meldedatum": 383,
+        "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 583.9,
@@ -30074,7 +30074,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.77,
+        "H_Inzidenz": 5.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.04.2022"
@@ -30096,7 +30096,7 @@
         "BelegteBetten": null,
         "Inzidenz": 646.574948812817,
         "Datum_neu": 1651276800000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 578.4,
@@ -30210,9 +30210,9 @@
         "BelegteBetten": null,
         "Inzidenz": 512.6,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 559,
+        "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 405.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 687,
@@ -30226,7 +30226,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.19,
+        "H_Inzidenz": 4.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.05.2022"
@@ -30248,9 +30248,9 @@
         "BelegteBetten": null,
         "Inzidenz": 525.70135421531,
         "Datum_neu": 1651622400000,
-        "F\u00e4lle_Meldedatum": 282,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 450.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 691,
@@ -30264,7 +30264,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.62,
+        "H_Inzidenz": 3.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.05.2022"
@@ -30277,7 +30277,7 @@
         "ObjectId": 790,
         "Sterbefall": 1696,
         "Genesungsfall": 198719,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5468,
         "Zuwachs_Fallzahl": 368,
         "Zuwachs_Sterbefall": 0,
@@ -30286,13 +30286,13 @@
         "BelegteBetten": null,
         "Inzidenz": 478.645066273932,
         "Datum_neu": 1651708800000,
-        "F\u00e4lle_Meldedatum": 66,
-        "Zeitraum": "28.04.2022 - 04.05.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 325,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 435.1,
         "Fallzahl_aktiv": 6167,
-        "Krh_N_belegt": 691,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": 644,
+        "Krh_I_belegt": 101,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -436,
         "Krh_I": null,
@@ -30302,11 +30302,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
-        "H_Zeitraum": "28.04.2022 - 04.05.2022",
-        "H_Datum": "04.05.2022",
+        "H_Inzidenz": 3.2,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "04.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "06.05.2022",
+        "Fallzahl": 206887,
+        "ObjectId": 791,
+        "Sterbefall": 1696,
+        "Genesungsfall": 199299,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5472,
+        "Zuwachs_Fallzahl": 305,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 580,
+        "BelegteBetten": null,
+        "Inzidenz": 453.859693236108,
+        "Datum_neu": 1651795200000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "29.04.2022 - 05.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 404.5,
+        "Fallzahl_aktiv": 5892,
+        "Krh_N_belegt": 644,
+        "Krh_I_belegt": 101,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -275,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.54,
+        "H_Zeitraum": "29.04.2022 - 05.05.2022",
+        "H_Datum": "05.05.2022",
+        "Datum_Bett": "05.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
