### PR TITLE
New data set: 2022-05-12T103203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-11T100303Z.json
+pjson/2022-05-12T103203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-11T100303Z.json pjson/2022-05-12T103203Z.json```:
```
--- pjson/2022-05-11T100303Z.json	2022-05-11 10:03:03.449774679 +0000
+++ pjson/2022-05-12T103203Z.json	2022-05-12 10:32:03.431664113 +0000
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 951,
+        "F\u00e4lle_Meldedatum": 952,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2040,
+        "F\u00e4lle_Meldedatum": 2041,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2084,
+        "F\u00e4lle_Meldedatum": 2083,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -28158,7 +28158,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646870400000,
-        "F\u00e4lle_Meldedatum": 1807,
+        "F\u00e4lle_Meldedatum": 1808,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -28994,7 +28994,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648771200000,
-        "F\u00e4lle_Meldedatum": 1009,
+        "F\u00e4lle_Meldedatum": 1010,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -30020,7 +30020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651104000000,
-        "F\u00e4lle_Meldedatum": 497,
+        "F\u00e4lle_Meldedatum": 498,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -30070,7 +30070,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30172,7 +30172,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 704,
+        "F\u00e4lle_Meldedatum": 707,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -30210,7 +30210,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 581,
+        "F\u00e4lle_Meldedatum": 582,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -30222,7 +30222,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30246,25 +30246,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 835,
         "BelegteBetten": null,
-        "Inzidenz": 525.70135421531,
+        "Inzidenz": null,
         "Datum_neu": 1651622400000,
-        "F\u00e4lle_Meldedatum": 331,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 450.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 691,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.09,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.05.2022"
@@ -30302,7 +30302,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.62,
+        "H_Inzidenz": 3.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.05.2022"
@@ -30340,7 +30340,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.3,
+        "H_Inzidenz": 3.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.05.2022"
@@ -30362,7 +30362,7 @@
         "BelegteBetten": null,
         "Inzidenz": 436.078882143755,
         "Datum_neu": 1651881600000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 387.4,
@@ -30378,7 +30378,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.96,
+        "H_Inzidenz": 3.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.05.2022"
@@ -30416,7 +30416,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
+        "H_Inzidenz": 2.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.05.2022"
@@ -30438,7 +30438,7 @@
         "BelegteBetten": null,
         "Inzidenz": 404.288947160458,
         "Datum_neu": 1652054400000,
-        "F\u00e4lle_Meldedatum": 497,
+        "F\u00e4lle_Meldedatum": 506,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 341,
@@ -30454,7 +30454,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.66,
+        "H_Inzidenz": 2.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.05.2022"
@@ -30465,34 +30465,34 @@
         "Datum": "10.05.2022",
         "Fallzahl": 207944,
         "ObjectId": 795,
-        "Sterbefall": 1698,
-        "Genesungsfall": 201384,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5489,
-        "Zuwachs_Fallzahl": 677,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 604,
         "BelegteBetten": null,
         "Inzidenz": 388.124573440138,
         "Datum_neu": 1652140800000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 315.7,
-        "Fallzahl_aktiv": 4862,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 546,
         "Krh_I_belegt": 86,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 72,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.34,
+        "H_Inzidenz": 2.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.05.2022"
@@ -30505,7 +30505,7 @@
         "ObjectId": 796,
         "Sterbefall": 1699,
         "Genesungsfall": 201971,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5494,
         "Zuwachs_Fallzahl": 296,
         "Zuwachs_Sterbefall": 1,
@@ -30514,13 +30514,13 @@
         "BelegteBetten": null,
         "Inzidenz": 348.072847444233,
         "Datum_neu": 1652227200000,
-        "F\u00e4lle_Meldedatum": 18,
-        "Zeitraum": "04.05.2022 - 10.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 245,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 307.6,
         "Fallzahl_aktiv": 4570,
-        "Krh_N_belegt": 546,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": 504,
+        "Krh_I_belegt": 75,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -292,
         "Krh_I": null,
@@ -30530,11 +30530,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.87,
-        "H_Zeitraum": "04.05.2022 - 10.05.2022",
-        "H_Datum": "10.05.2022",
+        "H_Inzidenz": 2.22,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.05.2022",
+        "Fallzahl": 208564,
+        "ObjectId": 797,
+        "Sterbefall": 1702,
+        "Genesungsfall": 202479,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5499,
+        "Zuwachs_Fallzahl": 324,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 508,
+        "BelegteBetten": null,
+        "Inzidenz": 340.709077193865,
+        "Datum_neu": 1652313600000,
+        "F\u00e4lle_Meldedatum": 43,
+        "Zeitraum": "05.05.2022 - 11.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 297.7,
+        "Fallzahl_aktiv": 4383,
+        "Krh_N_belegt": 504,
+        "Krh_I_belegt": 75,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -187,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2,
+        "H_Zeitraum": "05.05.2022 - 11.05.2022",
+        "H_Datum": "11.05.2022",
+        "Datum_Bett": "11.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
