### PR TITLE
New data set: 2022-05-25T102804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-24T101902Z.json
+pjson/2022-05-25T102804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-24T101902Z.json pjson/2022-05-25T102804Z.json```:
```
--- pjson/2022-05-24T101902Z.json	2022-05-24 10:19:03.070041280 +0000
+++ pjson/2022-05-25T102804Z.json	2022-05-25 10:28:04.689534336 +0000
@@ -30336,7 +30336,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30440,7 +30440,7 @@
         "Datum_neu": 1652054400000,
         "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30478,7 +30478,7 @@
         "Datum_neu": 1652140800000,
         "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30706,7 +30706,7 @@
         "Datum_neu": 1652659200000,
         "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30740,15 +30740,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 589,
         "BelegteBetten": null,
-        "Inzidenz": 284.672581630087,
+        "Inzidenz": null,
         "Datum_neu": 1652745600000,
-        "F\u00e4lle_Meldedatum": 291,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 232.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 415,
-        "Krh_I_belegt": 67,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30758,7 +30758,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.05.2022"
@@ -30796,7 +30796,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.83,
+        "H_Inzidenz": 2.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.05.2022"
@@ -30834,7 +30834,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.59,
+        "H_Inzidenz": 2.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.05.2022"
@@ -30872,7 +30872,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.37,
+        "H_Inzidenz": 2.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.05.2022"
@@ -30910,7 +30910,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
+        "H_Inzidenz": 2.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.05.2022"
@@ -30932,7 +30932,7 @@
         "BelegteBetten": null,
         "Inzidenz": 182.118610582277,
         "Datum_neu": 1653177600000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 196.5,
@@ -30948,7 +30948,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2,
+        "H_Inzidenz": 2.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.05.2022"
@@ -30959,26 +30959,26 @@
         "Datum": "23.05.2022",
         "Fallzahl": 210407,
         "ObjectId": 808,
-        "Sterbefall": 1707,
-        "Genesungsfall": 206141,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5557,
-        "Zuwachs_Fallzahl": 173,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 504,
         "BelegteBetten": null,
         "Inzidenz": 199.719817522181,
         "Datum_neu": 1653264000000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 180,
-        "Fallzahl_aktiv": 2559,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
         "Krh_I_belegt": 63,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -335,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -30986,7 +30986,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.87,
+        "H_Inzidenz": 2.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.05.2022"
@@ -30999,7 +30999,7 @@
         "ObjectId": 809,
         "Sterbefall": 1708,
         "Genesungsfall": 206462,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5564,
         "Zuwachs_Fallzahl": 457,
         "Zuwachs_Sterbefall": 1,
@@ -31008,9 +31008,9 @@
         "BelegteBetten": null,
         "Inzidenz": 225.94202377959,
         "Datum_neu": 1653350400000,
-        "F\u00e4lle_Meldedatum": 5,
-        "Zeitraum": "17.05.2022 - 23.05.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 150,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 176.2,
         "Fallzahl_aktiv": 2694,
         "Krh_N_belegt": 331,
@@ -31024,11 +31024,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.28,
-        "H_Zeitraum": "17.05.2022 - 23.05.2022",
-        "H_Datum": "23.05.2022",
+        "H_Inzidenz": 1.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "23.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.05.2022",
+        "Fallzahl": 211055,
+        "ObjectId": 810,
+        "Sterbefall": 1709,
+        "Genesungsfall": 206755,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5570,
+        "Zuwachs_Fallzahl": 191,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 293,
+        "BelegteBetten": null,
+        "Inzidenz": 205.646754552965,
+        "Datum_neu": 1653436800000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "18.05.2022 - 24.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 177.1,
+        "Fallzahl_aktiv": 2591,
+        "Krh_N_belegt": 331,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -103,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.06,
+        "H_Zeitraum": "18.05.2022 - 24.05.2022",
+        "H_Datum": "23.05.2022",
+        "Datum_Bett": "24.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
