### PR TITLE
New data set: 2022-06-30T102802Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-29T100203Z.json
+pjson/2022-06-30T102802Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-29T100203Z.json pjson/2022-06-30T102802Z.json```:
```
--- pjson/2022-06-29T100203Z.json	2022-06-29 10:02:03.997443237 +0000
+++ pjson/2022-06-30T102802Z.json	2022-06-30 10:28:03.083205046 +0000
@@ -30894,7 +30894,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653091200000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -31084,7 +31084,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653523200000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -32113,10 +32113,10 @@
         "F\u00e4lle_Meldedatum": 560,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 423,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 308,
-        "Krh_I_belegt": 40,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32126,7 +32126,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.06.2022"
@@ -32224,7 +32224,7 @@
         "BelegteBetten": null,
         "Inzidenz": 569.5,
         "Datum_neu": 1656115200000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 221,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 486.3,
@@ -32262,7 +32262,7 @@
         "BelegteBetten": null,
         "Inzidenz": 553.2,
         "Datum_neu": 1656201600000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 447.7,
@@ -32278,7 +32278,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.46,
+        "H_Inzidenz": 2.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.06.2022"
@@ -32300,7 +32300,7 @@
         "BelegteBetten": null,
         "Inzidenz": 527.1,
         "Datum_neu": 1656288000000,
-        "F\u00e4lle_Meldedatum": 715,
+        "F\u00e4lle_Meldedatum": 726,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 417.5,
@@ -32316,7 +32316,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.34,
+        "H_Inzidenz": 2.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.06.2022"
@@ -32327,34 +32327,34 @@
         "Datum": "28.06.2022",
         "Fallzahl": 221055,
         "ObjectId": 844,
-        "Sterbefall": 1729,
-        "Genesungsfall": 213804,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5692,
-        "Zuwachs_Fallzahl": 919,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 526,
         "BelegteBetten": null,
         "Inzidenz": 559.646539027982,
         "Datum_neu": 1656374400000,
-        "F\u00e4lle_Meldedatum": 673,
+        "F\u00e4lle_Meldedatum": 774,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 441.7,
-        "Fallzahl_aktiv": 5522,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 316,
         "Krh_I_belegt": 47,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 393,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.63,
+        "H_Inzidenz": 1.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.06.2022"
@@ -32367,7 +32367,7 @@
         "ObjectId": 845,
         "Sterbefall": 1729,
         "Genesungsfall": 214174,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5704,
         "Zuwachs_Fallzahl": 813,
         "Zuwachs_Sterbefall": 0,
@@ -32376,9 +32376,9 @@
         "BelegteBetten": null,
         "Inzidenz": 592.693703078415,
         "Datum_neu": 1656460800000,
-        "F\u00e4lle_Meldedatum": 102,
-        "Zeitraum": "22.06.2022 - 28.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 555,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 490.8,
         "Fallzahl_aktiv": 5965,
         "Krh_N_belegt": 316,
@@ -32392,11 +32392,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.33,
-        "H_Zeitraum": "22.06.2022 - 28.06.2022",
-        "H_Datum": "27.06.2022",
+        "H_Inzidenz": 1.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.06.2022",
+        "Fallzahl": 222498,
+        "ObjectId": 846,
+        "Sterbefall": 1729,
+        "Genesungsfall": 214623,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5713,
+        "Zuwachs_Fallzahl": 630,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 449,
+        "BelegteBetten": null,
+        "Inzidenz": 612.450159847696,
+        "Datum_neu": 1656547200000,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": "23.06.2022 - 29.06.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 532.2,
+        "Fallzahl_aktiv": 6146,
+        "Krh_N_belegt": 316,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 181,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 1.58,
+        "H_Zeitraum": "23.06.2022 - 29.06.2022",
+        "H_Datum": "27.06.2022",
+        "Datum_Bett": "29.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
