### PR TITLE
New data set: 2022-07-01T103103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-06-30T102802Z.json
+pjson/2022-07-01T103103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-06-30T102802Z.json pjson/2022-07-01T103103Z.json```:
```
--- pjson/2022-06-30T102802Z.json	2022-06-30 10:28:03.083205046 +0000
+++ pjson/2022-07-01T103103Z.json	2022-07-01 10:31:03.186075410 +0000
@@ -31352,7 +31352,7 @@
         "Datum_neu": 1654128000000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32070,7 +32070,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 403,
         "BelegteBetten": null,
-        "Inzidenz": 470.562879413772,
+        "Inzidenz": null,
         "Datum_neu": 1655769600000,
         "F\u00e4lle_Meldedatum": 588,
         "Zeitraum": null,
@@ -32108,7 +32108,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 402,
         "BelegteBetten": null,
-        "Inzidenz": 502.352814397069,
+        "Inzidenz": null,
         "Datum_neu": 1655856000000,
         "F\u00e4lle_Meldedatum": 560,
         "Zeitraum": null,
@@ -32146,15 +32146,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 324,
         "BelegteBetten": null,
-        "Inzidenz": 538.992061496462,
+        "Inzidenz": null,
         "Datum_neu": 1655942400000,
-        "F\u00e4lle_Meldedatum": 506,
+        "F\u00e4lle_Meldedatum": 507,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 470.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 336,
-        "Krh_I_belegt": 35,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32164,7 +32164,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.06.2022"
@@ -32186,7 +32186,7 @@
         "BelegteBetten": null,
         "Inzidenz": 549.229498185998,
         "Datum_neu": 1656028800000,
-        "F\u00e4lle_Meldedatum": 489,
+        "F\u00e4lle_Meldedatum": 490,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 485.1,
@@ -32202,7 +32202,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.81,
+        "H_Inzidenz": 2.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.06.2022"
@@ -32240,7 +32240,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.61,
+        "H_Inzidenz": 2.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.06.2022"
@@ -32278,7 +32278,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
+        "H_Inzidenz": 2.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.06.2022"
@@ -32300,7 +32300,7 @@
         "BelegteBetten": null,
         "Inzidenz": 527.1,
         "Datum_neu": 1656288000000,
-        "F\u00e4lle_Meldedatum": 726,
+        "F\u00e4lle_Meldedatum": 728,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 417.5,
@@ -32316,7 +32316,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.37,
+        "H_Inzidenz": 2.83,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.06.2022"
@@ -32338,7 +32338,7 @@
         "BelegteBetten": null,
         "Inzidenz": 559.646539027982,
         "Datum_neu": 1656374400000,
-        "F\u00e4lle_Meldedatum": 774,
+        "F\u00e4lle_Meldedatum": 781,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 441.7,
@@ -32354,7 +32354,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.68,
+        "H_Inzidenz": 2.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.06.2022"
@@ -32365,34 +32365,34 @@
         "Datum": "29.06.2022",
         "Fallzahl": 221868,
         "ObjectId": 845,
-        "Sterbefall": 1729,
-        "Genesungsfall": 214174,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5704,
-        "Zuwachs_Fallzahl": 813,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 370,
         "BelegteBetten": null,
         "Inzidenz": 592.693703078415,
         "Datum_neu": 1656460800000,
-        "F\u00e4lle_Meldedatum": 555,
+        "F\u00e4lle_Meldedatum": 584,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 490.8,
-        "Fallzahl_aktiv": 5965,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 316,
         "Krh_I_belegt": 47,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 443,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.7,
+        "H_Inzidenz": 2.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.06.2022"
@@ -32405,7 +32405,7 @@
         "ObjectId": 846,
         "Sterbefall": 1729,
         "Genesungsfall": 214623,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5713,
         "Zuwachs_Fallzahl": 630,
         "Zuwachs_Sterbefall": 0,
@@ -32414,9 +32414,9 @@
         "BelegteBetten": null,
         "Inzidenz": 612.450159847696,
         "Datum_neu": 1656547200000,
-        "F\u00e4lle_Meldedatum": 60,
-        "Zeitraum": "23.06.2022 - 29.06.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 398,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 532.2,
         "Fallzahl_aktiv": 6146,
         "Krh_N_belegt": 316,
@@ -32430,11 +32430,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 1.58,
-        "H_Zeitraum": "23.06.2022 - 29.06.2022",
-        "H_Datum": "27.06.2022",
+        "H_Inzidenz": 2.46,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.06.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.07.2022",
+        "Fallzahl": 222923,
+        "ObjectId": 847,
+        "Sterbefall": 1729,
+        "Genesungsfall": 215004,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5724,
+        "Zuwachs_Fallzahl": 425,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 381,
+        "BelegteBetten": null,
+        "Inzidenz": 600.057473328783,
+        "Datum_neu": 1656633600000,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": "24.06.2022 - 30.06.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 541.9,
+        "Fallzahl_aktiv": 6190,
+        "Krh_N_belegt": 339,
+        "Krh_I_belegt": 51,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 44,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.05,
+        "H_Zeitraum": "24.06.2022 - 30.06.2022",
+        "H_Datum": "30.06.2022",
+        "Datum_Bett": "30.06.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
