### PR TITLE
New data set: 2022-06-07T103003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-03T100503Z.json
+pjson/2022-06-07T103003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-03T100503Z.json pjson/2022-06-07T103003Z.json```:
```
--- pjson/2022-06-03T100503Z.json	2022-06-03 10:05:03.181188145 +0000
+++ pjson/2022-06-07T103003Z.json	2022-06-07 10:30:04.121992743 +0000
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 884,
+        "F\u00e4lle_Meldedatum": 883,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -24548,7 +24548,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638662400000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 888,
+        "F\u00e4lle_Meldedatum": 887,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 788,
+        "F\u00e4lle_Meldedatum": 787,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 480,
+        "F\u00e4lle_Meldedatum": 479,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 690,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -24966,7 +24966,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639612800000,
-        "F\u00e4lle_Meldedatum": 762,
+        "F\u00e4lle_Meldedatum": 761,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 552,
+        "F\u00e4lle_Meldedatum": 550,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 937,
+        "F\u00e4lle_Meldedatum": 936,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 423,
+        "F\u00e4lle_Meldedatum": 422,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 215,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -29906,7 +29906,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1109,
+        "F\u00e4lle_Meldedatum": 1110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -30818,7 +30818,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652918400000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -30868,7 +30868,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -30894,7 +30894,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653091200000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -30982,7 +30982,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31010,7 +31010,7 @@
         "Datum_neu": 1653350400000,
         "F\u00e4lle_Meldedatum": 165,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31046,7 +31046,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653436800000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -31058,7 +31058,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31080,7 +31080,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 255,
+        "Zuwachs_Genesung": 254,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653523200000,
@@ -31096,7 +31096,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31120,15 +31120,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 228,
         "BelegteBetten": null,
-        "Inzidenz": 167.6,
+        "Inzidenz": null,
         "Datum_neu": 1653609600000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 136.3,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31138,7 +31138,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.05.2022"
@@ -31158,25 +31158,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
-        "Inzidenz": 161.1,
+        "Inzidenz": null,
         "Datum_neu": 1653696000000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 133,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.05.2022"
@@ -31194,27 +31194,27 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 106,
+        "Zuwachs_Genesung": 105,
         "BelegteBetten": null,
-        "Inzidenz": 153.6,
+        "Inzidenz": null,
         "Datum_neu": 1653782400000,
         "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 120.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 331,
-        "Krh_I_belegt": 63,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.65,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.05.2022"
@@ -31232,17 +31232,17 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 316,
+        "Zuwachs_Genesung": 315,
         "BelegteBetten": null,
-        "Inzidenz": 144.222134415748,
+        "Inzidenz": null,
         "Datum_neu": 1653868800000,
-        "F\u00e4lle_Meldedatum": 269,
+        "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 107.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 263,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31252,7 +31252,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.05.2022"
@@ -31274,7 +31274,7 @@
         "BelegteBetten": null,
         "Inzidenz": 147.455009159812,
         "Datum_neu": 1653955200000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 243,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 101,
@@ -31312,7 +31312,7 @@
         "BelegteBetten": null,
         "Inzidenz": 161.823341355652,
         "Datum_neu": 1654041600000,
-        "F\u00e4lle_Meldedatum": 164,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 127.5,
@@ -31339,26 +31339,26 @@
         "Datum": "02.06.2022",
         "Fallzahl": 212123,
         "ObjectId": 818,
-        "Sterbefall": 1715,
-        "Genesungsfall": 208510,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5592,
-        "Zuwachs_Fallzahl": 159,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 223,
         "BelegteBetten": null,
         "Inzidenz": 168.468694996228,
         "Datum_neu": 1654128000000,
-        "F\u00e4lle_Meldedatum": 191,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 146,
-        "Fallzahl_aktiv": 1898,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
         "Krh_I_belegt": 44,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -64,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -31379,7 +31379,7 @@
         "ObjectId": 819,
         "Sterbefall": 1716,
         "Genesungsfall": 208685,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5593,
         "Zuwachs_Fallzahl": 238,
         "Zuwachs_Sterbefall": 1,
@@ -31388,10 +31388,10 @@
         "BelegteBetten": null,
         "Inzidenz": 198.642192607493,
         "Datum_neu": 1654214400000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "27.05.2022 - 02.06.2022",
-        "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 170,
+        "F\u00e4lle_Meldedatum": 116,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 170.1,
         "Fallzahl_aktiv": 1960,
         "Krh_N_belegt": 239,
         "Krh_I_belegt": 44,
@@ -31405,9 +31405,161 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.21,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.06.2022",
+        "Fallzahl": 212617,
+        "ObjectId": 820,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 73,
+        "BelegteBetten": null,
+        "Inzidenz": 198.462588455045,
+        "Datum_neu": 1654300800000,
+        "F\u00e4lle_Meldedatum": 119,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 176,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.21,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "03.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.06.2022",
+        "Fallzahl": 212654,
+        "ObjectId": 821,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 77,
+        "BelegteBetten": null,
+        "Inzidenz": 211.932899888645,
+        "Datum_neu": 1654387200000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 168.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.21,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.06.2022",
+        "Fallzahl": 212742,
+        "ObjectId": 822,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 248,
+        "BelegteBetten": null,
+        "Inzidenz": 211.034879126405,
+        "Datum_neu": 1654473600000,
+        "F\u00e4lle_Meldedatum": 88,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 160.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.21,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "05.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.06.2022",
+        "Fallzahl": 212750,
+        "ObjectId": 823,
+        "Sterbefall": 1722,
+        "Genesungsfall": 209242,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5599,
+        "Zuwachs_Fallzahl": 389,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 162,
+        "BelegteBetten": null,
+        "Inzidenz": 177.987715075973,
+        "Datum_neu": 1654560000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "31.05.2022 - 06.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 112.2,
+        "Fallzahl_aktiv": 1786,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 221,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.21,
         "H_Zeitraum": "27.05.2022 - 02.06.2022",
         "H_Datum": "02.06.2022",
-        "Datum_Bett": "02.06.2022"
+        "Datum_Bett": "06.06.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
