### PR TITLE
New data set: 2022-05-11T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-10T104904Z.json
+pjson/2022-05-11T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-10T104904Z.json pjson/2022-05-11T100303Z.json```:
```
--- pjson/2022-05-10T104904Z.json	2022-05-10 10:49:04.529523134 +0000
+++ pjson/2022-05-11T100303Z.json	2022-05-11 10:03:03.449774679 +0000
@@ -30172,7 +30172,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 703,
+        "F\u00e4lle_Meldedatum": 704,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -30208,15 +30208,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1378,
         "BelegteBetten": null,
-        "Inzidenz": 512.6,
+        "Inzidenz": null,
         "Datum_neu": 1651536000000,
         "F\u00e4lle_Meldedatum": 581,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 405.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 687,
-        "Krh_I_belegt": 104,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30226,7 +30226,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.05.2022"
@@ -30264,7 +30264,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.99,
+        "H_Inzidenz": 4.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.05.2022"
@@ -30302,7 +30302,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.55,
+        "H_Inzidenz": 3.62,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.05.2022"
@@ -30324,7 +30324,7 @@
         "BelegteBetten": null,
         "Inzidenz": 453.859693236108,
         "Datum_neu": 1651795200000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 270,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 404.5,
@@ -30340,7 +30340,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.23,
+        "H_Inzidenz": 3.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.05.2022"
@@ -30362,7 +30362,7 @@
         "BelegteBetten": null,
         "Inzidenz": 436.078882143755,
         "Datum_neu": 1651881600000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 387.4,
@@ -30378,7 +30378,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.88,
+        "H_Inzidenz": 2.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.05.2022"
@@ -30400,7 +30400,7 @@
         "BelegteBetten": null,
         "Inzidenz": 418.477675203851,
         "Datum_neu": 1651968000000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 358.8,
@@ -30416,7 +30416,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.76,
+        "H_Inzidenz": 2.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.05.2022"
@@ -30438,7 +30438,7 @@
         "BelegteBetten": null,
         "Inzidenz": 404.288947160458,
         "Datum_neu": 1652054400000,
-        "F\u00e4lle_Meldedatum": 449,
+        "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 341,
@@ -30450,11 +30450,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.51,
+        "H_Inzidenz": 2.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.05.2022"
@@ -30467,7 +30467,7 @@
         "ObjectId": 795,
         "Sterbefall": 1698,
         "Genesungsfall": 201384,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5489,
         "Zuwachs_Fallzahl": 677,
         "Zuwachs_Sterbefall": 1,
@@ -30476,13 +30476,13 @@
         "BelegteBetten": null,
         "Inzidenz": 388.124573440138,
         "Datum_neu": 1652140800000,
-        "F\u00e4lle_Meldedatum": 81,
-        "Zeitraum": "03.05.2022 - 09.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 291,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 315.7,
         "Fallzahl_aktiv": 4862,
-        "Krh_N_belegt": 558,
-        "Krh_I_belegt": 87,
+        "Krh_N_belegt": 546,
+        "Krh_I_belegt": 86,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 72,
         "Krh_I": null,
@@ -30492,11 +30492,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.92,
-        "H_Zeitraum": "03.05.2022 - 09.05.2022",
-        "H_Datum": "09.05.2022",
+        "H_Inzidenz": 2.34,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.05.2022",
+        "Fallzahl": 208240,
+        "ObjectId": 796,
+        "Sterbefall": 1699,
+        "Genesungsfall": 201971,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5494,
+        "Zuwachs_Fallzahl": 296,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 587,
+        "BelegteBetten": null,
+        "Inzidenz": 348.072847444233,
+        "Datum_neu": 1652227200000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "04.05.2022 - 10.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 307.6,
+        "Fallzahl_aktiv": 4570,
+        "Krh_N_belegt": 546,
+        "Krh_I_belegt": 86,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -292,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.87,
+        "H_Zeitraum": "04.05.2022 - 10.05.2022",
+        "H_Datum": "10.05.2022",
+        "Datum_Bett": "10.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
