### PR TITLE
New data set: 2022-06-20T100703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-17T101303Z.json
+pjson/2022-06-20T100703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-17T101303Z.json pjson/2022-06-20T100703Z.json```:
```
--- pjson/2022-06-17T101303Z.json	2022-06-17 10:13:03.993704744 +0000
+++ pjson/2022-06-20T100703Z.json	2022-06-20 10:07:03.176344999 +0000
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1364,
+        "F\u00e4lle_Meldedatum": 1365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2045,
+        "F\u00e4lle_Meldedatum": 2046,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2084,
+        "F\u00e4lle_Meldedatum": 2085,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -29792,7 +29792,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650585600000,
-        "F\u00e4lle_Meldedatum": 502,
+        "F\u00e4lle_Meldedatum": 503,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -31314,7 +31314,7 @@
         "Datum_neu": 1654041600000,
         "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31580,7 +31580,7 @@
         "Datum_neu": 1654646400000,
         "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31616,7 +31616,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654732800000,
-        "F\u00e4lle_Meldedatum": 326,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31652,15 +31652,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 154,
         "BelegteBetten": null,
-        "Inzidenz": 278.027227989511,
+        "Inzidenz": null,
         "Datum_neu": 1654819200000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 233.5,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 278,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31670,7 +31670,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.17,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.06.2022"
@@ -31690,15 +31690,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
-        "Inzidenz": 319.156578900104,
+        "Inzidenz": null,
         "Datum_neu": 1654905600000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 254.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 278,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31708,7 +31708,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.14,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.06.2022"
@@ -31726,17 +31726,17 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 48,
+        "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
-        "Inzidenz": 307.123100686088,
+        "Inzidenz": null,
         "Datum_neu": 1654992000000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 228.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 278,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31746,7 +31746,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.06.2022"
@@ -31768,7 +31768,7 @@
         "BelegteBetten": null,
         "Inzidenz": 300.298142893064,
         "Datum_neu": 1655078400000,
-        "F\u00e4lle_Meldedatum": 509,
+        "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 217.7,
@@ -31784,7 +31784,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.87,
+        "H_Inzidenz": 1.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.06.2022"
@@ -31802,11 +31802,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 240,
+        "Zuwachs_Genesung": 245,
         "BelegteBetten": null,
         "Inzidenz": 368.547720823305,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 515,
+        "F\u00e4lle_Meldedatum": 526,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 288.6,
@@ -31822,7 +31822,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
+        "H_Inzidenz": 2.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.06.2022"
@@ -31840,13 +31840,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 186,
+        "Zuwachs_Genesung": 187,
         "BelegteBetten": null,
         "Inzidenz": 394.769927080714,
         "Datum_neu": 1655251200000,
-        "F\u00e4lle_Meldedatum": 348,
+        "F\u00e4lle_Meldedatum": 363,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 321.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 310,
@@ -31860,7 +31860,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.02,
+        "H_Inzidenz": 2.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.06.2022"
@@ -31871,34 +31871,34 @@
         "Datum": "16.06.2022",
         "Fallzahl": 215914,
         "ObjectId": 832,
-        "Sterbefall": 1725,
-        "Genesungsfall": 210614,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5643,
-        "Zuwachs_Fallzahl": 420,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 221,
         "BelegteBetten": null,
         "Inzidenz": 387.94496928769,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 383,
+        "F\u00e4lle_Meldedatum": 440,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 324.9,
-        "Fallzahl_aktiv": 3575,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 291,
         "Krh_I_belegt": 31,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 199,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.73,
+        "H_Inzidenz": 1.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.06.2022"
@@ -31911,7 +31911,7 @@
         "ObjectId": 833,
         "Sterbefall": 1725,
         "Genesungsfall": 210746,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5647,
         "Zuwachs_Fallzahl": 418,
         "Zuwachs_Sterbefall": 0,
@@ -31920,9 +31920,9 @@
         "BelegteBetten": null,
         "Inzidenz": 408.419842666762,
         "Datum_neu": 1655424000000,
-        "F\u00e4lle_Meldedatum": 49,
-        "Zeitraum": "10.06.2022 - 16.06.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 362,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 350.9,
         "Fallzahl_aktiv": 3861,
         "Krh_N_belegt": 291,
@@ -31936,11 +31936,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.41,
-        "H_Zeitraum": "10.06.2022 - 16.06.2022",
-        "H_Datum": "16.06.2022",
+        "H_Inzidenz": 1.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.06.2022",
+        "Fallzahl": 216895,
+        "ObjectId": 834,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 146,
+        "BelegteBetten": null,
+        "Inzidenz": 437.336111210891,
+        "Datum_neu": 1655510400000,
+        "F\u00e4lle_Meldedatum": 138,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 356.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 291,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.43,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.06.2022",
+        "Fallzahl": 216997,
+        "ObjectId": 835,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 68,
+        "BelegteBetten": null,
+        "Inzidenz": 439.670965192715,
+        "Datum_neu": 1655596800000,
+        "F\u00e4lle_Meldedatum": 102,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 334.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 291,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.38,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.06.2022",
+        "Fallzahl": 217006,
+        "ObjectId": 836,
+        "Sterbefall": 1725,
+        "Genesungsfall": 211103,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5652,
+        "Zuwachs_Fallzahl": 674,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 136,
+        "BelegteBetten": null,
+        "Inzidenz": 441.826215022091,
+        "Datum_neu": 1655683200000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "13.06.2022 - 19.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 318.9,
+        "Fallzahl_aktiv": 4178,
+        "Krh_N_belegt": 291,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 538,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.26,
+        "H_Zeitraum": "13.06.2022 - 19.06.2022",
+        "H_Datum": "16.06.2022",
+        "Datum_Bett": "19.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
