### PR TITLE
New data set: 2022-07-04T101603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-01T103103Z.json
+pjson/2022-07-04T101603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-01T103103Z.json pjson/2022-07-04T101603Z.json```:
```
--- pjson/2022-07-01T103103Z.json	2022-07-01 10:31:03.186075410 +0000
+++ pjson/2022-07-04T101603Z.json	2022-07-04 10:16:04.007694197 +0000
@@ -32150,7 +32150,7 @@
         "Datum_neu": 1655942400000,
         "F\u00e4lle_Meldedatum": 507,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32184,15 +32184,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 313,
         "BelegteBetten": null,
-        "Inzidenz": 549.229498185998,
+        "Inzidenz": null,
         "Datum_neu": 1656028800000,
-        "F\u00e4lle_Meldedatum": 490,
+        "F\u00e4lle_Meldedatum": 491,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 485.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 336,
-        "Krh_I_belegt": 35,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32202,7 +32202,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.93,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.06.2022"
@@ -32222,15 +32222,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 125,
         "BelegteBetten": null,
-        "Inzidenz": 569.5,
+        "Inzidenz": null,
         "Datum_neu": 1656115200000,
-        "F\u00e4lle_Meldedatum": 221,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 486.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 336,
-        "Krh_I_belegt": 35,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32240,7 +32240,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.06.2022"
@@ -32260,15 +32260,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 95,
         "BelegteBetten": null,
-        "Inzidenz": 553.2,
+        "Inzidenz": null,
         "Datum_neu": 1656201600000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 447.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 336,
-        "Krh_I_belegt": 35,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32278,7 +32278,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.06.2022"
@@ -32300,13 +32300,13 @@
         "BelegteBetten": null,
         "Inzidenz": 527.1,
         "Datum_neu": 1656288000000,
-        "F\u00e4lle_Meldedatum": 728,
+        "F\u00e4lle_Meldedatum": 729,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 417.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 316,
-        "Krh_I_belegt": 47,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32316,7 +32316,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.83,
+        "H_Inzidenz": 3.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.06.2022"
@@ -32338,13 +32338,13 @@
         "BelegteBetten": null,
         "Inzidenz": 559.646539027982,
         "Datum_neu": 1656374400000,
-        "F\u00e4lle_Meldedatum": 781,
+        "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 441.7,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 316,
-        "Krh_I_belegt": 47,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32354,7 +32354,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.22,
+        "H_Inzidenz": 2.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.06.2022"
@@ -32376,13 +32376,13 @@
         "BelegteBetten": null,
         "Inzidenz": 592.693703078415,
         "Datum_neu": 1656460800000,
-        "F\u00e4lle_Meldedatum": 584,
+        "F\u00e4lle_Meldedatum": 617,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 490.8,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 316,
-        "Krh_I_belegt": 47,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -32392,7 +32392,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.37,
+        "H_Inzidenz": 2.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.06.2022"
@@ -32403,34 +32403,34 @@
         "Datum": "30.06.2022",
         "Fallzahl": 222498,
         "ObjectId": 846,
-        "Sterbefall": 1729,
-        "Genesungsfall": 214623,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5713,
-        "Zuwachs_Fallzahl": 630,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 449,
         "BelegteBetten": null,
         "Inzidenz": 612.450159847696,
         "Datum_neu": 1656547200000,
-        "F\u00e4lle_Meldedatum": 398,
+        "F\u00e4lle_Meldedatum": 484,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 532.2,
-        "Fallzahl_aktiv": 6146,
-        "Krh_N_belegt": 316,
-        "Krh_I_belegt": 47,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 181,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.46,
+        "H_Inzidenz": 2.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.06.2022"
@@ -32443,7 +32443,7 @@
         "ObjectId": 847,
         "Sterbefall": 1729,
         "Genesungsfall": 215004,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5724,
         "Zuwachs_Fallzahl": 425,
         "Zuwachs_Sterbefall": 0,
@@ -32452,15 +32452,129 @@
         "BelegteBetten": null,
         "Inzidenz": 600.057473328783,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 47,
-        "Zeitraum": "24.06.2022 - 30.06.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 463,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 541.9,
         "Fallzahl_aktiv": 6190,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 44,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.96,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.06.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.07.2022",
+        "Fallzahl": 223611,
+        "ObjectId": 848,
+        "Sterbefall": null,
+        "Genesungsfall": 215223,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 219,
+        "BelegteBetten": null,
+        "Inzidenz": 618.37709687848,
+        "Datum_neu": 1656720000000,
+        "F\u00e4lle_Meldedatum": 142,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 509.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.3,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "01.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.07.2022",
+        "Fallzahl": 223668,
+        "ObjectId": 849,
+        "Sterbefall": null,
+        "Genesungsfall": 215393,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 170,
+        "BelegteBetten": null,
+        "Inzidenz": 604.00876468264,
+        "Datum_neu": 1656806400000,
+        "F\u00e4lle_Meldedatum": 57,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 469.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.98,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.07.2022",
+        "Fallzahl": 223694,
+        "ObjectId": 850,
+        "Sterbefall": 1729,
+        "Genesungsfall": 216089,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5731,
+        "Zuwachs_Fallzahl": 771,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 696,
+        "BelegteBetten": null,
+        "Inzidenz": 589.101620029455,
+        "Datum_neu": 1656892800000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "27.06.2022 - 03.07.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 444.8,
+        "Fallzahl_aktiv": 5876,
         "Krh_N_belegt": 339,
         "Krh_I_belegt": 51,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 44,
+        "Fallzahl_aktiv_Zuwachs": 75,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -32468,10 +32582,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
-        "H_Zeitraum": "24.06.2022 - 30.06.2022",
+        "H_Inzidenz": 2.66,
+        "H_Zeitraum": "27.06.2022 - 03.07.2022",
         "H_Datum": "30.06.2022",
-        "Datum_Bett": "30.06.2022"
+        "Datum_Bett": "03.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
