### PR TITLE
New data set: 2022-06-21T101404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-20T100703Z.json
+pjson/2022-06-21T101404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-20T100703Z.json pjson/2022-06-21T101404Z.json```:
```
--- pjson/2022-06-20T100703Z.json	2022-06-20 10:07:03.176344999 +0000
+++ pjson/2022-06-21T101404Z.json	2022-06-21 10:14:04.808401065 +0000
@@ -31362,7 +31362,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31616,7 +31616,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654732800000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31654,7 +31654,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654819200000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31692,7 +31692,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654905600000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -31730,7 +31730,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654992000000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -31766,15 +31766,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 266,
         "BelegteBetten": null,
-        "Inzidenz": 300.298142893064,
+        "Inzidenz": null,
         "Datum_neu": 1655078400000,
         "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 217.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 310,
-        "Krh_I_belegt": 24,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31784,7 +31784,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.9,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.06.2022"
@@ -31806,7 +31806,7 @@
         "BelegteBetten": null,
         "Inzidenz": 368.547720823305,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 526,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 288.6,
@@ -31822,7 +31822,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
+        "H_Inzidenz": 2.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.06.2022"
@@ -31844,7 +31844,7 @@
         "BelegteBetten": null,
         "Inzidenz": 394.769927080714,
         "Datum_neu": 1655251200000,
-        "F\u00e4lle_Meldedatum": 363,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 321.1,
@@ -31860,7 +31860,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.1,
+        "H_Inzidenz": 2.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.06.2022"
@@ -31882,7 +31882,7 @@
         "BelegteBetten": null,
         "Inzidenz": 387.94496928769,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 440,
+        "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 324.9,
@@ -31898,7 +31898,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.82,
+        "H_Inzidenz": 2.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.06.2022"
@@ -31909,34 +31909,34 @@
         "Datum": "17.06.2022",
         "Fallzahl": 216332,
         "ObjectId": 833,
-        "Sterbefall": 1725,
-        "Genesungsfall": 210746,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5647,
-        "Zuwachs_Fallzahl": 418,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
         "Inzidenz": 408.419842666762,
         "Datum_neu": 1655424000000,
-        "F\u00e4lle_Meldedatum": 362,
+        "F\u00e4lle_Meldedatum": 382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 350.9,
-        "Fallzahl_aktiv": 3861,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 291,
         "Krh_I_belegt": 31,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 286,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.6,
+        "H_Inzidenz": 2.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.06.2022"
@@ -31958,7 +31958,7 @@
         "BelegteBetten": null,
         "Inzidenz": 437.336111210891,
         "Datum_neu": 1655510400000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 200,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 356.7,
@@ -31974,7 +31974,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.43,
+        "H_Inzidenz": 1.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.06.2022"
@@ -31996,9 +31996,9 @@
         "BelegteBetten": null,
         "Inzidenz": 439.670965192715,
         "Datum_neu": 1655596800000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 334.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 291,
@@ -32012,7 +32012,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.38,
+        "H_Inzidenz": 1.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.06.2022"
@@ -32025,7 +32025,7 @@
         "ObjectId": 836,
         "Sterbefall": 1725,
         "Genesungsfall": 211103,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5652,
         "Zuwachs_Fallzahl": 674,
         "Zuwachs_Sterbefall": 0,
@@ -32034,13 +32034,13 @@
         "BelegteBetten": null,
         "Inzidenz": 441.826215022091,
         "Datum_neu": 1655683200000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "13.06.2022 - 19.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 565,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 318.9,
         "Fallzahl_aktiv": 4178,
-        "Krh_N_belegt": 291,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": 308,
+        "Krh_I_belegt": 40,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 538,
         "Krh_I": null,
@@ -32050,11 +32050,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.26,
-        "H_Zeitraum": "13.06.2022 - 19.06.2022",
-        "H_Datum": "16.06.2022",
+        "H_Inzidenz": 1.9,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.06.2022",
+        "Fallzahl": 217780,
+        "ObjectId": 837,
+        "Sterbefall": 1726,
+        "Genesungsfall": 211507,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5657,
+        "Zuwachs_Fallzahl": 774,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 404,
+        "BelegteBetten": null,
+        "Inzidenz": 470.562879413772,
+        "Datum_neu": 1655769600000,
+        "F\u00e4lle_Meldedatum": 94,
+        "Zeitraum": "14.06.2022 - 20.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 338,
+        "Fallzahl_aktiv": 4547,
+        "Krh_N_belegt": 308,
+        "Krh_I_belegt": 40,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 369,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.53,
+        "H_Zeitraum": "14.06.2022 - 20.06.2022",
+        "H_Datum": "20.06.2022",
+        "Datum_Bett": "20.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
