### PR TITLE
New data set: 2022-05-23T101603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-19T103304Z.json
+pjson/2022-05-23T101603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-19T103304Z.json pjson/2022-05-23T101603Z.json```:
```
--- pjson/2022-05-19T103304Z.json	2022-05-19 10:33:04.204831467 +0000
+++ pjson/2022-05-23T101603Z.json	2022-05-23 10:16:03.762516271 +0000
@@ -29602,7 +29602,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650153600000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -29680,7 +29680,7 @@
         "Datum_neu": 1650326400000,
         "F\u00e4lle_Meldedatum": 1406,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29956,7 +29956,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30032,7 +30032,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30222,7 +30222,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30476,7 +30476,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652140800000,
-        "F\u00e4lle_Meldedatum": 330,
+        "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -30516,7 +30516,7 @@
         "Datum_neu": 1652227200000,
         "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30550,15 +30550,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 508,
         "BelegteBetten": null,
-        "Inzidenz": 340.709077193865,
+        "Inzidenz": null,
         "Datum_neu": 1652313600000,
         "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 297.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 472,
-        "Krh_I_belegt": 73,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30568,7 +30568,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.06,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.05.2022"
@@ -30588,15 +30588,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 390,
         "BelegteBetten": null,
-        "Inzidenz": 322.20984949172,
+        "Inzidenz": null,
         "Datum_neu": 1652400000000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 291.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 445,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30606,7 +30606,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.05.2022"
@@ -30626,15 +30626,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 185,
         "BelegteBetten": null,
-        "Inzidenz": 283.594956715399,
+        "Inzidenz": null,
         "Datum_neu": 1652486400000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 279.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 445,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30644,7 +30644,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.91,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.05.2022"
@@ -30664,15 +30664,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 100,
         "BelegteBetten": null,
-        "Inzidenz": 272.100290958727,
+        "Inzidenz": null,
         "Datum_neu": 1652572800000,
         "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 258.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 445,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30682,7 +30682,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.05.2022"
@@ -30704,9 +30704,9 @@
         "BelegteBetten": null,
         "Inzidenz": 307.84151729588,
         "Datum_neu": 1652659200000,
-        "F\u00e4lle_Meldedatum": 320,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 245.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 437,
@@ -30720,7 +30720,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.66,
+        "H_Inzidenz": 2.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.05.2022"
@@ -30742,7 +30742,7 @@
         "BelegteBetten": null,
         "Inzidenz": 284.672581630087,
         "Datum_neu": 1652745600000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 232.3,
@@ -30769,26 +30769,26 @@
         "Datum": "18.05.2022",
         "Fallzahl": 209887,
         "ObjectId": 803,
-        "Sterbefall": 1703,
-        "Genesungsfall": 204772,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5537,
-        "Zuwachs_Fallzahl": 293,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 334,
         "BelegteBetten": null,
         "Inzidenz": 279.464061209095,
         "Datum_neu": 1652832000000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 233.9,
-        "Fallzahl_aktiv": 3412,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 395,
         "Krh_I_belegt": 65,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -41,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30796,7 +30796,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.44,
+        "H_Inzidenz": 2.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.05.2022"
@@ -30805,11 +30805,11 @@
     {
       "attributes": {
         "Datum": "19.05.2022",
-        "Fallzahl": 210101,
+        "Fallzahl": 210234,
         "ObjectId": 804,
         "Sterbefall": 1703,
         "Genesungsfall": 205161,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5538,
         "Zuwachs_Fallzahl": 214,
         "Zuwachs_Sterbefall": 0,
@@ -30818,27 +30818,179 @@
         "BelegteBetten": null,
         "Inzidenz": 265.814145623047,
         "Datum_neu": 1652918400000,
-        "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "12.05.2022 - 18.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 200,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 238.4,
-        "Fallzahl_aktiv": 3237,
-        "Krh_N_belegt": 395,
-        "Krh_I_belegt": 65,
+        "Fallzahl_aktiv": 3370,
+        "Krh_N_belegt": 353,
+        "Krh_I_belegt": 66,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -175,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
-        "H_Zeitraum": "12.05.2022 - 18.05.2022",
-        "H_Datum": "18.05.2022",
+        "H_Inzidenz": 2.19,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "18.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.05.2022",
+        "Fallzahl": 210255,
+        "ObjectId": 805,
+        "Sterbefall": null,
+        "Genesungsfall": 205434,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 270,
+        "BelegteBetten": null,
+        "Inzidenz": 228.815690218758,
+        "Datum_neu": 1653004800000,
+        "F\u00e4lle_Meldedatum": 84,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 233.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 356,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.9,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.05.2022",
+        "Fallzahl": 210255,
+        "ObjectId": 806,
+        "Sterbefall": null,
+        "Genesungsfall": 205562,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 119,
+        "BelegteBetten": null,
+        "Inzidenz": 196.127734473221,
+        "Datum_neu": 1653091200000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 219.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 356,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.53,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "20.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.05.2022",
+        "Fallzahl": 210255,
+        "ObjectId": 807,
+        "Sterbefall": null,
+        "Genesungsfall": 205637,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 75,
+        "BelegteBetten": null,
+        "Inzidenz": 182.118610582277,
+        "Datum_neu": 1653177600000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 196.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 356,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.48,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.05.2022",
+        "Fallzahl": 210407,
+        "ObjectId": 808,
+        "Sterbefall": 1707,
+        "Genesungsfall": 206141,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5557,
+        "Zuwachs_Fallzahl": 173,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 504,
+        "BelegteBetten": null,
+        "Inzidenz": 199.719817522181,
+        "Datum_neu": 1653264000000,
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": "16.05.2022 - 22.05.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 180,
+        "Fallzahl_aktiv": 2559,
+        "Krh_N_belegt": 356,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -335,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.41,
+        "H_Zeitraum": "16.05.2022 - 22.05.2022",
+        "H_Datum": "20.05.2022",
+        "Datum_Bett": "22.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
