### PR TITLE
New data set: 2022-05-16T102803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-13T104003Z.json
+pjson/2022-05-16T102803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-13T104003Z.json pjson/2022-05-16T102803Z.json```:
```
--- pjson/2022-05-13T104003Z.json	2022-05-13 10:40:03.639601556 +0000
+++ pjson/2022-05-16T102803Z.json	2022-05-16 10:28:03.890933804 +0000
@@ -15012,7 +15012,7 @@
         "Datum_neu": 1616976000000,
         "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15050,7 +15050,7 @@
         "Datum_neu": 1617062400000,
         "F\u00e4lle_Meldedatum": 221,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15088,7 +15088,7 @@
         "Datum_neu": 1617148800000,
         "F\u00e4lle_Meldedatum": 104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15126,7 +15126,7 @@
         "Datum_neu": 1617235200000,
         "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15164,7 +15164,7 @@
         "Datum_neu": 1617321600000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15202,7 +15202,7 @@
         "Datum_neu": 1617408000000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15278,7 +15278,7 @@
         "Datum_neu": 1617580800000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15316,7 +15316,7 @@
         "Datum_neu": 1617667200000,
         "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15354,7 +15354,7 @@
         "Datum_neu": 1617753600000,
         "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15430,7 +15430,7 @@
         "Datum_neu": 1617926400000,
         "F\u00e4lle_Meldedatum": 182,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15468,7 +15468,7 @@
         "Datum_neu": 1618012800000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15544,7 +15544,7 @@
         "Datum_neu": 1618185600000,
         "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15620,7 +15620,7 @@
         "Datum_neu": 1618358400000,
         "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15848,7 +15848,7 @@
         "Datum_neu": 1618876800000,
         "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15886,7 +15886,7 @@
         "Datum_neu": 1618963200000,
         "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15924,7 +15924,7 @@
         "Datum_neu": 1619049600000,
         "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -15962,7 +15962,7 @@
         "Datum_neu": 1619136000000,
         "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16076,7 +16076,7 @@
         "Datum_neu": 1619395200000,
         "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16114,7 +16114,7 @@
         "Datum_neu": 1619481600000,
         "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16228,7 +16228,7 @@
         "Datum_neu": 1619740800000,
         "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16418,7 +16418,7 @@
         "Datum_neu": 1620172800000,
         "F\u00e4lle_Meldedatum": 114,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16494,7 +16494,7 @@
         "Datum_neu": 1620345600000,
         "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16646,7 +16646,7 @@
         "Datum_neu": 1620691200000,
         "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16722,7 +16722,7 @@
         "Datum_neu": 1620864000000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16874,7 +16874,7 @@
         "Datum_neu": 1621209600000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16912,7 +16912,7 @@
         "Datum_neu": 1621296000000,
         "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16950,7 +16950,7 @@
         "Datum_neu": 1621382400000,
         "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -16988,7 +16988,7 @@
         "Datum_neu": 1621468800000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -17178,7 +17178,7 @@
         "Datum_neu": 1621900800000,
         "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -17672,7 +17672,7 @@
         "Datum_neu": 1623024000000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -17748,7 +17748,7 @@
         "Datum_neu": 1623196800000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -17824,7 +17824,7 @@
         "Datum_neu": 1623369600000,
         "F\u00e4lle_Meldedatum": 4,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18204,7 +18204,7 @@
         "Datum_neu": 1624233600000,
         "F\u00e4lle_Meldedatum": 5,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -18774,7 +18774,7 @@
         "Datum_neu": 1625529600000,
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -19154,7 +19154,7 @@
         "Datum_neu": 1626393600000,
         "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20332,7 +20332,7 @@
         "Datum_neu": 1629072000000,
         "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20370,7 +20370,7 @@
         "Datum_neu": 1629158400000,
         "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20446,7 +20446,7 @@
         "Datum_neu": 1629331200000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20484,7 +20484,7 @@
         "Datum_neu": 1629417600000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20674,7 +20674,7 @@
         "Datum_neu": 1629849600000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -20978,7 +20978,7 @@
         "Datum_neu": 1630540800000,
         "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21016,7 +21016,7 @@
         "Datum_neu": 1630627200000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21396,7 +21396,7 @@
         "Datum_neu": 1631491200000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21434,7 +21434,7 @@
         "Datum_neu": 1631577600000,
         "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21510,7 +21510,7 @@
         "Datum_neu": 1631750400000,
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21662,7 +21662,7 @@
         "Datum_neu": 1632096000000,
         "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21700,7 +21700,7 @@
         "Datum_neu": 1632182400000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21738,7 +21738,7 @@
         "Datum_neu": 1632268800000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -21814,7 +21814,7 @@
         "Datum_neu": 1632441600000,
         "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22042,7 +22042,7 @@
         "Datum_neu": 1632960000000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22080,7 +22080,7 @@
         "Datum_neu": 1633046400000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22308,7 +22308,7 @@
         "Datum_neu": 1633564800000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22346,7 +22346,7 @@
         "Datum_neu": 1633651200000,
         "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22460,7 +22460,7 @@
         "Datum_neu": 1633910400000,
         "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22574,7 +22574,7 @@
         "Datum_neu": 1634169600000,
         "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22650,7 +22650,7 @@
         "Datum_neu": 1634342400000,
         "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22726,7 +22726,7 @@
         "Datum_neu": 1634515200000,
         "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22840,7 +22840,7 @@
         "Datum_neu": 1634774400000,
         "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -22878,7 +22878,7 @@
         "Datum_neu": 1634860800000,
         "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23030,7 +23030,7 @@
         "Datum_neu": 1635206400000,
         "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23068,7 +23068,7 @@
         "Datum_neu": 1635292800000,
         "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23106,7 +23106,7 @@
         "Datum_neu": 1635379200000,
         "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23258,7 +23258,7 @@
         "Datum_neu": 1635724800000,
         "F\u00e4lle_Meldedatum": 497,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23296,7 +23296,7 @@
         "Datum_neu": 1635811200000,
         "F\u00e4lle_Meldedatum": 692,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23372,7 +23372,7 @@
         "Datum_neu": 1635984000000,
         "F\u00e4lle_Meldedatum": 685,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23410,7 +23410,7 @@
         "Datum_neu": 1636070400000,
         "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23448,7 +23448,7 @@
         "Datum_neu": 1636156800000,
         "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23486,7 +23486,7 @@
         "Datum_neu": 1636243200000,
         "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23600,7 +23600,7 @@
         "Datum_neu": 1636502400000,
         "F\u00e4lle_Meldedatum": 972,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23676,7 +23676,7 @@
         "Datum_neu": 1636675200000,
         "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23714,7 +23714,7 @@
         "Datum_neu": 1636761600000,
         "F\u00e4lle_Meldedatum": 492,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23752,7 +23752,7 @@
         "Datum_neu": 1636848000000,
         "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23790,7 +23790,7 @@
         "Datum_neu": 1636934400000,
         "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23904,7 +23904,7 @@
         "Datum_neu": 1637193600000,
         "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -23942,7 +23942,7 @@
         "Datum_neu": 1637280000000,
         "F\u00e4lle_Meldedatum": 1481,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24018,7 +24018,7 @@
         "Datum_neu": 1637452800000,
         "F\u00e4lle_Meldedatum": 400,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24056,7 +24056,7 @@
         "Datum_neu": 1637539200000,
         "F\u00e4lle_Meldedatum": 1381,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24094,7 +24094,7 @@
         "Datum_neu": 1637625600000,
         "F\u00e4lle_Meldedatum": 1661,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 38,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24132,7 +24132,7 @@
         "Datum_neu": 1637712000000,
         "F\u00e4lle_Meldedatum": 1085,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24170,7 +24170,7 @@
         "Datum_neu": 1637798400000,
         "F\u00e4lle_Meldedatum": 1475,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24208,7 +24208,7 @@
         "Datum_neu": 1637884800000,
         "F\u00e4lle_Meldedatum": 1195,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24246,7 +24246,7 @@
         "Datum_neu": 1637971200000,
         "F\u00e4lle_Meldedatum": 770,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24284,7 +24284,7 @@
         "Datum_neu": 1638057600000,
         "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24360,7 +24360,7 @@
         "Datum_neu": 1638230400000,
         "F\u00e4lle_Meldedatum": 1327,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24398,7 +24398,7 @@
         "Datum_neu": 1638316800000,
         "F\u00e4lle_Meldedatum": 1117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24474,7 +24474,7 @@
         "Datum_neu": 1638489600000,
         "F\u00e4lle_Meldedatum": 1004,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24512,7 +24512,7 @@
         "Datum_neu": 1638576000000,
         "F\u00e4lle_Meldedatum": 535,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24550,7 +24550,7 @@
         "Datum_neu": 1638662400000,
         "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24588,7 +24588,7 @@
         "Datum_neu": 1638748800000,
         "F\u00e4lle_Meldedatum": 981,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 44,
