### PR TITLE
New data set: 2022-06-03T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-02T100203Z.json
+pjson/2022-06-03T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-02T100203Z.json pjson/2022-06-03T100503Z.json```:
```
--- pjson/2022-06-02T100203Z.json	2022-06-02 10:02:03.913181906 +0000
+++ pjson/2022-06-03T100503Z.json	2022-06-03 10:05:03.181188145 +0000
@@ -31082,15 +31082,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 255,
         "BelegteBetten": null,
-        "Inzidenz": 193.972484643845,
+        "Inzidenz": null,
         "Datum_neu": 1653523200000,
         "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 175.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31100,7 +31100,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.05.2022"
@@ -31138,7 +31138,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": 1.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.05.2022"
@@ -31176,7 +31176,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.6,
+        "H_Inzidenz": 1.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.05.2022"
@@ -31198,7 +31198,7 @@
         "BelegteBetten": null,
         "Inzidenz": 153.6,
         "Datum_neu": 1653782400000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 120.5,
@@ -31214,7 +31214,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": 1.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.05.2022"
@@ -31236,7 +31236,7 @@
         "BelegteBetten": null,
         "Inzidenz": 144.222134415748,
         "Datum_neu": 1653868800000,
-        "F\u00e4lle_Meldedatum": 268,
+        "F\u00e4lle_Meldedatum": 269,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 107.2,
@@ -31248,11 +31248,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.45,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.05.2022"
@@ -31274,7 +31274,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1653955200000,
-        "F\u00e4lle_Meldedatum": 232,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 101,
@@ -31290,7 +31290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.05.2022"
@@ -31301,34 +31301,34 @@
         "Datum": "01.06.2022",
         "Fallzahl": 211964,
         "ObjectId": 817,
-        "Sterbefall": 1715,
-        "Genesungsfall": 208287,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5590,
-        "Zuwachs_Fallzahl": 237,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 206,
         "BelegteBetten": null,
         "Inzidenz": 161.823341355652,
         "Datum_neu": 1654041600000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 164,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 127.5,
-        "Fallzahl_aktiv": 1962,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 263,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 27,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.08,
+        "H_Inzidenz": 1.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.05.2022"
@@ -31341,7 +31341,7 @@
         "ObjectId": 818,
         "Sterbefall": 1715,
         "Genesungsfall": 208510,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5592,
         "Zuwachs_Fallzahl": 159,
         "Zuwachs_Sterbefall": 0,
@@ -31350,13 +31350,13 @@
         "BelegteBetten": null,
         "Inzidenz": 168.468694996228,
         "Datum_neu": 1654128000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "26.05.2022 - 01.06.2022",
+        "F\u00e4lle_Meldedatum": 191,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 146,
         "Fallzahl_aktiv": 1898,
-        "Krh_N_belegt": 263,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -64,
         "Krh_I": null,
@@ -31366,11 +31366,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.84,
-        "H_Zeitraum": "26.05.2022 - 01.06.2022",
-        "H_Datum": "30.05.2022",
+        "H_Inzidenz": 1.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.06.2022",
+        "Fallzahl": 212361,
+        "ObjectId": 819,
+        "Sterbefall": 1716,
+        "Genesungsfall": 208685,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5593,
+        "Zuwachs_Fallzahl": 238,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 175,
+        "BelegteBetten": null,
+        "Inzidenz": 198.642192607493,
+        "Datum_neu": 1654214400000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "27.05.2022 - 02.06.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 170,
+        "Fallzahl_aktiv": 1960,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 62,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.21,
+        "H_Zeitraum": "27.05.2022 - 02.06.2022",
+        "H_Datum": "02.06.2022",
+        "Datum_Bett": "02.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
