### PR TITLE
New data set: 2022-05-13T104003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-12T103203Z.json
+pjson/2022-05-13T104003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-12T103203Z.json pjson/2022-05-13T104003Z.json```:
```
--- pjson/2022-05-12T103203Z.json	2022-05-12 10:32:03.431664113 +0000
+++ pjson/2022-05-13T104003Z.json	2022-05-13 10:40:03.639601556 +0000
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 952,
+        "F\u00e4lle_Meldedatum": 953,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1440,
+        "F\u00e4lle_Meldedatum": 1441,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1062,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -30286,7 +30286,7 @@
         "BelegteBetten": null,
         "Inzidenz": 478.645066273932,
         "Datum_neu": 1651708800000,
-        "F\u00e4lle_Meldedatum": 361,
+        "F\u00e4lle_Meldedatum": 362,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 435.1,
@@ -30302,7 +30302,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.72,
+        "H_Inzidenz": 3.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.05.2022"
@@ -30340,7 +30340,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.4,
+        "H_Inzidenz": 3.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.05.2022"
@@ -30378,7 +30378,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.01,
+        "H_Inzidenz": 3.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.05.2022"
@@ -30416,7 +30416,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
+        "H_Inzidenz": 3.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.05.2022"
@@ -30438,7 +30438,7 @@
         "BelegteBetten": null,
         "Inzidenz": 404.288947160458,
         "Datum_neu": 1652054400000,
-        "F\u00e4lle_Meldedatum": 506,
+        "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 341,
@@ -30454,7 +30454,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
+        "H_Inzidenz": 2.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.05.2022"
@@ -30476,9 +30476,9 @@
         "BelegteBetten": null,
         "Inzidenz": 388.124573440138,
         "Datum_neu": 1652140800000,
-        "F\u00e4lle_Meldedatum": 326,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 315.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 546,
@@ -30492,7 +30492,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.54,
+        "H_Inzidenz": 2.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.05.2022"
@@ -30503,26 +30503,26 @@
         "Datum": "11.05.2022",
         "Fallzahl": 208240,
         "ObjectId": 796,
-        "Sterbefall": 1699,
-        "Genesungsfall": 201971,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5494,
-        "Zuwachs_Fallzahl": 296,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 587,
         "BelegteBetten": null,
         "Inzidenz": 348.072847444233,
         "Datum_neu": 1652227200000,
-        "F\u00e4lle_Meldedatum": 245,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 307.6,
-        "Fallzahl_aktiv": 4570,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 504,
         "Krh_I_belegt": 75,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -292,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30530,7 +30530,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.22,
+        "H_Inzidenz": 2.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.05.2022"
@@ -30543,7 +30543,7 @@
         "ObjectId": 797,
         "Sterbefall": 1702,
         "Genesungsfall": 202479,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5499,
         "Zuwachs_Fallzahl": 324,
         "Zuwachs_Sterbefall": 3,
@@ -30552,13 +30552,13 @@
         "BelegteBetten": null,
         "Inzidenz": 340.709077193865,
         "Datum_neu": 1652313600000,
-        "F\u00e4lle_Meldedatum": 43,
-        "Zeitraum": "05.05.2022 - 11.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 220,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 297.7,
         "Fallzahl_aktiv": 4383,
-        "Krh_N_belegt": 504,
-        "Krh_I_belegt": 75,
+        "Krh_N_belegt": 472,
+        "Krh_I_belegt": 73,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -187,
         "Krh_I": null,
@@ -30568,11 +30568,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2,
-        "H_Zeitraum": "05.05.2022 - 11.05.2022",
-        "H_Datum": "11.05.2022",
+        "H_Inzidenz": 2.46,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.05.2022",
+        "Fallzahl": 208838,
+        "ObjectId": 798,
+        "Sterbefall": 1702,
+        "Genesungsfall": 202869,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5502,
+        "Zuwachs_Fallzahl": 274,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 390,
+        "BelegteBetten": null,
+        "Inzidenz": 322.20984949172,
+        "Datum_neu": 1652400000000,
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": "06.05.2022 - 12.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 291.1,
+        "Fallzahl_aktiv": 4267,
+        "Krh_N_belegt": 472,
+        "Krh_I_belegt": 73,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -116,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2,
+        "H_Zeitraum": "06.05.2022 - 12.05.2022",
+        "H_Datum": "12.05.2022",
+        "Datum_Bett": "12.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
