### PR TITLE
New data set: 2022-06-15T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-14T100403Z.json
+pjson/2022-06-15T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-14T100403Z.json pjson/2022-06-15T100103Z.json```:
```
--- pjson/2022-06-14T100403Z.json	2022-06-14 10:04:04.043275036 +0000
+++ pjson/2022-06-15T100103Z.json	2022-06-15 10:01:03.981667230 +0000
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 658,
+        "F\u00e4lle_Meldedatum": 657,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -25878,7 +25878,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641686400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1616,
+        "F\u00e4lle_Meldedatum": 1617,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 953,
+        "F\u00e4lle_Meldedatum": 952,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27360,7 +27360,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645056000000,
-        "F\u00e4lle_Meldedatum": 1162,
+        "F\u00e4lle_Meldedatum": 1163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27626,7 +27626,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645660800000,
-        "F\u00e4lle_Meldedatum": 1199,
+        "F\u00e4lle_Meldedatum": 1200,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 799,
+        "F\u00e4lle_Meldedatum": 798,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -27778,7 +27778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1589,
+        "F\u00e4lle_Meldedatum": 1590,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1363,
+        "F\u00e4lle_Meldedatum": 1364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2044,
+        "F\u00e4lle_Meldedatum": 2045,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2805,
+        "F\u00e4lle_Meldedatum": 2806,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28462,7 +28462,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647561600000,
-        "F\u00e4lle_Meldedatum": 2599,
+        "F\u00e4lle_Meldedatum": 2600,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28766,7 +28766,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648252800000,
-        "F\u00e4lle_Meldedatum": 830,
+        "F\u00e4lle_Meldedatum": 831,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1315,
+        "F\u00e4lle_Meldedatum": 1316,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -29792,7 +29792,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 501,
+        "F\u00e4lle_Meldedatum": 502,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -31538,15 +31538,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 163,
         "BelegteBetten": null,
-        "Inzidenz": 177.987715075973,
+        "Inzidenz": null,
         "Datum_neu": 1654560000000,
-        "F\u00e4lle_Meldedatum": 407,
+        "F\u00e4lle_Meldedatum": 408,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 112.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 257,
-        "Krh_I_belegt": 40,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31556,7 +31556,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.85,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.06.2022"
@@ -31578,7 +31578,7 @@
         "BelegteBetten": null,
         "Inzidenz": 217.321024462086,
         "Datum_neu": 1654646400000,
-        "F\u00e4lle_Meldedatum": 400,
+        "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 139.3,
@@ -31594,7 +31594,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.9,
+        "H_Inzidenz": 1.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.06.2022"
@@ -31632,7 +31632,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": 2.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.06.2022"
@@ -31654,7 +31654,7 @@
         "BelegteBetten": null,
         "Inzidenz": 278.027227989511,
         "Datum_neu": 1654819200000,
-        "F\u00e4lle_Meldedatum": 307,
+        "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 233.5,
@@ -31670,7 +31670,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2,
+        "H_Inzidenz": 2.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.06.2022"
@@ -31692,7 +31692,7 @@
         "BelegteBetten": null,
         "Inzidenz": 319.156578900104,
         "Datum_neu": 1654905600000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 254.5,
@@ -31708,7 +31708,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": 1.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.06.2022"
@@ -31730,7 +31730,7 @@
         "BelegteBetten": null,
         "Inzidenz": 307.123100686088,
         "Datum_neu": 1654992000000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 228.9,
@@ -31746,7 +31746,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.73,
+        "H_Inzidenz": 1.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.06.2022"
@@ -31757,34 +31757,34 @@
         "Datum": "13.06.2022",
         "Fallzahl": 214416,
         "ObjectId": 829,
-        "Sterbefall": 1725,
-        "Genesungsfall": 209967,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5625,
-        "Zuwachs_Fallzahl": 464,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 266,
         "BelegteBetten": null,
         "Inzidenz": 300.298142893064,
         "Datum_neu": 1655078400000,
-        "F\u00e4lle_Meldedatum": 426,
+        "F\u00e4lle_Meldedatum": 498,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 217.7,
-        "Fallzahl_aktiv": 2724,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 310,
         "Krh_I_belegt": 24,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 195,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.6,
+        "H_Inzidenz": 1.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.06.2022"
@@ -31797,7 +31797,7 @@
         "ObjectId": 830,
         "Sterbefall": 1725,
         "Genesungsfall": 210207,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5633,
         "Zuwachs_Fallzahl": 531,
         "Zuwachs_Sterbefall": 0,
@@ -31806,9 +31806,9 @@
         "BelegteBetten": null,
         "Inzidenz": 368.547720823305,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 25,
-        "Zeitraum": "07.06.2022 - 13.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 454,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 288.6,
         "Fallzahl_aktiv": 3015,
         "Krh_N_belegt": 310,
@@ -31822,11 +31822,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.43,
-        "H_Zeitraum": "07.06.2022 - 13.06.2022",
-        "H_Datum": "13.06.2022",
+        "H_Inzidenz": 1.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.06.2022",
+        "Fallzahl": 215494,
+        "ObjectId": 831,
+        "Sterbefall": 1725,
+        "Genesungsfall": 210393,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5636,
+        "Zuwachs_Fallzahl": 547,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 186,
+        "BelegteBetten": null,
+        "Inzidenz": 394.769927080714,
+        "Datum_neu": 1655251200000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "08.06.2022 - 14.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 321.1,
+        "Fallzahl_aktiv": 3376,
+        "Krh_N_belegt": 310,
+        "Krh_I_belegt": 24,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 361,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.33,
+        "H_Zeitraum": "08.06.2022 - 14.06.2022",
+        "H_Datum": "13.06.2022",
+        "Datum_Bett": "14.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
