### PR TITLE
New data set: 2022-05-30T104403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-27T102903Z.json
+pjson/2022-05-30T104403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-27T102903Z.json pjson/2022-05-30T104403Z.json```:
```
--- pjson/2022-05-27T102903Z.json	2022-05-27 10:29:03.443891105 +0000
+++ pjson/2022-05-30T104403Z.json	2022-05-30 10:44:03.638451110 +0000
@@ -30564,7 +30564,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30854,15 +30854,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 270,
         "BelegteBetten": null,
-        "Inzidenz": 228.815690218758,
+        "Inzidenz": null,
         "Datum_neu": 1653004800000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 233.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 356,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30872,7 +30872,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.51,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.05.2022"
@@ -30892,15 +30892,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 119,
         "BelegteBetten": null,
-        "Inzidenz": 196.127734473221,
+        "Inzidenz": null,
         "Datum_neu": 1653091200000,
         "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 219.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 356,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30910,7 +30910,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.22,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.05.2022"
@@ -30930,15 +30930,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 75,
         "BelegteBetten": null,
-        "Inzidenz": 182.118610582277,
+        "Inzidenz": null,
         "Datum_neu": 1653177600000,
         "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 196.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 356,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30948,7 +30948,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.17,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.05.2022"
@@ -30970,7 +30970,7 @@
         "BelegteBetten": null,
         "Inzidenz": 199.719817522181,
         "Datum_neu": 1653264000000,
-        "F\u00e4lle_Meldedatum": 265,
+        "F\u00e4lle_Meldedatum": 264,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 180,
@@ -30986,7 +30986,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
+        "H_Inzidenz": 2.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.05.2022"
@@ -31024,7 +31024,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.68,
+        "H_Inzidenz": 1.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.05.2022"
@@ -31035,26 +31035,26 @@
         "Datum": "25.05.2022",
         "Fallzahl": 211055,
         "ObjectId": 810,
-        "Sterbefall": 1709,
-        "Genesungsfall": 206755,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5570,
-        "Zuwachs_Fallzahl": 191,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 293,
         "BelegteBetten": null,
         "Inzidenz": 205.646754552965,
         "Datum_neu": 1653436800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 177.1,
-        "Fallzahl_aktiv": 2591,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
         "Krh_I_belegt": 63,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -103,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -31062,7 +31062,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.26,
+        "H_Inzidenz": 1.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.05.2022"
@@ -31074,7 +31074,7 @@
         "Fallzahl": 211208,
         "ObjectId": 811,
         "Sterbefall": null,
-        "Genesungsfall": 207010,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -31084,7 +31084,7 @@
         "BelegteBetten": null,
         "Inzidenz": 193.972484643845,
         "Datum_neu": 1653523200000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 175.5,
@@ -31100,7 +31100,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.08,
+        "H_Inzidenz": 1.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.05.2022"
@@ -31113,17 +31113,17 @@
         "ObjectId": 812,
         "Sterbefall": 1710,
         "Genesungsfall": 207238,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5573,
         "Zuwachs_Fallzahl": 166,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 3,
         "Zuwachs_Genesung": 228,
         "BelegteBetten": null,
-        "Inzidenz": 163.260174575236,
+        "Inzidenz": 167.6,
         "Datum_neu": 1653609600000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "20.05.2022 - 26.05.2022",
+        "F\u00e4lle_Meldedatum": 143,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 136.3,
         "Fallzahl_aktiv": 2273,
@@ -31138,11 +31138,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.89,
-        "H_Zeitraum": "20.05.2022 - 26.05.2022",
-        "H_Datum": "23.05.2022",
+        "H_Inzidenz": 1.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.05.2022",
+        "Fallzahl": 211403,
+        "ObjectId": 813,
+        "Sterbefall": null,
+        "Genesungsfall": 207370,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 132,
+        "BelegteBetten": null,
+        "Inzidenz": 161.1,
+        "Datum_neu": 1653696000000,
+        "F\u00e4lle_Meldedatum": 28,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 331,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.04,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.05.2022",
+        "Fallzahl": 211425,
+        "ObjectId": 814,
+        "Sterbefall": null,
+        "Genesungsfall": 207476,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 106,
+        "BelegteBetten": null,
+        "Inzidenz": 153.6,
+        "Datum_neu": 1653782400000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 331,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.91,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "28.05.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.05.2022",
+        "Fallzahl": 211441,
+        "ObjectId": 815,
+        "Sterbefall": 1711,
+        "Genesungsfall": 207792,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5573,
+        "Zuwachs_Fallzahl": 220,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 316,
+        "BelegteBetten": null,
+        "Inzidenz": 144.222134415748,
+        "Datum_neu": 1653868800000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "23.05.2022 - 29.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 107.2,
+        "Fallzahl_aktiv": 1938,
+        "Krh_N_belegt": 331,
+        "Krh_I_belegt": 63,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -97,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.84,
+        "H_Zeitraum": "23.05.2022 - 29.05.2022",
+        "H_Datum": "23.05.2022",
+        "Datum_Bett": "29.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