+        "Hosp_Meldedatum": 42,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24626,7 +24626,7 @@
         "Datum_neu": 1638835200000,
         "F\u00e4lle_Meldedatum": 1254,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24664,7 +24664,7 @@
         "Datum_neu": 1638921600000,
         "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 46,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24702,7 +24702,7 @@
         "Datum_neu": 1639008000000,
         "F\u00e4lle_Meldedatum": 889,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24740,7 +24740,7 @@
         "Datum_neu": 1639094400000,
         "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24778,7 +24778,7 @@
         "Datum_neu": 1639180800000,
         "F\u00e4lle_Meldedatum": 480,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24816,7 +24816,7 @@
         "Datum_neu": 1639267200000,
         "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24854,7 +24854,7 @@
         "Datum_neu": 1639353600000,
         "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24892,7 +24892,7 @@
         "Datum_neu": 1639440000000,
         "F\u00e4lle_Meldedatum": 1054,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24930,7 +24930,7 @@
         "Datum_neu": 1639526400000,
         "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -24968,7 +24968,7 @@
         "Datum_neu": 1639612800000,
         "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25006,7 +25006,7 @@
         "Datum_neu": 1639699200000,
         "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25120,7 +25120,7 @@
         "Datum_neu": 1639958400000,
         "F\u00e4lle_Meldedatum": 552,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 42,
