### PR TITLE
New data set: 2022-06-13T103103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-10T102704Z.json
+pjson/2022-06-13T103103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-10T102704Z.json pjson/2022-06-13T103103Z.json```:
```
--- pjson/2022-06-10T102704Z.json	2022-06-10 10:27:04.152747604 +0000
+++ pjson/2022-06-13T103103Z.json	2022-06-13 10:31:04.061909466 +0000
@@ -31096,7 +31096,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31324,7 +31324,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31362,7 +31362,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31386,15 +31386,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 175,
         "BelegteBetten": null,
-        "Inzidenz": 198.642192607493,
+        "Inzidenz": null,
         "Datum_neu": 1654214400000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 170.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31404,7 +31404,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.02,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.06.2022"
@@ -31424,15 +31424,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 73,
         "BelegteBetten": null,
-        "Inzidenz": 198.462588455045,
+        "Inzidenz": null,
         "Datum_neu": 1654300800000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 176,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31442,7 +31442,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.85,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.06.2022"
@@ -31462,15 +31462,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 77,
         "BelegteBetten": null,
-        "Inzidenz": 211.932899888645,
+        "Inzidenz": null,
         "Datum_neu": 1654387200000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 168.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31480,7 +31480,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.06.2022"
@@ -31502,7 +31502,7 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1654473600000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 160.5,
@@ -31518,7 +31518,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
+        "H_Inzidenz": 2.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.06.2022"
@@ -31540,7 +31540,7 @@
         "BelegteBetten": null,
         "Inzidenz": 177.987715075973,
         "Datum_neu": 1654560000000,
-        "F\u00e4lle_Meldedatum": 404,
+        "F\u00e4lle_Meldedatum": 407,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 112.2,
@@ -31556,7 +31556,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.55,
+        "H_Inzidenz": 1.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.06.2022"
@@ -31578,7 +31578,7 @@
         "BelegteBetten": null,
         "Inzidenz": 217.321024462086,
         "Datum_neu": 1654646400000,
-        "F\u00e4lle_Meldedatum": 388,
+        "F\u00e4lle_Meldedatum": 399,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 139.3,
@@ -31594,7 +31594,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
+        "H_Inzidenz": 1.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.06.2022"
@@ -31605,34 +31605,34 @@
         "Datum": "09.06.2022",
         "Fallzahl": 213641,
         "ObjectId": 825,
-        "Sterbefall": 1722,
-        "Genesungsfall": 209446,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5614,
-        "Zuwachs_Fallzahl": 378,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
         "Inzidenz": 257.372750457991,
         "Datum_neu": 1654732800000,
-        "F\u00e4lle_Meldedatum": 284,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 201.4,
-        "Fallzahl_aktiv": 2473,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 278,
         "Krh_I_belegt": 31,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 310,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.43,
+        "H_Inzidenz": 1.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.06.2022"
@@ -31644,8 +31644,8 @@
         "Fallzahl": 213952,
         "ObjectId": 826,
         "Sterbefall": 1722,
-        "Genesungsfall": 209599,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 209604,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5615,
         "Zuwachs_Fallzahl": 311,
         "Zuwachs_Sterbefall": 0,
@@ -31654,11 +31654,11 @@
         "BelegteBetten": null,
         "Inzidenz": 278.027227989511,
         "Datum_neu": 1654819200000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "03.06.2022 - 09.06.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 303,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 233.5,
-        "Fallzahl_aktiv": 2631,
+        "Fallzahl_aktiv": 2626,
         "Krh_N_belegt": 278,
         "Krh_I_belegt": 31,
         "Krh_I_frei": null,
@@ -31670,11 +31670,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
-        "H_Zeitraum": "03.06.2022 - 09.06.2022",
-        "H_Datum": "09.06.2022",
+        "H_Inzidenz": 1.58,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.06.2022",
+        "Fallzahl": 214376,
+        "ObjectId": 827,
+        "Sterbefall": null,
+        "Genesungsfall": 209653,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 49,
+        "BelegteBetten": null,
+        "Inzidenz": 319.156578900104,
+        "Datum_neu": 1654905600000,
+        "F\u00e4lle_Meldedatum": 78,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 254.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 278,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.33,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "10.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.06.2022",
+        "Fallzahl": 214400,
+        "ObjectId": 828,
+        "Sterbefall": null,
+        "Genesungsfall": 209701,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 48,
+        "BelegteBetten": null,
+        "Inzidenz": 307.123100686088,
+        "Datum_neu": 1654992000000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 228.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 278,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.08,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.06.2022",
+        "Fallzahl": 214416,
+        "ObjectId": 829,
+        "Sterbefall": 1725,
+        "Genesungsfall": 209967,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5625,
+        "Zuwachs_Fallzahl": 464,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 266,
+        "BelegteBetten": null,
+        "Inzidenz": 300.298142893064,
+        "Datum_neu": 1655078400000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "06.06.2022 - 12.06.2022",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 217.7,
+        "Fallzahl_aktiv": 2724,
+        "Krh_N_belegt": 278,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 195,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 0.94,
+        "H_Zeitraum": "06.06.2022 - 12.06.2022",
+        "H_Datum": "09.06.2022",
+        "Datum_Bett": "12.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
