### PR TITLE
New data set: 2022-06-23T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-22T103402Z.json
+pjson/2022-06-23T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-22T103402Z.json pjson/2022-06-23T100503Z.json```:
```
--- pjson/2022-06-22T103402Z.json	2022-06-22 10:34:02.822884563 +0000
+++ pjson/2022-06-23T100503Z.json	2022-06-23 10:05:03.875874614 +0000
@@ -29830,7 +29830,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650672000000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -31426,7 +31426,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654300800000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31628,7 +31628,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31768,7 +31768,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655078400000,
-        "F\u00e4lle_Meldedatum": 529,
+        "F\u00e4lle_Meldedatum": 530,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -31806,7 +31806,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -31842,15 +31842,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 187,
         "BelegteBetten": null,
-        "Inzidenz": 394.769927080714,
+        "Inzidenz": null,
         "Datum_neu": 1655251200000,
-        "F\u00e4lle_Meldedatum": 366,
+        "F\u00e4lle_Meldedatum": 367,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 321.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 310,
-        "Krh_I_belegt": 24,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31860,7 +31860,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.06.2022"
@@ -31882,7 +31882,7 @@
         "BelegteBetten": null,
         "Inzidenz": 387.94496928769,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 452,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 324.9,
@@ -31936,7 +31936,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.12,
+        "H_Inzidenz": 2.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.06.2022"
@@ -31958,7 +31958,7 @@
         "BelegteBetten": null,
         "Inzidenz": 437.336111210891,
         "Datum_neu": 1655510400000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 356.7,
@@ -31974,7 +31974,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.07,
+        "H_Inzidenz": 2.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.06.2022"
@@ -31996,7 +31996,7 @@
         "BelegteBetten": null,
         "Inzidenz": 439.670965192715,
         "Datum_neu": 1655596800000,
-        "F\u00e4lle_Meldedatum": 166,
+        "F\u00e4lle_Meldedatum": 167,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 334.6,
@@ -32012,7 +32012,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.14,
+        "H_Inzidenz": 2.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.06.2022"
@@ -32034,7 +32034,7 @@
         "BelegteBetten": null,
         "Inzidenz": 441.826215022091,
         "Datum_neu": 1655683200000,
-        "F\u00e4lle_Meldedatum": 684,
+        "F\u00e4lle_Meldedatum": 696,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 318.9,
@@ -32050,7 +32050,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.1,
+        "H_Inzidenz": 2.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.06.2022"
@@ -32061,34 +32061,34 @@
         "Datum": "21.06.2022",
         "Fallzahl": 217780,
         "ObjectId": 837,
-        "Sterbefall": 1726,
-        "Genesungsfall": 211507,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5657,
-        "Zuwachs_Fallzahl": 774,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 404,
         "BelegteBetten": null,
         "Inzidenz": 470.562879413772,
         "Datum_neu": 1655769600000,
-        "F\u00e4lle_Meldedatum": 530,
+        "F\u00e4lle_Meldedatum": 581,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 338,
-        "Fallzahl_aktiv": 4547,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 308,
         "Krh_I_belegt": 40,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 369,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.24,
+        "H_Inzidenz": 2.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.06.2022"
@@ -32101,7 +32101,7 @@
         "ObjectId": 838,
         "Sterbefall": 1726,
         "Genesungsfall": 211908,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5661,
         "Zuwachs_Fallzahl": 712,
         "Zuwachs_Sterbefall": 0,
@@ -32110,8 +32110,8 @@
         "BelegteBetten": null,
         "Inzidenz": 502.352814397069,
         "Datum_neu": 1655856000000,
-        "F\u00e4lle_Meldedatum": 102,
-        "Zeitraum": "15.06.2022 - 21.06.2022",
+        "F\u00e4lle_Meldedatum": 507,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 423,
         "Fallzahl_aktiv": 4858,
@@ -32126,10 +32126,48 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.85,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.06.2022",
+        "Fallzahl": 219015,
+        "ObjectId": 839,
+        "Sterbefall": 1728,
+        "Genesungsfall": 212229,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5661,
+        "Zuwachs_Fallzahl": 523,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 321,
+        "BelegteBetten": null,
+        "Inzidenz": 538.992061496462,
+        "Datum_neu": 1655942400000,
+        "F\u00e4lle_Meldedatum": 54,
+        "Zeitraum": "16.06.2022 - 22.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 470.7,
+        "Fallzahl_aktiv": 5058,
+        "Krh_N_belegt": 308,
+        "Krh_I_belegt": 40,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 200,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.65,
-        "H_Zeitraum": "15.06.2022 - 21.06.2022",
+        "H_Zeitraum": "16.06.2022 - 22.06.2022",
         "H_Datum": "20.06.2022",
-        "Datum_Bett": "21.06.2022"
+        "Datum_Bett": "22.06.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
