### PR TITLE
New data set: 2022-06-08T102303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-07T103003Z.json
+pjson/2022-06-08T102303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-07T103003Z.json pjson/2022-06-08T102303Z.json```:
```
--- pjson/2022-06-07T103003Z.json	2022-06-07 10:30:04.121992743 +0000
+++ pjson/2022-06-08T102303Z.json	2022-06-08 10:23:03.775265932 +0000
@@ -26866,7 +26866,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643932800000,
-        "F\u00e4lle_Meldedatum": 1103,
+        "F\u00e4lle_Meldedatum": 1104,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2598,
+        "F\u00e4lle_Meldedatum": 2599,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1529,
+        "F\u00e4lle_Meldedatum": 1530,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1064,
+        "F\u00e4lle_Meldedatum": 1065,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29450,7 +29450,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 745,
+        "F\u00e4lle_Meldedatum": 747,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -31272,15 +31272,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 289,
         "BelegteBetten": null,
-        "Inzidenz": 147.455009159812,
+        "Inzidenz": null,
         "Datum_neu": 1653955200000,
-        "F\u00e4lle_Meldedatum": 243,
+        "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 101,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 263,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31290,7 +31290,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.48,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.05.2022"
@@ -31328,7 +31328,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.05.2022"
@@ -31352,7 +31352,7 @@
         "Datum_neu": 1654128000000,
         "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 146,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
@@ -31366,7 +31366,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.06.2022"
@@ -31377,34 +31377,34 @@
         "Datum": "03.06.2022",
         "Fallzahl": 212361,
         "ObjectId": 819,
-        "Sterbefall": 1716,
-        "Genesungsfall": 208685,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5593,
-        "Zuwachs_Fallzahl": 238,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 175,
         "BelegteBetten": null,
         "Inzidenz": 198.642192607493,
         "Datum_neu": 1654214400000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 170.1,
-        "Fallzahl_aktiv": 1960,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
         "Krh_I_belegt": 44,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 62,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.06.2022"
@@ -31426,7 +31426,7 @@
         "BelegteBetten": null,
         "Inzidenz": 198.462588455045,
         "Datum_neu": 1654300800000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 176,
@@ -31442,7 +31442,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.06.2022"
@@ -31464,7 +31464,7 @@
         "BelegteBetten": null,
         "Inzidenz": 211.932899888645,
         "Datum_neu": 1654387200000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 168.1,
@@ -31480,7 +31480,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.06.2022"
@@ -31502,7 +31502,7 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1654473600000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 160.5,
@@ -31518,7 +31518,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
+        "H_Inzidenz": 1.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.06.2022"
@@ -31531,7 +31531,7 @@
         "ObjectId": 823,
         "Sterbefall": 1722,
         "Genesungsfall": 209242,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5599,
         "Zuwachs_Fallzahl": 389,
         "Zuwachs_Sterbefall": 6,
@@ -31540,9 +31540,9 @@
         "BelegteBetten": null,
         "Inzidenz": 177.987715075973,
         "Datum_neu": 1654560000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "31.05.2022 - 06.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 360,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 112.2,
         "Fallzahl_aktiv": 1786,
         "Krh_N_belegt": 239,
@@ -31556,11 +31556,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.21,
-        "H_Zeitraum": "27.05.2022 - 02.06.2022",
-        "H_Datum": "02.06.2022",
+        "H_Inzidenz": 1.06,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.06.2022",
+        "Fallzahl": 213263,
+        "ObjectId": 824,
+        "Sterbefall": 1722,
+        "Genesungsfall": 209378,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5607,
+        "Zuwachs_Fallzahl": 513,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 136,
+        "BelegteBetten": null,
+        "Inzidenz": 217.321024462086,
+        "Datum_neu": 1654646400000,
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": "01.06.2022 - 07.06.2022",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 139.3,
+        "Fallzahl_aktiv": 2163,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 377,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.81,
+        "H_Zeitraum": "01.06.2022 - 07.06.2022",
+        "H_Datum": "02.06.2022",
+        "Datum_Bett": "07.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
