### PR TITLE
New data set: 2022-06-22T103402Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-21T101404Z.json
+pjson/2022-06-22T103402Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-21T101404Z.json pjson/2022-06-22T103402Z.json```:
```
--- pjson/2022-06-21T101404Z.json	2022-06-21 10:14:04.808401065 +0000
+++ pjson/2022-06-22T103402Z.json	2022-06-22 10:34:02.822884563 +0000
@@ -31540,7 +31540,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654560000000,
-        "F\u00e4lle_Meldedatum": 408,
+        "F\u00e4lle_Meldedatum": 407,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31804,15 +31804,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 245,
         "BelegteBetten": null,
-        "Inzidenz": 368.547720823305,
+        "Inzidenz": null,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 288.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 310,
-        "Krh_I_belegt": 24,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31822,7 +31822,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.17,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.06.2022"
@@ -31844,7 +31844,7 @@
         "BelegteBetten": null,
         "Inzidenz": 394.769927080714,
         "Datum_neu": 1655251200000,
-        "F\u00e4lle_Meldedatum": 365,
+        "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 321.1,
@@ -31860,7 +31860,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.32,
+        "H_Inzidenz": 2.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.06.2022"
@@ -31882,7 +31882,7 @@
         "BelegteBetten": null,
         "Inzidenz": 387.94496928769,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 453,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 324.9,
@@ -31898,7 +31898,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.1,
+        "H_Inzidenz": 2.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.06.2022"
@@ -31920,7 +31920,7 @@
         "BelegteBetten": null,
         "Inzidenz": 408.419842666762,
         "Datum_neu": 1655424000000,
-        "F\u00e4lle_Meldedatum": 382,
+        "F\u00e4lle_Meldedatum": 383,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 350.9,
@@ -31936,7 +31936,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
+        "H_Inzidenz": 2.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.06.2022"
@@ -31958,7 +31958,7 @@
         "BelegteBetten": null,
         "Inzidenz": 437.336111210891,
         "Datum_neu": 1655510400000,
-        "F\u00e4lle_Meldedatum": 200,
+        "F\u00e4lle_Meldedatum": 214,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 356.7,
@@ -31974,7 +31974,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": 2.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.06.2022"
@@ -31996,7 +31996,7 @@
         "BelegteBetten": null,
         "Inzidenz": 439.670965192715,
         "Datum_neu": 1655596800000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 166,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 334.6,
@@ -32012,7 +32012,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.97,
+        "H_Inzidenz": 2.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.06.2022"
@@ -32023,34 +32023,34 @@
         "Datum": "20.06.2022",
         "Fallzahl": 217006,
         "ObjectId": 836,
-        "Sterbefall": 1725,
-        "Genesungsfall": 211103,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5652,
-        "Zuwachs_Fallzahl": 674,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 136,
         "BelegteBetten": null,
         "Inzidenz": 441.826215022091,
         "Datum_neu": 1655683200000,
-        "F\u00e4lle_Meldedatum": 565,
+        "F\u00e4lle_Meldedatum": 684,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 318.9,
-        "Fallzahl_aktiv": 4178,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 308,
         "Krh_I_belegt": 40,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 538,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.9,
+        "H_Inzidenz": 2.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.06.2022"
@@ -32063,7 +32063,7 @@
         "ObjectId": 837,
         "Sterbefall": 1726,
         "Genesungsfall": 211507,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5657,
         "Zuwachs_Fallzahl": 774,
         "Zuwachs_Sterbefall": 1,
@@ -32072,9 +32072,9 @@
         "BelegteBetten": null,
         "Inzidenz": 470.562879413772,
         "Datum_neu": 1655769600000,
-        "F\u00e4lle_Meldedatum": 94,
-        "Zeitraum": "14.06.2022 - 20.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 530,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 338,
         "Fallzahl_aktiv": 4547,
         "Krh_N_belegt": 308,
@@ -32088,11 +32088,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.53,
-        "H_Zeitraum": "14.06.2022 - 20.06.2022",
-        "H_Datum": "20.06.2022",
+        "H_Inzidenz": 2.24,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.06.2022",
+        "Fallzahl": 218492,
+        "ObjectId": 838,
+        "Sterbefall": 1726,
+        "Genesungsfall": 211908,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5661,
+        "Zuwachs_Fallzahl": 712,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 401,
+        "BelegteBetten": null,
+        "Inzidenz": 502.352814397069,
+        "Datum_neu": 1655856000000,
+        "F\u00e4lle_Meldedatum": 102,
+        "Zeitraum": "15.06.2022 - 21.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 423,
+        "Fallzahl_aktiv": 4858,
+        "Krh_N_belegt": 308,
+        "Krh_I_belegt": 40,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 311,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.65,
+        "H_Zeitraum": "15.06.2022 - 21.06.2022",
+        "H_Datum": "20.06.2022",
+        "Datum_Bett": "21.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
