### PR TITLE
New data set: 2022-06-17T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-16T104703Z.json
+pjson/2022-06-17T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-16T104703Z.json pjson/2022-06-17T101303Z.json```:
```
--- pjson/2022-06-16T104703Z.json	2022-06-16 10:47:03.318315989 +0000
+++ pjson/2022-06-17T101303Z.json	2022-06-17 10:13:03.993704744 +0000
@@ -23788,7 +23788,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636934400000,
-        "F\u00e4lle_Meldedatum": 1145,
+        "F\u00e4lle_Meldedatum": 1144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -23940,7 +23940,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637280000000,
-        "F\u00e4lle_Meldedatum": 1482,
+        "F\u00e4lle_Meldedatum": 1481,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -23978,7 +23978,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637366400000,
-        "F\u00e4lle_Meldedatum": 906,
+        "F\u00e4lle_Meldedatum": 905,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 770,
+        "F\u00e4lle_Meldedatum": 769,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -31426,7 +31426,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654300800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31614,15 +31614,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 77,
         "BelegteBetten": null,
-        "Inzidenz": 257.372750457991,
+        "Inzidenz": null,
         "Datum_neu": 1654732800000,
         "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 201.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 278,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31632,7 +31632,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.02,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.06.2022"
@@ -31670,7 +31670,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
+        "H_Inzidenz": 2.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.06.2022"
@@ -31708,7 +31708,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
+        "H_Inzidenz": 2.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.06.2022"
@@ -31746,7 +31746,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.82,
+        "H_Inzidenz": 1.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.06.2022"
@@ -31768,7 +31768,7 @@
         "BelegteBetten": null,
         "Inzidenz": 300.298142893064,
         "Datum_neu": 1655078400000,
-        "F\u00e4lle_Meldedatum": 508,
+        "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 217.7,
@@ -31784,7 +31784,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.75,
+        "H_Inzidenz": 1.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.06.2022"
@@ -31806,7 +31806,7 @@
         "BelegteBetten": null,
         "Inzidenz": 368.547720823305,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 510,
+        "F\u00e4lle_Meldedatum": 515,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 288.6,
@@ -31822,7 +31822,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.85,
+        "H_Inzidenz": 2.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.06.2022"
@@ -31833,34 +31833,34 @@
         "Datum": "15.06.2022",
         "Fallzahl": 215494,
         "ObjectId": 831,
-        "Sterbefall": 1725,
-        "Genesungsfall": 210393,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5636,
-        "Zuwachs_Fallzahl": 547,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 186,
         "BelegteBetten": null,
         "Inzidenz": 394.769927080714,
         "Datum_neu": 1655251200000,
-        "F\u00e4lle_Meldedatum": 297,
+        "F\u00e4lle_Meldedatum": 348,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 321.1,
-        "Fallzahl_aktiv": 3376,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 310,
         "Krh_I_belegt": 24,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 361,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.6,
+        "H_Inzidenz": 2.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.06.2022"
@@ -31873,7 +31873,7 @@
         "ObjectId": 832,
         "Sterbefall": 1725,
         "Genesungsfall": 210614,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5643,
         "Zuwachs_Fallzahl": 420,
         "Zuwachs_Sterbefall": 0,
@@ -31882,13 +31882,13 @@
         "BelegteBetten": null,
         "Inzidenz": 387.94496928769,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 68,
-        "Zeitraum": "09.06.2022 - 15.06.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 383,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 324.9,
         "Fallzahl_aktiv": 3575,
-        "Krh_N_belegt": 310,
-        "Krh_I_belegt": 24,
+        "Krh_N_belegt": 291,
+        "Krh_I_belegt": 31,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 199,
         "Krh_I": null,
@@ -31898,11 +31898,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.23,
-        "H_Zeitraum": "09.06.2022 - 15.06.2022",
-        "H_Datum": "13.06.2022",
+        "H_Inzidenz": 1.73,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.06.2022",
+        "Fallzahl": 216332,
+        "ObjectId": 833,
+        "Sterbefall": 1725,
+        "Genesungsfall": 210746,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5647,
+        "Zuwachs_Fallzahl": 418,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 132,
+        "BelegteBetten": null,
+        "Inzidenz": 408.419842666762,
+        "Datum_neu": 1655424000000,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": "10.06.2022 - 16.06.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 350.9,
+        "Fallzahl_aktiv": 3861,
+        "Krh_N_belegt": 291,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 286,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.41,
+        "H_Zeitraum": "10.06.2022 - 16.06.2022",
+        "H_Datum": "16.06.2022",
+        "Datum_Bett": "16.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
