### PR TITLE
New data set: 2022-06-27T101004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-24T101704Z.json
+pjson/2022-06-27T101004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-24T101704Z.json pjson/2022-06-27T101004Z.json```:
```
--- pjson/2022-06-24T101704Z.json	2022-06-24 10:17:04.270165562 +0000
+++ pjson/2022-06-27T101004Z.json	2022-06-27 10:10:04.549994220 +0000
@@ -31894,7 +31894,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -31918,15 +31918,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
-        "Inzidenz": 408.419842666762,
+        "Inzidenz": null,
         "Datum_neu": 1655424000000,
         "F\u00e4lle_Meldedatum": 384,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 350.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 291,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31936,7 +31936,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.22,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.06.2022"
@@ -31956,15 +31956,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 146,
         "BelegteBetten": null,
-        "Inzidenz": 437.336111210891,
+        "Inzidenz": null,
         "Datum_neu": 1655510400000,
         "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 356.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 291,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -31974,7 +31974,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.32,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.06.2022"
@@ -31994,15 +31994,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
-        "Inzidenz": 439.670965192715,
+        "Inzidenz": null,
         "Datum_neu": 1655596800000,
-        "F\u00e4lle_Meldedatum": 168,
+        "F\u00e4lle_Meldedatum": 169,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 334.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 291,
-        "Krh_I_belegt": 31,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32012,7 +32012,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.44,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.06.2022"
@@ -32034,7 +32034,7 @@
         "BelegteBetten": null,
         "Inzidenz": 441.826215022091,
         "Datum_neu": 1655683200000,
-        "F\u00e4lle_Meldedatum": 697,
+        "F\u00e4lle_Meldedatum": 699,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 318.9,
@@ -32050,7 +32050,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.44,
+        "H_Inzidenz": 2.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.06.2022"
@@ -32072,7 +32072,7 @@
         "BelegteBetten": null,
         "Inzidenz": 470.562879413772,
         "Datum_neu": 1655769600000,
-        "F\u00e4lle_Meldedatum": 586,
+        "F\u00e4lle_Meldedatum": 587,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 338,
@@ -32088,7 +32088,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.76,
+        "H_Inzidenz": 2.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.06.2022"
@@ -32110,7 +32110,7 @@
         "BelegteBetten": null,
         "Inzidenz": 502.352814397069,
         "Datum_neu": 1655856000000,
-        "F\u00e4lle_Meldedatum": 555,
+        "F\u00e4lle_Meldedatum": 559,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 423,
@@ -32126,7 +32126,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.34,
+        "H_Inzidenz": 2.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.06.2022"
@@ -32148,7 +32148,7 @@
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1655942400000,
-        "F\u00e4lle_Meldedatum": 453,
+        "F\u00e4lle_Meldedatum": 503,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 470.7,
@@ -32164,7 +32164,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.19,
+        "H_Inzidenz": 2.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.06.2022"
@@ -32177,7 +32177,7 @@
         "ObjectId": 840,
         "Sterbefall": 1728,
         "Genesungsfall": 212539,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5676,
         "Zuwachs_Fallzahl": 500,
         "Zuwachs_Sterbefall": 0,
@@ -32186,9 +32186,9 @@
         "BelegteBetten": null,
         "Inzidenz": 549.229498185998,
         "Datum_neu": 1656028800000,
-        "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "17.06.2022 - 23.06.2022",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 439,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 485.1,
         "Fallzahl_aktiv": 5248,
         "Krh_N_belegt": 336,
@@ -32202,10 +32202,124 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.14,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.06.2022",
+        "Fallzahl": 220091,
+        "ObjectId": 841,
+        "Sterbefall": null,
+        "Genesungsfall": 212664,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 125,
+        "BelegteBetten": null,
+        "Inzidenz": 569.524767412623,
+        "Datum_neu": 1656115200000,
+        "F\u00e4lle_Meldedatum": 124,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 486.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 336,
+        "Krh_I_belegt": 35,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
         "H_Inzidenz": 1.82,
-        "H_Zeitraum": "17.06.2022 - 23.06.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "24.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.06.2022",
+        "Fallzahl": 220115,
+        "ObjectId": 842,
+        "Sterbefall": null,
+        "Genesungsfall": 212759,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 95,
+        "BelegteBetten": null,
+        "Inzidenz": 553.180789539854,
+        "Datum_neu": 1656201600000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 447.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 336,
+        "Krh_I_belegt": 35,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.65,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.06.2022",
+        "Fallzahl": 220136,
+        "ObjectId": 843,
+        "Sterbefall": 1729,
+        "Genesungsfall": 213279,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5683,
+        "Zuwachs_Fallzahl": 621,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 520,
+        "BelegteBetten": null,
+        "Inzidenz": 527.138187434893,
+        "Datum_neu": 1656288000000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "20.06.2022 - 26.06.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 417.5,
+        "Fallzahl_aktiv": 5128,
+        "Krh_N_belegt": 336,
+        "Krh_I_belegt": 35,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 100,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.5,
+        "H_Zeitraum": "20.06.2022 - 26.06.2022",
         "H_Datum": "23.06.2022",
-        "Datum_Bett": "23.06.2022"
+        "Datum_Bett": "26.06.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
