### PR TITLE
New data set: 2022-06-10T102704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-09T100404Z.json
+pjson/2022-06-10T102704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-09T100404Z.json pjson/2022-06-10T102704Z.json```:
```
--- pjson/2022-06-09T100404Z.json	2022-06-09 10:04:04.194364612 +0000
+++ pjson/2022-06-10T102704Z.json	2022-06-10 10:27:04.152747604 +0000
@@ -29452,7 +29452,7 @@
         "Datum_neu": 1649808000000,
         "F\u00e4lle_Meldedatum": 747,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29680,7 +29680,7 @@
         "Datum_neu": 1650326400000,
         "F\u00e4lle_Meldedatum": 1406,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29870,7 +29870,7 @@
         "Datum_neu": 1650758400000,
         "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29908,7 +29908,7 @@
         "Datum_neu": 1650844800000,
         "F\u00e4lle_Meldedatum": 1110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29946,7 +29946,7 @@
         "Datum_neu": 1650931200000,
         "F\u00e4lle_Meldedatum": 608,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30060,7 +30060,7 @@
         "Datum_neu": 1651190400000,
         "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30250,7 +30250,7 @@
         "Datum_neu": 1651622400000,
         "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30288,7 +30288,7 @@
         "Datum_neu": 1651708800000,
         "F\u00e4lle_Meldedatum": 361,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30440,7 +30440,7 @@
         "Datum_neu": 1652054400000,
         "F\u00e4lle_Meldedatum": 510,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30478,7 +30478,7 @@
         "Datum_neu": 1652140800000,
         "F\u00e4lle_Meldedatum": 331,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30554,7 +30554,7 @@
         "Datum_neu": 1652313600000,
         "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -30592,7 +30592,7 @@
         "Datum_neu": 1652400000000,
         "F\u00e4lle_Meldedatum": 228,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31010,7 +31010,7 @@
         "Datum_neu": 1653350400000,
         "F\u00e4lle_Meldedatum": 165,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31124,7 +31124,7 @@
         "Datum_neu": 1653609600000,
         "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31348,15 +31348,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 223,
         "BelegteBetten": null,
-        "Inzidenz": 168.468694996228,
+        "Inzidenz": null,
         "Datum_neu": 1654128000000,
         "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 146,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31366,7 +31366,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.75,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.06.2022"
@@ -31390,7 +31390,7 @@
         "Datum_neu": 1654214400000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 170.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 239,
@@ -31404,7 +31404,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": 2.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.06.2022"
@@ -31442,7 +31442,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.77,
+        "H_Inzidenz": 1.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.06.2022"
@@ -31464,7 +31464,7 @@
         "BelegteBetten": null,
         "Inzidenz": 211.932899888645,
         "Datum_neu": 1654387200000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 168.1,
@@ -31480,7 +31480,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.87,
+        "H_Inzidenz": 1.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.06.2022"
@@ -31518,7 +31518,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.95,
+        "H_Inzidenz": 2.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.06.2022"
@@ -31540,13 +31540,13 @@
         "BelegteBetten": null,
         "Inzidenz": 177.987715075973,
         "Datum_neu": 1654560000000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 404,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 112.2,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": 257,
+        "Krh_I_belegt": 40,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31556,7 +31556,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.48,
+        "H_Inzidenz": 1.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.06.2022"
@@ -31567,34 +31567,34 @@
         "Datum": "08.06.2022",
         "Fallzahl": 213263,
         "ObjectId": 824,
-        "Sterbefall": 1722,
-        "Genesungsfall": 209378,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5607,
-        "Zuwachs_Fallzahl": 513,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 136,
         "BelegteBetten": null,
         "Inzidenz": 217.321024462086,
         "Datum_neu": 1654646400000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 388,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 139.3,
-        "Fallzahl_aktiv": 2163,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 257,
+        "Krh_I_belegt": 40,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 377,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.38,
+        "H_Inzidenz": 1.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.06.2022"
@@ -31607,7 +31607,7 @@
         "ObjectId": 825,
         "Sterbefall": 1722,
         "Genesungsfall": 209446,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5614,
         "Zuwachs_Fallzahl": 378,
         "Zuwachs_Sterbefall": 0,
@@ -31616,13 +31616,13 @@
         "BelegteBetten": null,
         "Inzidenz": 257.372750457991,
         "Datum_neu": 1654732800000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "02.06.2022 - 08.06.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 284,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 201.4,
         "Fallzahl_aktiv": 2473,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": 278,
+        "Krh_I_belegt": 31,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 310,
         "Krh_I": null,
@@ -31632,11 +31632,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.18,
-        "H_Zeitraum": "02.06.2022 - 08.06.2022",
-        "H_Datum": "02.06.2022",
+        "H_Inzidenz": 1.43,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.06.2022",
+        "Fallzahl": 213952,
+        "ObjectId": 826,
+        "Sterbefall": 1722,
+        "Genesungsfall": 209599,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5615,
+        "Zuwachs_Fallzahl": 311,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 153,
+        "BelegteBetten": null,
+        "Inzidenz": 278.027227989511,
+        "Datum_neu": 1654819200000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "03.06.2022 - 09.06.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 233.5,
+        "Fallzahl_aktiv": 2631,
+        "Krh_N_belegt": 278,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 158,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.23,
+        "H_Zeitraum": "03.06.2022 - 09.06.2022",
+        "H_Datum": "09.06.2022",
+        "Datum_Bett": "09.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
