### PR TITLE
New data set: 2022-05-17T102004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-16T102803Z.json
+pjson/2022-05-17T102004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-16T102803Z.json pjson/2022-05-17T102004Z.json```:
```
--- pjson/2022-05-16T102803Z.json	2022-05-16 10:28:03.890933804 +0000
+++ pjson/2022-05-17T102004Z.json	2022-05-17 10:20:04.212444700 +0000
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1249,
+        "F\u00e4lle_Meldedatum": 1250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2041,
+        "F\u00e4lle_Meldedatum": 2042,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -29906,7 +29906,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1108,
+        "F\u00e4lle_Meldedatum": 1109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -29944,7 +29944,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650931200000,
-        "F\u00e4lle_Meldedatum": 607,
+        "F\u00e4lle_Meldedatum": 608,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -30286,7 +30286,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651708800000,
-        "F\u00e4lle_Meldedatum": 362,
+        "F\u00e4lle_Meldedatum": 361,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -30362,7 +30362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651881600000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -30436,15 +30436,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1092,
         "BelegteBetten": null,
-        "Inzidenz": 404.288947160458,
+        "Inzidenz": null,
         "Datum_neu": 1652054400000,
         "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 341,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 558,
-        "Krh_I_belegt": 87,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30454,7 +30454,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.01,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.05.2022"
@@ -30492,7 +30492,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
+        "H_Inzidenz": 2.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.05.2022"
@@ -30514,7 +30514,7 @@
         "BelegteBetten": null,
         "Inzidenz": 348.072847444233,
         "Datum_neu": 1652227200000,
-        "F\u00e4lle_Meldedatum": 281,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 307.6,
@@ -30530,7 +30530,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.51,
+        "H_Inzidenz": 2.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.05.2022"
@@ -30552,7 +30552,7 @@
         "BelegteBetten": null,
         "Inzidenz": 340.709077193865,
         "Datum_neu": 1652313600000,
-        "F\u00e4lle_Meldedatum": 247,
+        "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 297.7,
@@ -30568,7 +30568,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.54,
+        "H_Inzidenz": 2.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.05.2022"
@@ -30579,26 +30579,26 @@
         "Datum": "13.05.2022",
         "Fallzahl": 208838,
         "ObjectId": 798,
-        "Sterbefall": 1702,
-        "Genesungsfall": 202869,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5502,
-        "Zuwachs_Fallzahl": 274,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 390,
         "BelegteBetten": null,
         "Inzidenz": 322.20984949172,
         "Datum_neu": 1652400000000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 291.1,
-        "Fallzahl_aktiv": 4267,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 445,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -116,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30606,7 +30606,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.1,
+        "H_Inzidenz": 2.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.05.2022"
@@ -30618,7 +30618,7 @@
         "Fallzahl": 208894,
         "ObjectId": 799,
         "Sterbefall": null,
-        "Genesungsfall": 203054,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30628,7 +30628,7 @@
         "BelegteBetten": null,
         "Inzidenz": 283.594956715399,
         "Datum_neu": 1652486400000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 279.7,
@@ -30644,7 +30644,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.87,
+        "H_Inzidenz": 2.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.05.2022"
@@ -30656,7 +30656,7 @@
         "Fallzahl": 208951,
         "ObjectId": 800,
         "Sterbefall": null,
-        "Genesungsfall": 203154,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30666,12 +30666,12 @@
         "BelegteBetten": null,
         "Inzidenz": 272.100290958727,
         "Datum_neu": 1652572800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 258.2,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 455,
+        "Krh_N_belegt": 445,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
@@ -30682,7 +30682,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.65,
+        "H_Inzidenz": 2.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.05.2022"
@@ -30695,7 +30695,7 @@
         "ObjectId": 801,
         "Sterbefall": 1703,
         "Genesungsfall": 203849,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5523,
         "Zuwachs_Fallzahl": 334,
         "Zuwachs_Sterbefall": 1,
@@ -30704,13 +30704,13 @@
         "BelegteBetten": null,
         "Inzidenz": 307.84151729588,
         "Datum_neu": 1652659200000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "09.05.2022 - 15.05.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 287,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 245.8,
         "Fallzahl_aktiv": 3620,
-        "Krh_N_belegt": 455,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": 437,
+        "Krh_I_belegt": 71,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -362,
         "Krh_I": null,
@@ -30720,11 +30720,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.58,
-        "H_Zeitraum": "09.05.2022 - 15.05.2022",
-        "H_Datum": "13.05.2022",
+        "H_Inzidenz": 2.14,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.05.2022",
+        "Fallzahl": 209594,
+        "ObjectId": 802,
+        "Sterbefall": 1703,
+        "Genesungsfall": 204438,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5528,
+        "Zuwachs_Fallzahl": 422,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 589,
+        "BelegteBetten": null,
+        "Inzidenz": 284.672581630087,
+        "Datum_neu": 1652745600000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "10.05.2022 - 16.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 232.3,
+        "Fallzahl_aktiv": 3453,
+        "Krh_N_belegt": 437,
+        "Krh_I_belegt": 71,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -167,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.7,
+        "H_Zeitraum": "10.05.2022 - 16.05.2022",
+        "H_Datum": "16.05.2022",
+        "Datum_Bett": "16.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
