### PR TITLE
New data set: 2022-05-10T104904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-09T105004Z.json
+pjson/2022-05-10T104904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-09T111903Z.json pjson/2022-05-10T104904Z.json```:
```
--- pjson/2022-05-09T111903Z.json	2022-05-09 11:19:04.017620435 +0000
+++ pjson/2022-05-10T104904Z.json	2022-05-10 10:49:04.529523134 +0000
@@ -29678,7 +29678,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1405,
+        "F\u00e4lle_Meldedatum": 1406,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -29716,7 +29716,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 835,
+        "F\u00e4lle_Meldedatum": 836,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29792,7 +29792,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 501,
+        "F\u00e4lle_Meldedatum": 502,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -29906,7 +29906,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1107,
+        "F\u00e4lle_Meldedatum": 1108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -30170,15 +30170,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 380,
         "BelegteBetten": null,
-        "Inzidenz": 582.276662236431,
+        "Inzidenz": null,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 688,
+        "F\u00e4lle_Meldedatum": 703,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 499.3,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 662,
-        "Krh_I_belegt": 104,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30188,7 +30188,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.05.2022"
@@ -30210,7 +30210,7 @@
         "BelegteBetten": null,
         "Inzidenz": 512.6,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 564,
+        "F\u00e4lle_Meldedatum": 581,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 405.9,
@@ -30226,7 +30226,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.24,
+        "H_Inzidenz": 4.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.05.2022"
@@ -30248,7 +30248,7 @@
         "BelegteBetten": null,
         "Inzidenz": 525.70135421531,
         "Datum_neu": 1651622400000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 450.7,
@@ -30264,7 +30264,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.82,
+        "H_Inzidenz": 3.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.05.2022"
@@ -30286,7 +30286,7 @@
         "BelegteBetten": null,
         "Inzidenz": 478.645066273932,
         "Datum_neu": 1651708800000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 361,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 435.1,
@@ -30302,7 +30302,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.38,
+        "H_Inzidenz": 3.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.05.2022"
@@ -30313,26 +30313,26 @@
         "Datum": "06.05.2022",
         "Fallzahl": 206887,
         "ObjectId": 791,
-        "Sterbefall": 1696,
-        "Genesungsfall": 199299,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5472,
-        "Zuwachs_Fallzahl": 305,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 580,
         "BelegteBetten": null,
         "Inzidenz": 453.859693236108,
         "Datum_neu": 1651795200000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 404.5,
-        "Fallzahl_aktiv": 5892,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 634,
         "Krh_I_belegt": 95,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -275,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30340,7 +30340,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.08,
+        "H_Inzidenz": 3.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.05.2022"
@@ -30352,7 +30352,7 @@
         "Fallzahl": 206948,
         "ObjectId": 792,
         "Sterbefall": null,
-        "Genesungsfall": 199439,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30362,7 +30362,7 @@
         "BelegteBetten": null,
         "Inzidenz": 436.078882143755,
         "Datum_neu": 1651881600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 387.4,
@@ -30378,7 +30378,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
+        "H_Inzidenz": 2.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.05.2022"
@@ -30390,7 +30390,7 @@
         "Fallzahl": 206969,
         "ObjectId": 793,
         "Sterbefall": null,
-        "Genesungsfall": 199688,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30400,7 +30400,7 @@
         "BelegteBetten": null,
         "Inzidenz": 418.477675203851,
         "Datum_neu": 1651968000000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 358.8,
@@ -30412,11 +30412,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.27,
+        "H_Inzidenz": 2.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.05.2022"
@@ -30427,26 +30427,26 @@
         "Datum": "09.05.2022",
         "Fallzahl": 207267,
         "ObjectId": 794,
-        "Sterbefall": 1697,
-        "Genesungsfall": 200780,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 5481,
-        "Zuwachs_Fallzahl": 380,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1092,
         "BelegteBetten": null,
         "Inzidenz": 404.288947160458,
         "Datum_neu": 1652054400000,
-        "F\u00e4lle_Meldedatum": 21,
-        "Zeitraum": "02.05.2022 - 08.05.2022",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 449,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 341,
-        "Fallzahl_aktiv": 4790,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 95,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 558,
+        "Krh_I_belegt": 87,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -713,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30454,11 +30454,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.02,
-        "H_Zeitraum": "02.05.2022 - 08.05.2022",
-        "H_Datum": "06.05.2022",
+        "H_Inzidenz": 2.51,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.05.2022",
+        "Fallzahl": 207944,
+        "ObjectId": 795,
+        "Sterbefall": 1698,
+        "Genesungsfall": 201384,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5489,
+        "Zuwachs_Fallzahl": 677,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 604,
+        "BelegteBetten": null,
+        "Inzidenz": 388.124573440138,
+        "Datum_neu": 1652140800000,
+        "F\u00e4lle_Meldedatum": 81,
+        "Zeitraum": "03.05.2022 - 09.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 315.7,
+        "Fallzahl_aktiv": 4862,
+        "Krh_N_belegt": 558,
+        "Krh_I_belegt": 87,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 72,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.92,
+        "H_Zeitraum": "03.05.2022 - 09.05.2022",
+        "H_Datum": "09.05.2022",
+        "Datum_Bett": "09.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
