### PR TITLE
New data set: 2022-06-29T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-28T114903Z.json
+pjson/2022-06-29T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-28T114903Z.json pjson/2022-06-29T100203Z.json```:
```
--- pjson/2022-06-28T114903Z.json	2022-06-28 11:49:03.513681686 +0000
+++ pjson/2022-06-29T100203Z.json	2022-06-29 10:02:03.997443237 +0000
@@ -30852,7 +30852,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 270,
+        "Zuwachs_Genesung": 271,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653004800000,
@@ -30890,7 +30890,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 119,
+        "Zuwachs_Genesung": 128,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653091200000,
@@ -31042,7 +31042,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 293,
+        "Zuwachs_Genesung": 295,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653436800000,
@@ -31194,7 +31194,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 104,
+        "Zuwachs_Genesung": 105,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653782400000,
@@ -31536,7 +31536,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 163,
+        "Zuwachs_Genesung": 164,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654560000000,
@@ -31574,13 +31574,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 127,
+        "Zuwachs_Genesung": 129,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654646400000,
         "F\u00e4lle_Meldedatum": 402,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31612,7 +31612,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 77,
+        "Zuwachs_Genesung": 75,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654732800000,
@@ -31650,13 +31650,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 154,
+        "Zuwachs_Genesung": 153,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654819200000,
         "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31688,7 +31688,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 49,
+        "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654905600000,
@@ -31840,7 +31840,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 187,
+        "Zuwachs_Genesung": 168,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655251200000,
@@ -31878,7 +31878,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 221,
+        "Zuwachs_Genesung": 220,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655337600000,
@@ -31954,7 +31954,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 146,
+        "Zuwachs_Genesung": 145,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655510400000,
@@ -32034,7 +32034,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655683200000,
-        "F\u00e4lle_Meldedatum": 699,
+        "F\u00e4lle_Meldedatum": 698,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -32068,17 +32068,17 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 404,
+        "Zuwachs_Genesung": 403,
         "BelegteBetten": null,
         "Inzidenz": 470.562879413772,
         "Datum_neu": 1655769600000,
-        "F\u00e4lle_Meldedatum": 589,
+        "F\u00e4lle_Meldedatum": 588,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 338,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 308,
-        "Krh_I_belegt": 40,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32088,7 +32088,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.11,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.06.2022"
@@ -32106,7 +32106,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 401,
+        "Zuwachs_Genesung": 402,
         "BelegteBetten": null,
         "Inzidenz": 502.352814397069,
         "Datum_neu": 1655856000000,
@@ -32126,7 +32126,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.81,
+        "H_Inzidenz": 2.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.06.2022"
@@ -32144,11 +32144,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 321,
+        "Zuwachs_Genesung": 324,
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1655942400000,
-        "F\u00e4lle_Meldedatum": 505,
+        "F\u00e4lle_Meldedatum": 506,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 470.7,
@@ -32164,7 +32164,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": 2.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.06.2022"
@@ -32182,11 +32182,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 310,
+        "Zuwachs_Genesung": 313,
         "BelegteBetten": null,
         "Inzidenz": 549.229498185998,
         "Datum_neu": 1656028800000,
-        "F\u00e4lle_Meldedatum": 482,
+        "F\u00e4lle_Meldedatum": 489,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 485.1,
@@ -32202,7 +32202,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.71,
+        "H_Inzidenz": 2.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.06.2022"
@@ -32224,7 +32224,7 @@
         "BelegteBetten": null,
         "Inzidenz": 569.5,
         "Datum_neu": 1656115200000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 486.3,
@@ -32240,7 +32240,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.51,
+        "H_Inzidenz": 2.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.06.2022"
@@ -32262,7 +32262,7 @@
         "BelegteBetten": null,
         "Inzidenz": 553.2,
         "Datum_neu": 1656201600000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 447.7,
@@ -32278,7 +32278,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.32,
+        "H_Inzidenz": 2.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.06.2022"
@@ -32289,34 +32289,34 @@
         "Datum": "27.06.2022",
         "Fallzahl": 220136,
         "ObjectId": 843,
-        "Sterbefall": 1729,
-        "Genesungsfall": 213279,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5683,
-        "Zuwachs_Fallzahl": 621,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 520,
         "BelegteBetten": null,
         "Inzidenz": 527.1,
         "Datum_neu": 1656288000000,
-        "F\u00e4lle_Meldedatum": 651,
+        "F\u00e4lle_Meldedatum": 715,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 417.5,
-        "Fallzahl_aktiv": 5128,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 316,
         "Krh_I_belegt": 47,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 100,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.17,
+        "H_Inzidenz": 2.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.06.2022"
@@ -32324,29 +32324,67 @@
     },
     {
       "attributes": {
-        "Datum": "28.06.2023",
+        "Datum": "28.06.2022",
         "Fallzahl": 221055,
         "ObjectId": 844,
         "Sterbefall": 1729,
         "Genesungsfall": 213804,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5692,
         "Zuwachs_Fallzahl": 919,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 9,
-        "Zuwachs_Genesung": 525,
+        "Zuwachs_Genesung": 526,
         "BelegteBetten": null,
         "Inzidenz": 559.646539027982,
-        "Datum_neu": 1687910400000,
-        "F\u00e4lle_Meldedatum": 60,
-        "Zeitraum": "21.06.2022 - 27.06.2022",
-        "Hosp_Meldedatum": 0,
+        "Datum_neu": 1656374400000,
+        "F\u00e4lle_Meldedatum": 673,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 441.7,
         "Fallzahl_aktiv": 5522,
         "Krh_N_belegt": 316,
         "Krh_I_belegt": 47,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 394,
+        "Fallzahl_aktiv_Zuwachs": 393,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.63,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.06.2022",
+        "Fallzahl": 221868,
+        "ObjectId": 845,
+        "Sterbefall": 1729,
+        "Genesungsfall": 214174,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5704,
+        "Zuwachs_Fallzahl": 813,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 370,
+        "BelegteBetten": null,
+        "Inzidenz": 592.693703078415,
+        "Datum_neu": 1656460800000,
+        "F\u00e4lle_Meldedatum": 102,
+        "Zeitraum": "22.06.2022 - 28.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 490.8,
+        "Fallzahl_aktiv": 5965,
+        "Krh_N_belegt": 316,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 443,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -32354,10 +32392,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.26,
-        "H_Zeitraum": "21.06.2022 - 27.06.2022",
+        "H_Inzidenz": 1.33,
+        "H_Zeitraum": "22.06.2022 - 28.06.2022",
         "H_Datum": "27.06.2022",
-        "Datum_Bett": "27.06.2023"
+        "Datum_Bett": "28.06.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
