### PR TITLE
New data set: 2022-05-31T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-30T110503Z.json
+pjson/2022-05-31T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-30T110503Z.json pjson/2022-05-31T100303Z.json```:
```
--- pjson/2022-05-30T110503Z.json	2022-05-30 11:05:03.631338237 +0000
+++ pjson/2022-05-31T100303Z.json	2022-05-31 10:03:03.209607862 +0000
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 302,
+        "F\u00e4lle_Meldedatum": 303,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -30968,15 +30968,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 504,
         "BelegteBetten": null,
-        "Inzidenz": 199.719817522181,
+        "Inzidenz": null,
         "Datum_neu": 1653264000000,
-        "F\u00e4lle_Meldedatum": 264,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 180,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -30986,7 +30986,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.22,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.05.2022"
@@ -31008,9 +31008,9 @@
         "BelegteBetten": null,
         "Inzidenz": 225.94202377959,
         "Datum_neu": 1653350400000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 164,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 176.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
@@ -31024,7 +31024,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.8,
+        "H_Inzidenz": 1.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.05.2022"
@@ -31046,9 +31046,9 @@
         "BelegteBetten": null,
         "Inzidenz": 205.646754552965,
         "Datum_neu": 1653436800000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 177.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
@@ -31062,7 +31062,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": 1.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.05.2022"
@@ -31084,7 +31084,7 @@
         "BelegteBetten": null,
         "Inzidenz": 193.972484643845,
         "Datum_neu": 1653523200000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 175.5,
@@ -31100,7 +31100,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.48,
+        "H_Inzidenz": 1.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.05.2022"
@@ -31111,26 +31111,26 @@
         "Datum": "27.05.2022",
         "Fallzahl": 211221,
         "ObjectId": 812,
-        "Sterbefall": 1710,
-        "Genesungsfall": 207238,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5573,
-        "Zuwachs_Fallzahl": 166,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 228,
         "BelegteBetten": null,
         "Inzidenz": 167.6,
         "Datum_neu": 1653609600000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 136.3,
-        "Fallzahl_aktiv": 2273,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
         "Krh_I_belegt": 63,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -63,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -31138,7 +31138,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": 1.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.05.2022"
@@ -31150,7 +31150,7 @@
         "Fallzahl": 211403,
         "ObjectId": 813,
         "Sterbefall": null,
-        "Genesungsfall": 207370,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -31160,9 +31160,9 @@
         "BelegteBetten": null,
         "Inzidenz": 161.1,
         "Datum_neu": 1653696000000,
-        "F\u00e4lle_Meldedatum": 28,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 133,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
@@ -31176,7 +31176,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.04,
+        "H_Inzidenz": 1.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.05.2022"
@@ -31188,7 +31188,7 @@
         "Fallzahl": 211425,
         "ObjectId": 814,
         "Sterbefall": null,
-        "Genesungsfall": 207476,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -31198,7 +31198,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1653782400000,
-        "F\u00e4lle_Meldedatum": 22,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 120.5,
@@ -31214,7 +31214,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.91,
+        "H_Inzidenz": 1.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.05.2022"
@@ -31227,7 +31227,7 @@
         "ObjectId": 815,
         "Sterbefall": 1711,
         "Genesungsfall": 207792,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5573,
         "Zuwachs_Fallzahl": 220,
         "Zuwachs_Sterbefall": 1,
@@ -31236,13 +31236,13 @@
         "BelegteBetten": null,
         "Inzidenz": 144.222134415748,
         "Datum_neu": 1653868800000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "23.05.2022 - 29.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 238,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 107.2,
         "Fallzahl_aktiv": 1938,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": 263,
+        "Krh_I_belegt": 50,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -97,
         "Krh_I": null,
@@ -31252,11 +31252,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.84,
-        "H_Zeitraum": "23.05.2022 - 29.05.2022",
-        "H_Datum": "23.05.2022",
+        "H_Inzidenz": 1.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "31.05.2022",
+        "Fallzahl": 211727,
+        "ObjectId": 816,
+        "Sterbefall": 1711,
+        "Genesungsfall": 208081,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5586,
+        "Zuwachs_Fallzahl": 286,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 289,
+        "BelegteBetten": null,
+        "Inzidenz": 147.455009159812,
+        "Datum_neu": 1653955200000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "24.05.2022 - 30.05.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 101,
+        "Fallzahl_aktiv": 1935,
+        "Krh_N_belegt": 263,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.99,
+        "H_Zeitraum": "24.05.2022 - 30.05.2022",
+        "H_Datum": "30.05.2022",
+        "Datum_Bett": "30.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
