### PR TITLE
New data set: 2022-05-27T102903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-25T102804Z.json
+pjson/2022-05-27T102903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-25T102804Z.json pjson/2022-05-27T102903Z.json```:
```
--- pjson/2022-05-25T102804Z.json	2022-05-25 10:28:04.689534336 +0000
+++ pjson/2022-05-27T102903Z.json	2022-05-27 10:29:03.443891105 +0000
@@ -16682,7 +16682,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620777600000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -16720,7 +16720,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1620864000000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -17442,7 +17442,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1622505600000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 31,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -22686,7 +22686,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634428800000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -22762,7 +22762,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634601600000,
-        "F\u00e4lle_Meldedatum": 296,
+        "F\u00e4lle_Meldedatum": 297,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -22800,7 +22800,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634688000000,
-        "F\u00e4lle_Meldedatum": 281,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23522,7 +23522,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636329600000,
-        "F\u00e4lle_Meldedatum": 715,
+        "F\u00e4lle_Meldedatum": 716,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -23598,7 +23598,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636502400000,
-        "F\u00e4lle_Meldedatum": 972,
+        "F\u00e4lle_Meldedatum": 971,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1481,
+        "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -24054,7 +24054,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637539200000,
-        "F\u00e4lle_Meldedatum": 1381,
+        "F\u00e4lle_Meldedatum": 1382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1475,
+        "F\u00e4lle_Meldedatum": 1474,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24282,7 +24282,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638057600000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24358,7 +24358,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638230400000,
-        "F\u00e4lle_Meldedatum": 1327,
+        "F\u00e4lle_Meldedatum": 1326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 885,
+        "F\u00e4lle_Meldedatum": 884,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1004,
+        "F\u00e4lle_Meldedatum": 1003,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24586,7 +24586,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638748800000,
-        "F\u00e4lle_Meldedatum": 981,
+        "F\u00e4lle_Meldedatum": 982,
         "Zeitraum": null,
         "Hosp_Meldedatum": 44,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 889,
+        "F\u00e4lle_Meldedatum": 888,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25346,7 +25346,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640476800000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -29412,7 +29412,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1262,
+        "F\u00e4lle_Meldedatum": 1263,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -30552,7 +30552,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652313600000,
-        "F\u00e4lle_Meldedatum": 251,
+        "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -30678,7 +30678,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30778,15 +30778,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 334,
         "BelegteBetten": null,
-        "Inzidenz": 279.464061209095,
+        "Inzidenz": null,
         "Datum_neu": 1652832000000,
         "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 233.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 395,
-        "Krh_I_belegt": 65,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30796,7 +30796,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.05.2022"
@@ -30816,15 +30816,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 389,
         "BelegteBetten": null,
-        "Inzidenz": 265.814145623047,
+        "Inzidenz": null,
         "Datum_neu": 1652918400000,
         "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 238.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 353,
-        "Krh_I_belegt": 66,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30834,7 +30834,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.71,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.05.2022"
@@ -30872,7 +30872,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
+        "H_Inzidenz": 2.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.05.2022"
@@ -30910,7 +30910,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.19,
+        "H_Inzidenz": 2.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.05.2022"
@@ -30932,7 +30932,7 @@
         "BelegteBetten": null,
         "Inzidenz": 182.118610582277,
         "Datum_neu": 1653177600000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 196.5,
@@ -30948,7 +30948,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.14,
+        "H_Inzidenz": 2.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.05.2022"
@@ -30970,7 +30970,7 @@
         "BelegteBetten": null,
         "Inzidenz": 199.719817522181,
         "Datum_neu": 1653264000000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 180,
@@ -30986,7 +30986,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
+        "H_Inzidenz": 2.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.05.2022"
@@ -30997,34 +30997,34 @@
         "Datum": "24.05.2022",
         "Fallzahl": 210864,
         "ObjectId": 809,
-        "Sterbefall": 1708,
-        "Genesungsfall": 206462,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5564,
-        "Zuwachs_Fallzahl": 457,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 321,
         "BelegteBetten": null,
         "Inzidenz": 225.94202377959,
         "Datum_neu": 1653350400000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 176.2,
-        "Fallzahl_aktiv": 2694,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
         "Krh_I_belegt": 63,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 135,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.6,
+        "H_Inzidenz": 1.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.05.2022"
@@ -31037,7 +31037,7 @@
         "ObjectId": 810,
         "Sterbefall": 1709,
         "Genesungsfall": 206755,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5570,
         "Zuwachs_Fallzahl": 191,
         "Zuwachs_Sterbefall": 1,
@@ -31046,9 +31046,9 @@
         "BelegteBetten": null,
         "Inzidenz": 205.646754552965,
         "Datum_neu": 1653436800000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "18.05.2022 - 24.05.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 110,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 177.1,
         "Fallzahl_aktiv": 2591,
         "Krh_N_belegt": 331,
@@ -31062,11 +31062,87 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.06,
-        "H_Zeitraum": "18.05.2022 - 24.05.2022",
-        "H_Datum": "23.05.2022",
+        "H_Inzidenz": 1.26,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.05.2022",
+        "Fallzahl": 211208,
+        "ObjectId": 811,
+        "Sterbefall": null,
+        "Genesungsfall": 207010,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 255,
+        "BelegteBetten": null,
+        "Inzidenz": 193.972484643845,
+        "Datum_neu": 1653523200000,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 175.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 331,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.08,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.05.2022",
+        "Fallzahl": 211221,
+        "ObjectId": 812,
+        "Sterbefall": 1710,
+        "Genesungsfall": 207238,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5573,
+        "Zuwachs_Fallzahl": 166,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 228,
+        "BelegteBetten": null,
+        "Inzidenz": 163.260174575236,
+        "Datum_neu": 1653609600000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "20.05.2022 - 26.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 136.3,
+        "Fallzahl_aktiv": 2273,
+        "Krh_N_belegt": 331,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -63,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.89,
+        "H_Zeitraum": "20.05.2022 - 26.05.2022",
+        "H_Datum": "23.05.2022",
+        "Datum_Bett": "26.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
