### PR TITLE
New data set: 2022-06-28T114903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-27T101004Z.json
+pjson/2022-06-28T114903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-27T101004Z.json pjson/2022-06-28T114903Z.json```:
```
--- pjson/2022-06-27T101004Z.json	2022-06-27 10:10:04.549994220 +0000
+++ pjson/2022-06-28T114903Z.json	2022-06-28 11:49:03.513681686 +0000
@@ -32032,15 +32032,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 136,
         "BelegteBetten": null,
-        "Inzidenz": 441.826215022091,
+        "Inzidenz": null,
         "Datum_neu": 1655683200000,
         "F\u00e4lle_Meldedatum": 699,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 318.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 308,
-        "Krh_I_belegt": 40,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32050,7 +32050,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.06.2022"
@@ -32072,7 +32072,7 @@
         "BelegteBetten": null,
         "Inzidenz": 470.562879413772,
         "Datum_neu": 1655769600000,
-        "F\u00e4lle_Meldedatum": 587,
+        "F\u00e4lle_Meldedatum": 589,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 338,
@@ -32088,7 +32088,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.81,
+        "H_Inzidenz": 3.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.06.2022"
@@ -32110,7 +32110,7 @@
         "BelegteBetten": null,
         "Inzidenz": 502.352814397069,
         "Datum_neu": 1655856000000,
-        "F\u00e4lle_Meldedatum": 559,
+        "F\u00e4lle_Meldedatum": 560,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 423,
@@ -32126,7 +32126,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.42,
+        "H_Inzidenz": 2.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.06.2022"
@@ -32137,34 +32137,34 @@
         "Datum": "23.06.2022",
         "Fallzahl": 219015,
         "ObjectId": 839,
-        "Sterbefall": 1728,
-        "Genesungsfall": 212229,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5661,
-        "Zuwachs_Fallzahl": 523,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 321,
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1655942400000,
-        "F\u00e4lle_Meldedatum": 503,
+        "F\u00e4lle_Meldedatum": 505,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 470.7,
-        "Fallzahl_aktiv": 5058,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 336,
         "Krh_I_belegt": 35,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 200,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.32,
+        "H_Inzidenz": 2.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.06.2022"
@@ -32175,34 +32175,34 @@
         "Datum": "24.06.2022",
         "Fallzahl": 219515,
         "ObjectId": 840,
-        "Sterbefall": 1728,
-        "Genesungsfall": 212539,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5676,
-        "Zuwachs_Fallzahl": 500,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 310,
         "BelegteBetten": null,
         "Inzidenz": 549.229498185998,
         "Datum_neu": 1656028800000,
-        "F\u00e4lle_Meldedatum": 439,
+        "F\u00e4lle_Meldedatum": 482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 485.1,
-        "Fallzahl_aktiv": 5248,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 336,
         "Krh_I_belegt": 35,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 190,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.14,
+        "H_Inzidenz": 2.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.06.2022"
@@ -32214,7 +32214,7 @@
         "Fallzahl": 220091,
         "ObjectId": 841,
         "Sterbefall": null,
-        "Genesungsfall": 212664,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -32222,9 +32222,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 125,
         "BelegteBetten": null,
-        "Inzidenz": 569.524767412623,
+        "Inzidenz": 569.5,
         "Datum_neu": 1656115200000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 486.3,
@@ -32240,7 +32240,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.82,
+        "H_Inzidenz": 2.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.06.2022"
@@ -32252,7 +32252,7 @@
         "Fallzahl": 220115,
         "ObjectId": 842,
         "Sterbefall": null,
-        "Genesungsfall": 212759,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -32260,9 +32260,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 95,
         "BelegteBetten": null,
-        "Inzidenz": 553.180789539854,
+        "Inzidenz": 553.2,
         "Datum_neu": 1656201600000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 447.7,
@@ -32278,7 +32278,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.65,
+        "H_Inzidenz": 2.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.06.2022"
@@ -32291,22 +32291,22 @@
         "ObjectId": 843,
         "Sterbefall": 1729,
         "Genesungsfall": 213279,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5683,
         "Zuwachs_Fallzahl": 621,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 7,
         "Zuwachs_Genesung": 520,
         "BelegteBetten": null,
-        "Inzidenz": 527.138187434893,
+        "Inzidenz": 527.1,
         "Datum_neu": 1656288000000,
-        "F\u00e4lle_Meldedatum": 21,
-        "Zeitraum": "20.06.2022 - 26.06.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 651,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 417.5,
         "Fallzahl_aktiv": 5128,
-        "Krh_N_belegt": 336,
-        "Krh_I_belegt": 35,
+        "Krh_N_belegt": 316,
+        "Krh_I_belegt": 47,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 100,
         "Krh_I": null,
@@ -32316,11 +32316,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.5,
-        "H_Zeitraum": "20.06.2022 - 26.06.2022",
-        "H_Datum": "23.06.2022",
+        "H_Inzidenz": 2.17,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.06.2023",
+        "Fallzahl": 221055,
+        "ObjectId": 844,
+        "Sterbefall": 1729,
+        "Genesungsfall": 213804,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5692,
+        "Zuwachs_Fallzahl": 919,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 525,
+        "BelegteBetten": null,
+        "Inzidenz": 559.646539027982,
+        "Datum_neu": 1687910400000,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": "21.06.2022 - 27.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 441.7,
+        "Fallzahl_aktiv": 5522,
+        "Krh_N_belegt": 316,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 394,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.26,
+        "H_Zeitraum": "21.06.2022 - 27.06.2022",
+        "H_Datum": "27.06.2022",
+        "Datum_Bett": "27.06.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
