### PR TITLE
New data set: 2022-06-02T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-01T100303Z.json
+pjson/2022-06-02T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-01T100303Z.json pjson/2022-06-02T100203Z.json```:
```
--- pjson/2022-06-01T100303Z.json	2022-06-01 10:03:03.621276875 +0000
+++ pjson/2022-06-02T100203Z.json	2022-06-02 10:02:03.913181906 +0000
@@ -27930,7 +27930,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646352000000,
-        "F\u00e4lle_Meldedatum": 981,
+        "F\u00e4lle_Meldedatum": 982,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -28006,7 +28006,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646524800000,
-        "F\u00e4lle_Meldedatum": 374,
+        "F\u00e4lle_Meldedatum": 375,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2042,
+        "F\u00e4lle_Meldedatum": 2044,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2083,
+        "F\u00e4lle_Meldedatum": 2084,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2099,
+        "F\u00e4lle_Meldedatum": 2098,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28348,7 +28348,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647302400000,
-        "F\u00e4lle_Meldedatum": 2595,
+        "F\u00e4lle_Meldedatum": 2596,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 376,
+        "F\u00e4lle_Meldedatum": 377,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2970,
+        "F\u00e4lle_Meldedatum": 2969,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1440,
+        "F\u00e4lle_Meldedatum": 1439,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -31044,15 +31044,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 293,
         "BelegteBetten": null,
-        "Inzidenz": 205.646754552965,
+        "Inzidenz": null,
         "Datum_neu": 1653436800000,
         "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 177.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31062,7 +31062,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.05.2022"
@@ -31100,7 +31100,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.77,
+        "H_Inzidenz": 1.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.05.2022"
@@ -31138,7 +31138,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": 1.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.05.2022"
@@ -31160,7 +31160,7 @@
         "BelegteBetten": null,
         "Inzidenz": 161.1,
         "Datum_neu": 1653696000000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 133,
@@ -31176,7 +31176,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.45,
+        "H_Inzidenz": 1.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.05.2022"
@@ -31198,7 +31198,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1653782400000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 120.5,
@@ -31214,7 +31214,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.41,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.05.2022"
@@ -31236,7 +31236,7 @@
         "BelegteBetten": null,
         "Inzidenz": 144.222134415748,
         "Datum_neu": 1653868800000,
-        "F\u00e4lle_Meldedatum": 261,
+        "F\u00e4lle_Meldedatum": 268,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 107.2,
@@ -31252,7 +31252,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.05.2022"
@@ -31263,26 +31263,26 @@
         "Datum": "31.05.2022",
         "Fallzahl": 211727,
         "ObjectId": 816,
-        "Sterbefall": 1711,
-        "Genesungsfall": 208081,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5586,
-        "Zuwachs_Fallzahl": 286,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 289,
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1653955200000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 232,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 101,
-        "Fallzahl_aktiv": 1935,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 263,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -31290,7 +31290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": 1.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.05.2022"
@@ -31303,7 +31303,7 @@
         "ObjectId": 817,
         "Sterbefall": 1715,
         "Genesungsfall": 208287,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5590,
         "Zuwachs_Fallzahl": 237,
         "Zuwachs_Sterbefall": 4,
@@ -31312,9 +31312,9 @@
         "BelegteBetten": null,
         "Inzidenz": 161.823341355652,
         "Datum_neu": 1654041600000,
-        "F\u00e4lle_Meldedatum": 11,
-        "Zeitraum": "25.05.2022 - 31.05.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 129,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 127.5,
         "Fallzahl_aktiv": 1962,
         "Krh_N_belegt": 263,
@@ -31328,11 +31328,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.89,
-        "H_Zeitraum": "25.05.2022 - 31.05.2022",
-        "H_Datum": "30.05.2022",
+        "H_Inzidenz": 1.08,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "31.05.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "02.06.2022",
+        "Fallzahl": 212123,
+        "ObjectId": 818,
+        "Sterbefall": 1715,
+        "Genesungsfall": 208510,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5592,
+        "Zuwachs_Fallzahl": 159,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 223,
+        "BelegteBetten": null,
+        "Inzidenz": 168.468694996228,
+        "Datum_neu": 1654128000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "26.05.2022 - 01.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 146,
+        "Fallzahl_aktiv": 1898,
+        "Krh_N_belegt": 263,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -64,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.84,
+        "H_Zeitraum": "26.05.2022 - 01.06.2022",
+        "H_Datum": "30.05.2022",
+        "Datum_Bett": "01.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
