### PR TITLE
New data set: 2022-05-09T111903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-09T105004Z.json
+pjson/2022-05-09T111903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-09T105004Z.json pjson/2022-05-09T111903Z.json```:
```
--- pjson/2022-05-09T105004Z.json	2022-05-09 10:50:04.368586631 +0000
+++ pjson/2022-05-09T111903Z.json	2022-05-09 11:19:04.017620435 +0000
@@ -30349,7 +30349,7 @@
     {
       "attributes": {
         "Datum": "07.05.2022",
-        "Fallzahl": null,
+        "Fallzahl": 206948,
         "ObjectId": 792,
         "Sterbefall": null,
         "Genesungsfall": 199439,
@@ -30387,7 +30387,7 @@
     {
       "attributes": {
         "Datum": "08.05.2022",
-        "Fallzahl": null,
+        "Fallzahl": 206969,
         "ObjectId": 793,
         "Sterbefall": null,
         "Genesungsfall": 199688,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
