### PR TITLE
New data set: 2022-05-18T101403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-17T102004Z.json
+pjson/2022-05-18T101403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-17T102004Z.json pjson/2022-05-18T101403Z.json```:
```
--- pjson/2022-05-17T102004Z.json	2022-05-17 10:20:04.212444700 +0000
+++ pjson/2022-05-18T101403Z.json	2022-05-18 10:14:04.022141029 +0000
@@ -27816,7 +27816,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
-        "F\u00e4lle_Meldedatum": 1829,
+        "F\u00e4lle_Meldedatum": 1830,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29298,7 +29298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649462400000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -29414,7 +29414,7 @@
         "Datum_neu": 1649721600000,
         "F\u00e4lle_Meldedatum": 1262,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29452,7 +29452,7 @@
         "Datum_neu": 1649808000000,
         "F\u00e4lle_Meldedatum": 745,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29680,7 +29680,7 @@
         "Datum_neu": 1650326400000,
         "F\u00e4lle_Meldedatum": 1406,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29870,7 +29870,7 @@
         "Datum_neu": 1650758400000,
         "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29908,7 +29908,7 @@
         "Datum_neu": 1650844800000,
         "F\u00e4lle_Meldedatum": 1109,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29946,7 +29946,7 @@
         "Datum_neu": 1650931200000,
         "F\u00e4lle_Meldedatum": 608,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29982,7 +29982,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651017600000,
-        "F\u00e4lle_Meldedatum": 572,
+        "F\u00e4lle_Meldedatum": 571,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -30060,7 +30060,7 @@
         "Datum_neu": 1651190400000,
         "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30288,7 +30288,7 @@
         "Datum_neu": 1651708800000,
         "F\u00e4lle_Meldedatum": 361,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30440,7 +30440,7 @@
         "Datum_neu": 1652054400000,
         "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30474,15 +30474,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 604,
         "BelegteBetten": null,
-        "Inzidenz": 388.124573440138,
+        "Inzidenz": null,
         "Datum_neu": 1652140800000,
         "F\u00e4lle_Meldedatum": 330,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 315.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 546,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30492,7 +30492,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.96,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.05.2022"
@@ -30530,7 +30530,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": 2.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.05.2022"
@@ -30554,7 +30554,7 @@
         "Datum_neu": 1652313600000,
         "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 297.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 472,
@@ -30568,7 +30568,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.81,
+        "H_Inzidenz": 2.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.05.2022"
@@ -30590,9 +30590,9 @@
         "BelegteBetten": null,
         "Inzidenz": 322.20984949172,
         "Datum_neu": 1652400000000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 291.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 445,
@@ -30606,7 +30606,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.46,
+        "H_Inzidenz": 2.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.05.2022"
@@ -30644,7 +30644,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.44,
+        "H_Inzidenz": 2.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.05.2022"
@@ -30666,9 +30666,9 @@
         "BelegteBetten": null,
         "Inzidenz": 272.100290958727,
         "Datum_neu": 1652572800000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 258.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 445,
@@ -30682,7 +30682,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.19,
+        "H_Inzidenz": 2.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.05.2022"
@@ -30693,26 +30693,26 @@
         "Datum": "16.05.2022",
         "Fallzahl": 209172,
         "ObjectId": 801,
-        "Sterbefall": 1703,
-        "Genesungsfall": 203849,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5523,
-        "Zuwachs_Fallzahl": 334,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 21,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 695,
         "BelegteBetten": null,
         "Inzidenz": 307.84151729588,
         "Datum_neu": 1652659200000,
-        "F\u00e4lle_Meldedatum": 287,
+        "F\u00e4lle_Meldedatum": 317,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 245.8,
-        "Fallzahl_aktiv": 3620,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 437,
         "Krh_I_belegt": 71,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -362,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30720,7 +30720,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.14,
+        "H_Inzidenz": 2.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.05.2022"
@@ -30733,7 +30733,7 @@
         "ObjectId": 802,
         "Sterbefall": 1703,
         "Genesungsfall": 204438,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5528,
         "Zuwachs_Fallzahl": 422,
         "Zuwachs_Sterbefall": 0,
@@ -30742,13 +30742,13 @@
         "BelegteBetten": null,
         "Inzidenz": 284.672581630087,
         "Datum_neu": 1652745600000,
-        "F\u00e4lle_Meldedatum": 46,
-        "Zeitraum": "10.05.2022 - 16.05.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 263,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 232.3,
         "Fallzahl_aktiv": 3453,
-        "Krh_N_belegt": 437,
-        "Krh_I_belegt": 71,
+        "Krh_N_belegt": 415,
+        "Krh_I_belegt": 67,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -167,
         "Krh_I": null,
@@ -30758,11 +30758,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
-        "H_Zeitraum": "10.05.2022 - 16.05.2022",
-        "H_Datum": "16.05.2022",
+        "H_Inzidenz": 2.32,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.05.2022",
+        "Fallzahl": 209887,
+        "ObjectId": 803,
+        "Sterbefall": 1703,
+        "Genesungsfall": 204772,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5537,
+        "Zuwachs_Fallzahl": 293,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 334,
+        "BelegteBetten": null,
+        "Inzidenz": 279.464061209095,
+        "Datum_neu": 1652832000000,
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": "11.05.2022 - 17.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 233.9,
+        "Fallzahl_aktiv": 3412,
+        "Krh_N_belegt": 415,
+        "Krh_I_belegt": 67,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -41,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.92,
+        "H_Zeitraum": "11.05.2022 - 17.05.2022",
+        "H_Datum": "17.05.2022",
+        "Datum_Bett": "17.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
