### PR TITLE
New data set: 2022-06-14T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-13T103103Z.json
+pjson/2022-06-14T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-13T103103Z.json pjson/2022-06-14T100403Z.json```:
```
--- pjson/2022-06-13T103103Z.json	2022-06-13 10:31:04.061909466 +0000
+++ pjson/2022-06-14T100403Z.json	2022-06-14 10:04:04.043275036 +0000
@@ -29754,7 +29754,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650499200000,
-        "F\u00e4lle_Meldedatum": 805,
+        "F\u00e4lle_Meldedatum": 806,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -30776,7 +30776,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 334,
+        "Zuwachs_Genesung": 331,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652832000000,
@@ -31080,7 +31080,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 254,
+        "Zuwachs_Genesung": 253,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653523200000,
@@ -31118,7 +31118,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 228,
+        "Zuwachs_Genesung": 229,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653609600000,
@@ -31194,7 +31194,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 105,
+        "Zuwachs_Genesung": 104,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653782400000,
@@ -31274,7 +31274,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653955200000,
-        "F\u00e4lle_Meldedatum": 245,
+        "F\u00e4lle_Meldedatum": 246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -31308,11 +31308,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 206,
+        "Zuwachs_Genesung": 205,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654041600000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -31346,11 +31346,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 223,
+        "Zuwachs_Genesung": 224,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654128000000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31384,7 +31384,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 175,
+        "Zuwachs_Genesung": 173,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654214400000,
@@ -31498,17 +31498,17 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 248,
+        "Zuwachs_Genesung": 257,
         "BelegteBetten": null,
-        "Inzidenz": 211.034879126405,
+        "Inzidenz": null,
         "Datum_neu": 1654473600000,
         "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 160.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 239,
-        "Krh_I_belegt": 44,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31518,7 +31518,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.06.2022"
@@ -31536,7 +31536,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 162,
+        "Zuwachs_Genesung": 163,
         "BelegteBetten": null,
         "Inzidenz": 177.987715075973,
         "Datum_neu": 1654560000000,
@@ -31556,7 +31556,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": 1.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.06.2022"
@@ -31574,13 +31574,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 136,
+        "Zuwachs_Genesung": 127,
         "BelegteBetten": null,
         "Inzidenz": 217.321024462086,
         "Datum_neu": 1654646400000,
-        "F\u00e4lle_Meldedatum": 399,
+        "F\u00e4lle_Meldedatum": 400,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 139.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 257,
@@ -31594,7 +31594,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.68,
+        "H_Inzidenz": 1.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.06.2022"
@@ -31612,11 +31612,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 68,
+        "Zuwachs_Genesung": 77,
         "BelegteBetten": null,
         "Inzidenz": 257.372750457991,
         "Datum_neu": 1654732800000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 201.4,
@@ -31632,7 +31632,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.6,
+        "H_Inzidenz": 1.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.06.2022"
@@ -31643,34 +31643,34 @@
         "Datum": "10.06.2022",
         "Fallzahl": 213952,
         "ObjectId": 826,
-        "Sterbefall": 1722,
-        "Genesungsfall": 209604,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5615,
-        "Zuwachs_Fallzahl": 311,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
-        "Zuwachs_Genesung": 153,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 154,
         "BelegteBetten": null,
         "Inzidenz": 278.027227989511,
         "Datum_neu": 1654819200000,
-        "F\u00e4lle_Meldedatum": 303,
+        "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 233.5,
-        "Fallzahl_aktiv": 2626,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 278,
         "Krh_I_belegt": 31,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 158,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.58,
+        "H_Inzidenz": 2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.06.2022"
@@ -31682,7 +31682,7 @@
         "Fallzahl": 214376,
         "ObjectId": 827,
         "Sterbefall": null,
-        "Genesungsfall": 209653,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -31692,7 +31692,7 @@
         "BelegteBetten": null,
         "Inzidenz": 319.156578900104,
         "Datum_neu": 1654905600000,
-        "F\u00e4lle_Meldedatum": 78,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 254.5,
@@ -31708,7 +31708,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
+        "H_Inzidenz": 1.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.06.2022"
@@ -31720,7 +31720,7 @@
         "Fallzahl": 214400,
         "ObjectId": 828,
         "Sterbefall": null,
-        "Genesungsfall": 209701,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -31730,9 +31730,9 @@
         "BelegteBetten": null,
         "Inzidenz": 307.123100686088,
         "Datum_neu": 1654992000000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 228.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 278,
@@ -31746,7 +31746,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.08,
+        "H_Inzidenz": 1.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.06.2022"
@@ -31759,7 +31759,7 @@
         "ObjectId": 829,
         "Sterbefall": 1725,
         "Genesungsfall": 209967,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5625,
         "Zuwachs_Fallzahl": 464,
         "Zuwachs_Sterbefall": 3,
@@ -31768,13 +31768,13 @@
         "BelegteBetten": null,
         "Inzidenz": 300.298142893064,
         "Datum_neu": 1655078400000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "06.06.2022 - 12.06.2022",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 426,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 217.7,
         "Fallzahl_aktiv": 2724,
-        "Krh_N_belegt": 278,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": 310,
+        "Krh_I_belegt": 24,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 195,
         "Krh_I": null,
@@ -31784,11 +31784,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 0.94,
-        "H_Zeitraum": "06.06.2022 - 12.06.2022",
-        "H_Datum": "09.06.2022",
+        "H_Inzidenz": 1.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.06.2022",
+        "Fallzahl": 214947,
+        "ObjectId": 830,
+        "Sterbefall": 1725,
+        "Genesungsfall": 210207,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5633,
+        "Zuwachs_Fallzahl": 531,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 240,
+        "BelegteBetten": null,
+        "Inzidenz": 368.547720823305,
+        "Datum_neu": 1655164800000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "07.06.2022 - 13.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 288.6,
+        "Fallzahl_aktiv": 3015,
+        "Krh_N_belegt": 310,
+        "Krh_I_belegt": 24,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 291,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.43,
+        "H_Zeitraum": "07.06.2022 - 13.06.2022",
+        "H_Datum": "13.06.2022",
+        "Datum_Bett": "13.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
