### PR TITLE
New data set: 2022-05-24T101902Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-23T101603Z.json
+pjson/2022-05-24T101902Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-23T101603Z.json pjson/2022-05-24T101902Z.json```:
```
--- pjson/2022-05-23T101603Z.json	2022-05-23 10:16:03.762516271 +0000
+++ pjson/2022-05-24T101902Z.json	2022-05-24 10:19:03.070041280 +0000
@@ -26638,7 +26638,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643414400000,
-        "F\u00e4lle_Meldedatum": 425,
+        "F\u00e4lle_Meldedatum": 424,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -27018,7 +27018,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644278400000,
-        "F\u00e4lle_Meldedatum": 1770,
+        "F\u00e4lle_Meldedatum": 1769,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27094,7 +27094,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644451200000,
-        "F\u00e4lle_Meldedatum": 1355,
+        "F\u00e4lle_Meldedatum": 1354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1250,
+        "F\u00e4lle_Meldedatum": 1249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -28160,7 +28160,7 @@
         "Datum_neu": 1646870400000,
         "F\u00e4lle_Meldedatum": 1808,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2136,
+        "F\u00e4lle_Meldedatum": 2137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -29488,9 +29488,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 785,
+        "F\u00e4lle_Meldedatum": 784,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29716,7 +29716,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650412800000,
-        "F\u00e4lle_Meldedatum": 836,
+        "F\u00e4lle_Meldedatum": 837,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -30060,7 +30060,7 @@
         "Datum_neu": 1651190400000,
         "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30592,7 +30592,7 @@
         "Datum_neu": 1652400000000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30628,7 +30628,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652486400000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -30666,7 +30666,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652572800000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -30702,15 +30702,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 695,
         "BelegteBetten": null,
-        "Inzidenz": 307.84151729588,
+        "Inzidenz": null,
         "Datum_neu": 1652659200000,
         "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 245.8,
+        "Hosp_Meldedatum": 14,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 437,
-        "Krh_I_belegt": 71,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30720,7 +30720,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.05.2022"
@@ -30744,7 +30744,7 @@
         "Datum_neu": 1652745600000,
         "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 232.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 415,
@@ -30758,7 +30758,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.56,
+        "H_Inzidenz": 2.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.05.2022"
@@ -30796,7 +30796,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.51,
+        "H_Inzidenz": 2.83,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.05.2022"
@@ -30807,26 +30807,26 @@
         "Datum": "19.05.2022",
         "Fallzahl": 210234,
         "ObjectId": 804,
-        "Sterbefall": 1703,
-        "Genesungsfall": 205161,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5538,
-        "Zuwachs_Fallzahl": 214,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 389,
         "BelegteBetten": null,
         "Inzidenz": 265.814145623047,
         "Datum_neu": 1652918400000,
-        "F\u00e4lle_Meldedatum": 200,
+        "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 238.4,
-        "Fallzahl_aktiv": 3370,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 353,
         "Krh_I_belegt": 66,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -175,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30834,7 +30834,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.19,
+        "H_Inzidenz": 2.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.05.2022"
@@ -30846,7 +30846,7 @@
         "Fallzahl": 210255,
         "ObjectId": 805,
         "Sterbefall": null,
-        "Genesungsfall": 205434,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30856,7 +30856,7 @@
         "BelegteBetten": null,
         "Inzidenz": 228.815690218758,
         "Datum_neu": 1653004800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 233.9,
@@ -30868,11 +30868,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.9,
+        "H_Inzidenz": 2.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.05.2022"
@@ -30884,7 +30884,7 @@
         "Fallzahl": 210255,
         "ObjectId": 806,
         "Sterbefall": null,
-        "Genesungsfall": 205562,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30894,7 +30894,7 @@
         "BelegteBetten": null,
         "Inzidenz": 196.127734473221,
         "Datum_neu": 1653091200000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 219.3,
@@ -30910,7 +30910,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": 2.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.05.2022"
@@ -30922,7 +30922,7 @@
         "Fallzahl": 210255,
         "ObjectId": 807,
         "Sterbefall": null,
-        "Genesungsfall": 205637,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -30932,7 +30932,7 @@
         "BelegteBetten": null,
         "Inzidenz": 182.118610582277,
         "Datum_neu": 1653177600000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 196.5,
@@ -30948,7 +30948,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.48,
+        "H_Inzidenz": 2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.05.2022"
@@ -30961,7 +30961,7 @@
         "ObjectId": 808,
         "Sterbefall": 1707,
         "Genesungsfall": 206141,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5557,
         "Zuwachs_Fallzahl": 173,
         "Zuwachs_Sterbefall": 4,
@@ -30970,12 +30970,12 @@
         "BelegteBetten": null,
         "Inzidenz": 199.719817522181,
         "Datum_neu": 1653264000000,
-        "F\u00e4lle_Meldedatum": 19,
-        "Zeitraum": "16.05.2022 - 22.05.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 239,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 180,
         "Fallzahl_aktiv": 2559,
-        "Krh_N_belegt": 356,
+        "Krh_N_belegt": 331,
         "Krh_I_belegt": 63,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -335,
@@ -30986,11 +30986,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.41,
-        "H_Zeitraum": "16.05.2022 - 22.05.2022",
-        "H_Datum": "20.05.2022",
+        "H_Inzidenz": 1.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.05.2022",
+        "Fallzahl": 210864,
+        "ObjectId": 809,
+        "Sterbefall": 1708,
+        "Genesungsfall": 206462,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5564,
+        "Zuwachs_Fallzahl": 457,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 321,
+        "BelegteBetten": null,
+        "Inzidenz": 225.94202377959,
+        "Datum_neu": 1653350400000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": "17.05.2022 - 23.05.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 176.2,
+        "Fallzahl_aktiv": 2694,
+        "Krh_N_belegt": 331,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 135,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.28,
+        "H_Zeitraum": "17.05.2022 - 23.05.2022",
+        "H_Datum": "23.05.2022",
+        "Datum_Bett": "23.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
