### PR TITLE
New data set: 2022-06-16T104703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-15T100103Z.json
+pjson/2022-06-16T104703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-15T100103Z.json pjson/2022-06-16T104703Z.json```:
```
--- pjson/2022-06-15T100103Z.json	2022-06-15 10:01:03.981667230 +0000
+++ pjson/2022-06-16T104703Z.json	2022-06-16 10:47:03.318315989 +0000
@@ -24434,7 +24434,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638403200000,
-        "F\u00e4lle_Meldedatum": 883,
+        "F\u00e4lle_Meldedatum": 882,
         "Zeitraum": null,
         "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
@@ -31466,7 +31466,7 @@
         "Datum_neu": 1654387200000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31576,15 +31576,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 127,
         "BelegteBetten": null,
-        "Inzidenz": 217.321024462086,
+        "Inzidenz": null,
         "Datum_neu": 1654646400000,
         "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 139.3,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 257,
-        "Krh_I_belegt": 40,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31594,7 +31594,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.06.2022"
@@ -31616,7 +31616,7 @@
         "BelegteBetten": null,
         "Inzidenz": 257.372750457991,
         "Datum_neu": 1654732800000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 201.4,
@@ -31656,7 +31656,7 @@
         "Datum_neu": 1654819200000,
         "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 233.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 278,
@@ -31708,7 +31708,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.05,
+        "H_Inzidenz": 2.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.06.2022"
@@ -31746,7 +31746,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.8,
+        "H_Inzidenz": 1.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.06.2022"
@@ -31768,7 +31768,7 @@
         "BelegteBetten": null,
         "Inzidenz": 300.298142893064,
         "Datum_neu": 1655078400000,
-        "F\u00e4lle_Meldedatum": 498,
+        "F\u00e4lle_Meldedatum": 508,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 217.7,
@@ -31784,7 +31784,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": 1.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.06.2022"
@@ -31795,34 +31795,34 @@
         "Datum": "14.06.2022",
         "Fallzahl": 214947,
         "ObjectId": 830,
-        "Sterbefall": 1725,
-        "Genesungsfall": 210207,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5633,
-        "Zuwachs_Fallzahl": 531,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 240,
         "BelegteBetten": null,
         "Inzidenz": 368.547720823305,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 510,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 288.6,
-        "Fallzahl_aktiv": 3015,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 310,
         "Krh_I_belegt": 24,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 291,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": 1.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.06.2022"
@@ -31835,7 +31835,7 @@
         "ObjectId": 831,
         "Sterbefall": 1725,
         "Genesungsfall": 210393,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5636,
         "Zuwachs_Fallzahl": 547,
         "Zuwachs_Sterbefall": 0,
@@ -31844,9 +31844,9 @@
         "BelegteBetten": null,
         "Inzidenz": 394.769927080714,
         "Datum_neu": 1655251200000,
-        "F\u00e4lle_Meldedatum": 11,
-        "Zeitraum": "08.06.2022 - 14.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 297,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 321.1,
         "Fallzahl_aktiv": 3376,
         "Krh_N_belegt": 310,
@@ -31860,11 +31860,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
-        "H_Zeitraum": "08.06.2022 - 14.06.2022",
-        "H_Datum": "13.06.2022",
+        "H_Inzidenz": 1.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "14.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.06.2022",
+        "Fallzahl": 215914,
+        "ObjectId": 832,
+        "Sterbefall": 1725,
+        "Genesungsfall": 210614,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5643,
+        "Zuwachs_Fallzahl": 420,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 221,
+        "BelegteBetten": null,
+        "Inzidenz": 387.94496928769,
+        "Datum_neu": 1655337600000,
+        "F\u00e4lle_Meldedatum": 68,
+        "Zeitraum": "09.06.2022 - 15.06.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 324.9,
+        "Fallzahl_aktiv": 3575,
+        "Krh_N_belegt": 310,
+        "Krh_I_belegt": 24,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 199,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.23,
+        "H_Zeitraum": "09.06.2022 - 15.06.2022",
+        "H_Datum": "13.06.2022",
+        "Datum_Bett": "15.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
