### PR TITLE
New data set: 2022-05-09T105004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-06T101504Z.json
+pjson/2022-05-09T105004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-06T101504Z.json pjson/2022-05-09T105004Z.json```:
```
--- pjson/2022-05-06T101504Z.json	2022-05-06 10:15:04.259092709 +0000
+++ pjson/2022-05-09T105004Z.json	2022-05-09 10:50:04.368586631 +0000
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1828,
+        "F\u00e4lle_Meldedatum": 1829,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1973,
+        "F\u00e4lle_Meldedatum": 1972,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1314,
+        "F\u00e4lle_Meldedatum": 1315,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -29412,7 +29412,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1261,
+        "F\u00e4lle_Meldedatum": 1262,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -29538,7 +29538,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -29794,7 +29794,7 @@
         "Datum_neu": 1650585600000,
         "F\u00e4lle_Meldedatum": 501,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29944,7 +29944,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650931200000,
-        "F\u00e4lle_Meldedatum": 606,
+        "F\u00e4lle_Meldedatum": 607,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -30056,15 +30056,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 245,
         "BelegteBetten": null,
-        "Inzidenz": 655.375552282769,
+        "Inzidenz": null,
         "Datum_neu": 1651190400000,
         "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 583.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 726,
-        "Krh_I_belegt": 99,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30074,7 +30074,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.04.2022"
@@ -30094,15 +30094,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 258,
         "BelegteBetten": null,
-        "Inzidenz": 646.574948812817,
+        "Inzidenz": null,
         "Datum_neu": 1651276800000,
         "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 578.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 726,
-        "Krh_I_belegt": 99,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30112,7 +30112,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.35,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.04.2022"
@@ -30132,15 +30132,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 176,
         "BelegteBetten": null,
-        "Inzidenz": 635.798699665936,
+        "Inzidenz": null,
         "Datum_neu": 1651363200000,
-        "F\u00e4lle_Meldedatum": 99,
+        "F\u00e4lle_Meldedatum": 100,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 542,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 726,
-        "Krh_I_belegt": 99,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30150,7 +30150,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.13,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.04.2022"
@@ -30172,7 +30172,7 @@
         "BelegteBetten": null,
         "Inzidenz": 582.276662236431,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 688,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 499.3,
@@ -30210,7 +30210,7 @@
         "BelegteBetten": null,
         "Inzidenz": 512.6,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 562,
+        "F\u00e4lle_Meldedatum": 564,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 405.9,
@@ -30248,7 +30248,7 @@
         "BelegteBetten": null,
         "Inzidenz": 525.70135421531,
         "Datum_neu": 1651622400000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 450.7,
@@ -30264,7 +30264,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 3.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.05.2022"
@@ -30275,26 +30275,26 @@
         "Datum": "05.05.2022",
         "Fallzahl": 206582,
         "ObjectId": 790,
-        "Sterbefall": 1696,
-        "Genesungsfall": 198719,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5468,
-        "Zuwachs_Fallzahl": 368,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 804,
         "BelegteBetten": null,
         "Inzidenz": 478.645066273932,
         "Datum_neu": 1651708800000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 435.1,
-        "Fallzahl_aktiv": 6167,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 644,
         "Krh_I_belegt": 101,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -436,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30302,7 +30302,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.2,
+        "H_Inzidenz": 3.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.05.2022"
@@ -30315,7 +30315,7 @@
         "ObjectId": 791,
         "Sterbefall": 1696,
         "Genesungsfall": 199299,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5472,
         "Zuwachs_Fallzahl": 305,
         "Zuwachs_Sterbefall": 0,
@@ -30324,13 +30324,13 @@
         "BelegteBetten": null,
         "Inzidenz": 453.859693236108,
         "Datum_neu": 1651795200000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "29.04.2022 - 05.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 255,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 404.5,
         "Fallzahl_aktiv": 5892,
-        "Krh_N_belegt": 644,
-        "Krh_I_belegt": 101,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 95,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -275,
         "Krh_I": null,
@@ -30340,11 +30340,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.54,
-        "H_Zeitraum": "29.04.2022 - 05.05.2022",
-        "H_Datum": "05.05.2022",
+        "H_Inzidenz": 3.08,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.05.2022",
+        "Fallzahl": null,
+        "ObjectId": 792,
+        "Sterbefall": null,
+        "Genesungsfall": 199439,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 140,
+        "BelegteBetten": null,
+        "Inzidenz": 436.078882143755,
+        "Datum_neu": 1651881600000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 387.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 95,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.49,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "06.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.05.2022",
+        "Fallzahl": null,
+        "ObjectId": 793,
+        "Sterbefall": null,
+        "Genesungsfall": 199688,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 249,
+        "BelegteBetten": null,
+        "Inzidenz": 418.477675203851,
+        "Datum_neu": 1651968000000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 358.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 95,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.27,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "07.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.05.2022",
+        "Fallzahl": 207267,
+        "ObjectId": 794,
+        "Sterbefall": 1697,
+        "Genesungsfall": 200780,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5481,
+        "Zuwachs_Fallzahl": 380,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 1092,
+        "BelegteBetten": null,
+        "Inzidenz": 404.288947160458,
+        "Datum_neu": 1652054400000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "02.05.2022 - 08.05.2022",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 341,
+        "Fallzahl_aktiv": 4790,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 95,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -713,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.02,
+        "H_Zeitraum": "02.05.2022 - 08.05.2022",
+        "H_Datum": "06.05.2022",
+        "Datum_Bett": "08.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