+        "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25158,7 +25158,7 @@
         "Datum_neu": 1640044800000,
         "F\u00e4lle_Meldedatum": 937,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25196,7 +25196,7 @@
         "Datum_neu": 1640131200000,
         "F\u00e4lle_Meldedatum": 423,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25234,7 +25234,7 @@
         "Datum_neu": 1640217600000,
         "F\u00e4lle_Meldedatum": 403,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25272,7 +25272,7 @@
         "Datum_neu": 1640304000000,
         "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25348,7 +25348,7 @@
         "Datum_neu": 1640476800000,
         "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25386,7 +25386,7 @@
         "Datum_neu": 1640563200000,
         "F\u00e4lle_Meldedatum": 544,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25424,7 +25424,7 @@
         "Datum_neu": 1640649600000,
         "F\u00e4lle_Meldedatum": 486,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25462,7 +25462,7 @@
         "Datum_neu": 1640736000000,
         "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25500,7 +25500,7 @@
         "Datum_neu": 1640822400000,
         "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25538,7 +25538,7 @@
         "Datum_neu": 1640908800000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25576,7 +25576,7 @@
         "Datum_neu": 1640995200000,
         "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25614,7 +25614,7 @@
         "Datum_neu": 1641081600000,
         "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25690,7 +25690,7 @@
         "Datum_neu": 1641254400000,
         "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25728,7 +25728,7 @@
         "Datum_neu": 1641340800000,
         "F\u00e4lle_Meldedatum": 339,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25766,7 +25766,7 @@
         "Datum_neu": 1641427200000,
         "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25918,7 +25918,7 @@
         "Datum_neu": 1641772800000,
         "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -25956,7 +25956,7 @@
         "Datum_neu": 1641859200000,
         "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26032,7 +26032,7 @@
         "Datum_neu": 1642032000000,
         "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26070,7 +26070,7 @@
         "Datum_neu": 1642118400000,
         "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26184,7 +26184,7 @@
         "Datum_neu": 1642377600000,
         "F\u00e4lle_Meldedatum": 702,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26298,7 +26298,7 @@
         "Datum_neu": 1642636800000,
         "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26336,7 +26336,7 @@
         "Datum_neu": 1642723200000,
         "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26372,9 +26372,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642809600000,
