### PR TITLE
New data set: 2022-06-09T100404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-08T102303Z.json
+pjson/2022-06-09T100404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-08T102303Z.json pjson/2022-06-09T100404Z.json```:
```
--- pjson/2022-06-08T102303Z.json	2022-06-08 10:23:03.775265932 +0000
+++ pjson/2022-06-09T100404Z.json	2022-06-09 10:04:04.194364612 +0000
@@ -31310,15 +31310,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 206,
         "BelegteBetten": null,
-        "Inzidenz": 161.823341355652,
+        "Inzidenz": null,
         "Datum_neu": 1654041600000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 127.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 263,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31328,7 +31328,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.05.2022"
@@ -31366,7 +31366,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": 1.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.06.2022"
@@ -31388,9 +31388,9 @@
         "BelegteBetten": null,
         "Inzidenz": 198.642192607493,
         "Datum_neu": 1654214400000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 170.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
@@ -31404,7 +31404,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.75,
+        "H_Inzidenz": 1.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.06.2022"
@@ -31442,7 +31442,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.43,
+        "H_Inzidenz": 1.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.06.2022"
@@ -31466,7 +31466,7 @@
         "Datum_neu": 1654387200000,
         "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 168.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
@@ -31480,7 +31480,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.43,
+        "H_Inzidenz": 1.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.06.2022"
@@ -31502,9 +31502,9 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1654473600000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 160.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
@@ -31518,7 +31518,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.43,
+        "H_Inzidenz": 1.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.06.2022"
@@ -31529,34 +31529,34 @@
         "Datum": "07.06.2022",
         "Fallzahl": 212750,
         "ObjectId": 823,
-        "Sterbefall": 1722,
-        "Genesungsfall": 209242,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5599,
-        "Zuwachs_Fallzahl": 389,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 162,
         "BelegteBetten": null,
         "Inzidenz": 177.987715075973,
         "Datum_neu": 1654560000000,
-        "F\u00e4lle_Meldedatum": 360,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 112.2,
-        "Fallzahl_aktiv": 1786,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
         "Krh_I_belegt": 44,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 221,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.06,
+        "H_Inzidenz": 1.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.06.2022"
@@ -31569,7 +31569,7 @@
         "ObjectId": 824,
         "Sterbefall": 1722,
         "Genesungsfall": 209378,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5607,
         "Zuwachs_Fallzahl": 513,
         "Zuwachs_Sterbefall": 0,
@@ -31578,9 +31578,9 @@
         "BelegteBetten": null,
         "Inzidenz": 217.321024462086,
         "Datum_neu": 1654646400000,
-        "F\u00e4lle_Meldedatum": 51,
-        "Zeitraum": "01.06.2022 - 07.06.2022",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 353,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 139.3,
         "Fallzahl_aktiv": 2163,
         "Krh_N_belegt": 239,
@@ -31594,11 +31594,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.81,
-        "H_Zeitraum": "01.06.2022 - 07.06.2022",
-        "H_Datum": "02.06.2022",
+        "H_Inzidenz": 1.38,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.06.2022",
+        "Fallzahl": 213641,
+        "ObjectId": 825,
+        "Sterbefall": 1722,
+        "Genesungsfall": 209446,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5614,
+        "Zuwachs_Fallzahl": 378,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 68,
+        "BelegteBetten": null,
+        "Inzidenz": 257.372750457991,
+        "Datum_neu": 1654732800000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "02.06.2022 - 08.06.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 201.4,
+        "Fallzahl_aktiv": 2473,
+        "Krh_N_belegt": 239,
+        "Krh_I_belegt": 44,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 310,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.18,
+        "H_Zeitraum": "02.06.2022 - 08.06.2022",
+        "H_Datum": "02.06.2022",
+        "Datum_Bett": "08.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
