### PR TITLE
New data set: 2022-06-01T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-05-31T100303Z.json
+pjson/2022-06-01T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-05-31T100303Z.json pjson/2022-06-01T100303Z.json```:
```
--- pjson/2022-05-31T100303Z.json	2022-05-31 10:03:03.209607862 +0000
+++ pjson/2022-06-01T100303Z.json	2022-06-01 10:03:03.621276875 +0000
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2597,
+        "F\u00e4lle_Meldedatum": 2595,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2705,
+        "F\u00e4lle_Meldedatum": 2704,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2971,
+        "F\u00e4lle_Meldedatum": 2970,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1972,
+        "F\u00e4lle_Meldedatum": 1971,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1441,
+        "F\u00e4lle_Meldedatum": 1440,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29488,7 +29488,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649894400000,
-        "F\u00e4lle_Meldedatum": 784,
+        "F\u00e4lle_Meldedatum": 783,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -29754,7 +29754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650499200000,
-        "F\u00e4lle_Meldedatum": 804,
+        "F\u00e4lle_Meldedatum": 805,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29792,7 +29792,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 502,
+        "F\u00e4lle_Meldedatum": 501,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -29868,7 +29868,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650758400000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -29982,7 +29982,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651017600000,
-        "F\u00e4lle_Meldedatum": 571,
+        "F\u00e4lle_Meldedatum": 572,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -30020,7 +30020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651104000000,
-        "F\u00e4lle_Meldedatum": 498,
+        "F\u00e4lle_Meldedatum": 499,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -30172,7 +30172,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651449600000,
-        "F\u00e4lle_Meldedatum": 707,
+        "F\u00e4lle_Meldedatum": 706,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -30210,7 +30210,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 582,
+        "F\u00e4lle_Meldedatum": 583,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -30438,7 +30438,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652054400000,
-        "F\u00e4lle_Meldedatum": 509,
+        "F\u00e4lle_Meldedatum": 510,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -30526,7 +30526,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30640,7 +30640,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30678,7 +30678,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30792,7 +30792,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30818,7 +30818,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652918400000,
-        "F\u00e4lle_Meldedatum": 218,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -30856,7 +30856,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653004800000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -31006,15 +31006,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 321,
         "BelegteBetten": null,
-        "Inzidenz": 225.94202377959,
+        "Inzidenz": null,
         "Datum_neu": 1653350400000,
-        "F\u00e4lle_Meldedatum": 164,
+        "F\u00e4lle_Meldedatum": 165,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 176.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31024,7 +31024,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.9,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.05.2022"
@@ -31048,7 +31048,7 @@
         "Datum_neu": 1653436800000,
         "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 177.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 331,
@@ -31062,7 +31062,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.63,
+        "H_Inzidenz": 1.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.05.2022"
@@ -31100,7 +31100,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.68,
+        "H_Inzidenz": 1.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.05.2022"
@@ -31138,7 +31138,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.45,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.05.2022"
@@ -31160,7 +31160,7 @@
         "BelegteBetten": null,
         "Inzidenz": 161.1,
         "Datum_neu": 1653696000000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 133,
@@ -31176,7 +31176,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.36,
+        "H_Inzidenz": 1.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.05.2022"
@@ -31198,7 +31198,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1653782400000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 120.5,
@@ -31214,7 +31214,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.28,
+        "H_Inzidenz": 1.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.05.2022"
@@ -31225,26 +31225,26 @@
         "Datum": "30.05.2022",
         "Fallzahl": 211441,
         "ObjectId": 815,
-        "Sterbefall": 1711,
-        "Genesungsfall": 207792,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5573,
-        "Zuwachs_Fallzahl": 220,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 316,
         "BelegteBetten": null,
         "Inzidenz": 144.222134415748,
         "Datum_neu": 1653868800000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 261,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 107.2,
-        "Fallzahl_aktiv": 1938,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 263,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -97,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -31252,7 +31252,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": 1.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.05.2022"
@@ -31265,7 +31265,7 @@
         "ObjectId": 816,
         "Sterbefall": 1711,
         "Genesungsfall": 208081,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5586,
         "Zuwachs_Fallzahl": 286,
         "Zuwachs_Sterbefall": 0,
@@ -31274,9 +31274,9 @@
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1653955200000,
-        "F\u00e4lle_Meldedatum": 18,
-        "Zeitraum": "24.05.2022 - 30.05.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 214,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 101,
         "Fallzahl_aktiv": 1935,
         "Krh_N_belegt": 263,
@@ -31290,11 +31290,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.99,
-        "H_Zeitraum": "24.05.2022 - 30.05.2022",
-        "H_Datum": "30.05.2022",
+        "H_Inzidenz": 1.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "30.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.06.2022",
+        "Fallzahl": 211964,
+        "ObjectId": 817,
+        "Sterbefall": 1715,
+        "Genesungsfall": 208287,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5590,
+        "Zuwachs_Fallzahl": 237,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 206,
+        "BelegteBetten": null,
+        "Inzidenz": 161.823341355652,
+        "Datum_neu": 1654041600000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "25.05.2022 - 31.05.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 127.5,
+        "Fallzahl_aktiv": 1962,
+        "Krh_N_belegt": 263,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 27,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.89,
+        "H_Zeitraum": "25.05.2022 - 31.05.2022",
+        "H_Datum": "30.05.2022",
+        "Datum_Bett": "31.05.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
