### PR TITLE
New data set: 2022-05-30T110503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-27T102903Z.json
+pjson/2022-05-30T110503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-30T104403Z.json pjson/2022-05-30T110503Z.json```:
```
--- pjson/2022-05-30T104403Z.json	2022-05-30 10:44:03.638451110 +0000
+++ pjson/2022-05-30T110503Z.json	2022-05-30 11:05:03.631338237 +0000
@@ -31163,7 +31163,7 @@
         "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null,
+        "Inzidenz_RKI": 133,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
         "Krh_I_belegt": 63,
@@ -31201,7 +31201,7 @@
         "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": null,
+        "Inzidenz_RKI": 120.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
         "Krh_I_belegt": 63,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
