### PR TITLE
New data set: 2022-06-24T101704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-23T100503Z.json
+pjson/2022-06-24T101704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-23T100503Z.json pjson/2022-06-24T101704Z.json```:
```
--- pjson/2022-06-23T100503Z.json	2022-06-23 10:05:03.875874614 +0000
+++ pjson/2022-06-24T101704Z.json	2022-06-24 10:17:04.270165562 +0000
@@ -31314,7 +31314,7 @@
         "Datum_neu": 1654041600000,
         "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31542,7 +31542,7 @@
         "Datum_neu": 1654560000000,
         "F\u00e4lle_Meldedatum": 407,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31618,7 +31618,7 @@
         "Datum_neu": 1654732800000,
         "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31770,7 +31770,7 @@
         "Datum_neu": 1655078400000,
         "F\u00e4lle_Meldedatum": 530,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31844,9 +31844,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655251200000,
-        "F\u00e4lle_Meldedatum": 367,
+        "F\u00e4lle_Meldedatum": 368,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31880,15 +31880,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 221,
         "BelegteBetten": null,
-        "Inzidenz": 387.94496928769,
+        "Inzidenz": null,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 452,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 324.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 291,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31898,7 +31898,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.12,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.06.2022"
@@ -31920,7 +31920,7 @@
         "BelegteBetten": null,
         "Inzidenz": 408.419842666762,
         "Datum_neu": 1655424000000,
-        "F\u00e4lle_Meldedatum": 383,
+        "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 350.9,
@@ -31936,7 +31936,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.14,
+        "H_Inzidenz": 2.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.06.2022"
@@ -31974,7 +31974,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.1,
+        "H_Inzidenz": 2.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.06.2022"
@@ -31996,7 +31996,7 @@
         "BelegteBetten": null,
         "Inzidenz": 439.670965192715,
         "Datum_neu": 1655596800000,
-        "F\u00e4lle_Meldedatum": 167,
+        "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 334.6,
@@ -32012,7 +32012,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.19,
+        "H_Inzidenz": 2.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.06.2022"
@@ -32034,7 +32034,7 @@
         "BelegteBetten": null,
         "Inzidenz": 441.826215022091,
         "Datum_neu": 1655683200000,
-        "F\u00e4lle_Meldedatum": 696,
+        "F\u00e4lle_Meldedatum": 697,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 318.9,
@@ -32050,7 +32050,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.17,
+        "H_Inzidenz": 2.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.06.2022"
@@ -32072,7 +32072,7 @@
         "BelegteBetten": null,
         "Inzidenz": 470.562879413772,
         "Datum_neu": 1655769600000,
-        "F\u00e4lle_Meldedatum": 581,
+        "F\u00e4lle_Meldedatum": 586,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 338,
@@ -32088,7 +32088,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.37,
+        "H_Inzidenz": 2.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.06.2022"
@@ -32099,34 +32099,34 @@
         "Datum": "22.06.2022",
         "Fallzahl": 218492,
         "ObjectId": 838,
-        "Sterbefall": 1726,
-        "Genesungsfall": 211908,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5661,
-        "Zuwachs_Fallzahl": 712,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 401,
         "BelegteBetten": null,
         "Inzidenz": 502.352814397069,
         "Datum_neu": 1655856000000,
-        "F\u00e4lle_Meldedatum": 507,
+        "F\u00e4lle_Meldedatum": 555,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 423,
-        "Fallzahl_aktiv": 4858,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 308,
         "Krh_I_belegt": 40,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 311,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.85,
+        "H_Inzidenz": 2.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.06.2022"
@@ -32139,7 +32139,7 @@
         "ObjectId": 839,
         "Sterbefall": 1728,
         "Genesungsfall": 212229,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5661,
         "Zuwachs_Fallzahl": 523,
         "Zuwachs_Sterbefall": 2,
@@ -32148,13 +32148,13 @@
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1655942400000,
-        "F\u00e4lle_Meldedatum": 54,
-        "Zeitraum": "16.06.2022 - 22.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 453,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 470.7,
         "Fallzahl_aktiv": 5058,
-        "Krh_N_belegt": 308,
-        "Krh_I_belegt": 40,
+        "Krh_N_belegt": 336,
+        "Krh_I_belegt": 35,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 200,
         "Krh_I": null,
@@ -32164,11 +32164,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.65,
-        "H_Zeitraum": "16.06.2022 - 22.06.2022",
-        "H_Datum": "20.06.2022",
+        "H_Inzidenz": 2.19,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.06.2022",
+        "Fallzahl": 219515,
+        "ObjectId": 840,
+        "Sterbefall": 1728,
+        "Genesungsfall": 212539,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5676,
+        "Zuwachs_Fallzahl": 500,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 310,
+        "BelegteBetten": null,
+        "Inzidenz": 549.229498185998,
+        "Datum_neu": 1656028800000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "17.06.2022 - 23.06.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 485.1,
+        "Fallzahl_aktiv": 5248,
+        "Krh_N_belegt": 336,
+        "Krh_I_belegt": 35,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 190,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.82,
+        "H_Zeitraum": "17.06.2022 - 23.06.2022",
+        "H_Datum": "23.06.2022",
+        "Datum_Bett": "23.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