-        "F\u00e4lle_Meldedatum": 302,
+        "F\u00e4lle_Meldedatum": 303,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26564,7 +26564,7 @@
         "Datum_neu": 1643241600000,
         "F\u00e4lle_Meldedatum": 943,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26602,7 +26602,7 @@
         "Datum_neu": 1643328000000,
         "F\u00e4lle_Meldedatum": 1006,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26716,7 +26716,7 @@
         "Datum_neu": 1643587200000,
         "F\u00e4lle_Meldedatum": 1500,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26754,7 +26754,7 @@
         "Datum_neu": 1643673600000,
         "F\u00e4lle_Meldedatum": 1661,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26868,7 +26868,7 @@
         "Datum_neu": 1643932800000,
         "F\u00e4lle_Meldedatum": 1103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -26982,7 +26982,7 @@
         "Datum_neu": 1644192000000,
         "F\u00e4lle_Meldedatum": 1803,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27020,7 +27020,7 @@
         "Datum_neu": 1644278400000,
         "F\u00e4lle_Meldedatum": 1770,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27058,7 +27058,7 @@
         "Datum_neu": 1644364800000,
         "F\u00e4lle_Meldedatum": 1616,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27248,7 +27248,7 @@
         "Datum_neu": 1644796800000,
         "F\u00e4lle_Meldedatum": 1485,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27286,7 +27286,7 @@
         "Datum_neu": 1644883200000,
         "F\u00e4lle_Meldedatum": 1249,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27400,7 +27400,7 @@
         "Datum_neu": 1645142400000,
         "F\u00e4lle_Meldedatum": 903,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27514,7 +27514,7 @@
         "Datum_neu": 1645401600000,
         "F\u00e4lle_Meldedatum": 1484,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27628,7 +27628,7 @@
         "Datum_neu": 1645660800000,
         "F\u00e4lle_Meldedatum": 1199,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27666,7 +27666,7 @@
         "Datum_neu": 1645747200000,
         "F\u00e4lle_Meldedatum": 799,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27780,7 +27780,7 @@
         "Datum_neu": 1646006400000,
         "F\u00e4lle_Meldedatum": 1589,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -27894,7 +27894,7 @@
         "Datum_neu": 1646265600000,
         "F\u00e4lle_Meldedatum": 1206,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28160,7 +28160,7 @@
         "Datum_neu": 1646870400000,
         "F\u00e4lle_Meldedatum": 1808,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28198,7 +28198,7 @@
         "Datum_neu": 1646956800000,
         "F\u00e4lle_Meldedatum": 1927,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28234,7 +28234,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647043200000,
-        "F\u00e4lle_Meldedatum": 1110,
+        "F\u00e4lle_Meldedatum": 1111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28312,7 +28312,7 @@
         "Datum_neu": 1647216000000,
         "F\u00e4lle_Meldedatum": 2866,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28348,9 +28348,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2598,
+        "F\u00e4lle_Meldedatum": 2597,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28388,7 +28388,7 @@
         "Datum_neu": 1647388800000,
         "F\u00e4lle_Meldedatum": 2805,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28464,7 +28464,7 @@
         "Datum_neu": 1647561600000,
         "F\u00e4lle_Meldedatum": 2598,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28540,7 +28540,7 @@
         "Datum_neu": 1647734400000,
         "F\u00e4lle_Meldedatum": 376,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28578,7 +28578,7 @@
         "Datum_neu": 1647820800000,
         "F\u00e4lle_Meldedatum": 3064,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28654,7 +28654,7 @@
         "Datum_neu": 1647993600000,
         "F\u00e4lle_Meldedatum": 2136,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28692,7 +28692,7 @@
         "Datum_neu": 1648080000000,
         "F\u00e4lle_Meldedatum": 2199,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28730,7 +28730,7 @@
         "Datum_neu": 1648166400000,
         "F\u00e4lle_Meldedatum": 1781,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28806,7 +28806,7 @@
         "Datum_neu": 1648339200000,
         "F\u00e4lle_Meldedatum": 426,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28844,7 +28844,7 @@
         "Datum_neu": 1648425600000,
         "F\u00e4lle_Meldedatum": 2364,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28920,7 +28920,7 @@
         "Datum_neu": 1648598400000,
         "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28958,7 +28958,7 @@
         "Datum_neu": 1648684800000,
         "F\u00e4lle_Meldedatum": 1289,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28996,7 +28996,7 @@
         "Datum_neu": 1648771200000,
         "F\u00e4lle_Meldedatum": 1010,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29110,7 +29110,7 @@
         "Datum_neu": 1649030400000,
         "F\u00e4lle_Meldedatum": 1810,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29186,7 +29186,7 @@
         "Datum_neu": 1649203200000,
         "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29262,7 +29262,7 @@
         "Datum_neu": 1649376000000,
         "F\u00e4lle_Meldedatum": 887,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29300,7 +29300,7 @@
         "Datum_neu": 1649462400000,
         "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29338,7 +29338,7 @@
         "Datum_neu": 1649548800000,
         "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29376,7 +29376,7 @@
         "Datum_neu": 1649635200000,
         "F\u00e4lle_Meldedatum": 1315,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30174,7 +30174,7 @@
         "Datum_neu": 1651449600000,
         "F\u00e4lle_Meldedatum": 707,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30212,7 +30212,7 @@
         "Datum_neu": 1651536000000,
         "F\u00e4lle_Meldedatum": 582,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30284,15 +30284,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 804,
         "BelegteBetten": null,
-        "Inzidenz": 478.645066273932,
+        "Inzidenz": null,
         "Datum_neu": 1651708800000,
         "F\u00e4lle_Meldedatum": 362,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 435.1,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 644,
-        "Krh_I_belegt": 101,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30302,7 +30302,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.77,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.05.2022"
@@ -30322,15 +30322,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 580,
         "BelegteBetten": null,
-        "Inzidenz": 453.859693236108,
+        "Inzidenz": null,
         "Datum_neu": 1651795200000,
         "F\u00e4lle_Meldedatum": 270,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 404.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 95,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30340,7 +30340,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.5,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.05.2022"
@@ -30360,15 +30360,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 140,
         "BelegteBetten": null,
-        "Inzidenz": 436.078882143755,
+        "Inzidenz": null,
         "Datum_neu": 1651881600000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 387.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 95,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30378,7 +30378,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.5,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.05.2022"
@@ -30398,15 +30398,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 249,
         "BelegteBetten": null,
-        "Inzidenz": 418.477675203851,
+        "Inzidenz": null,
         "Datum_neu": 1651968000000,
         "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 358.8,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 95,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30416,7 +30416,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.13,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.05.2022"
@@ -30454,7 +30454,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.93,
+        "H_Inzidenz": 3.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.05.2022"
@@ -30476,9 +30476,9 @@
         "BelegteBetten": null,
         "Inzidenz": 388.124573440138,
         "Datum_neu": 1652140800000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 315.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 546,
@@ -30492,7 +30492,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": 2.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.05.2022"
@@ -30514,7 +30514,7 @@
         "BelegteBetten": null,
         "Inzidenz": 348.072847444233,
         "Datum_neu": 1652227200000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 281,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 307.6,
@@ -30530,7 +30530,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
+        "H_Inzidenz": 2.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.05.2022"
@@ -30541,34 +30541,34 @@
         "Datum": "12.05.2022",
         "Fallzahl": 208564,
         "ObjectId": 797,
-        "Sterbefall": 1702,
-        "Genesungsfall": 202479,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5499,
-        "Zuwachs_Fallzahl": 324,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 508,
         "BelegteBetten": null,
         "Inzidenz": 340.709077193865,
         "Datum_neu": 1652313600000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 297.7,
-        "Fallzahl_aktiv": 4383,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 472,
         "Krh_I_belegt": 73,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -187,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.46,
+        "H_Inzidenz": 2.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.05.2022"
@@ -30581,7 +30581,7 @@
         "ObjectId": 798,
         "Sterbefall": 1702,
         "Genesungsfall": 202869,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5502,
         "Zuwachs_Fallzahl": 274,
         "Zuwachs_Sterbefall": 0,
@@ -30590,13 +30590,13 @@
         "BelegteBetten": null,
         "Inzidenz": 322.20984949172,
         "Datum_neu": 1652400000000,
-        "F\u00e4lle_Meldedatum": 55,
-        "Zeitraum": "06.05.2022 - 12.05.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 211,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 291.1,
         "Fallzahl_aktiv": 4267,
-        "Krh_N_belegt": 472,
-        "Krh_I_belegt": 73,
+        "Krh_N_belegt": 445,
+        "Krh_I_belegt": 79,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -116,
         "Krh_I": null,
@@ -30606,11 +30606,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2,
-        "H_Zeitraum": "06.05.2022 - 12.05.2022",
-        "H_Datum": "12.05.2022",
+        "H_Inzidenz": 2.1,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.05.2022",
+        "Fallzahl": 208894,
+        "ObjectId": 799,
+        "Sterbefall": null,
+        "Genesungsfall": 203054,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 185,
+        "BelegteBetten": null,
+        "Inzidenz": 283.594956715399,
+        "Datum_neu": 1652486400000,
+        "F\u00e4lle_Meldedatum": 98,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 279.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 445,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "13.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.05.2022",
+        "Fallzahl": 208951,
+        "ObjectId": 800,
+        "Sterbefall": null,
+        "Genesungsfall": 203154,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 100,
+        "BelegteBetten": null,
+        "Inzidenz": 272.100290958727,
+        "Datum_neu": 1652572800000,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 258.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 455,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.65,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "14.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.05.2022",
+        "Fallzahl": 209172,
+        "ObjectId": 801,
+        "Sterbefall": 1703,
+        "Genesungsfall": 203849,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5523,
+        "Zuwachs_Fallzahl": 334,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 695,
+        "BelegteBetten": null,
+        "Inzidenz": 307.84151729588,
+        "Datum_neu": 1652659200000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "09.05.2022 - 15.05.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 245.8,
+        "Fallzahl_aktiv": 3620,
+        "Krh_N_belegt": 455,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -362,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.58,
+        "H_Zeitraum": "09.05.2022 - 15.05.2022",
+        "H_Datum": "13.05.2022",
+        "Datum_Bett": "15.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
