### PR TITLE
New data set: 2022-07-05T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-04T101603Z.json
+pjson/2022-07-05T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-04T101603Z.json pjson/2022-07-05T100403Z.json```:
```
--- pjson/2022-07-04T101603Z.json	2022-07-04 10:16:04.007694197 +0000
+++ pjson/2022-07-05T100403Z.json	2022-07-05 10:04:03.610762451 +0000
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1054,
+        "F\u00e4lle_Meldedatum": 1053,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 187,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -25498,7 +25498,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 416,
+        "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25536,7 +25536,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26524,7 +26524,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643155200000,
-        "F\u00e4lle_Meldedatum": 1144,
+        "F\u00e4lle_Meldedatum": 1145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1661,
+        "F\u00e4lle_Meldedatum": 1662,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27056,7 +27056,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644364800000,
-        "F\u00e4lle_Meldedatum": 1617,
+        "F\u00e4lle_Meldedatum": 1618,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1249,
+        "F\u00e4lle_Meldedatum": 1250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -32298,12 +32298,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 520,
         "BelegteBetten": null,
-        "Inzidenz": 527.1,
+        "Inzidenz": null,
         "Datum_neu": 1656288000000,
         "F\u00e4lle_Meldedatum": 729,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 417.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32316,7 +32316,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.08,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.06.2022"
@@ -32354,7 +32354,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.54,
+        "H_Inzidenz": 3.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.06.2022"
@@ -32376,7 +32376,7 @@
         "BelegteBetten": null,
         "Inzidenz": 592.693703078415,
         "Datum_neu": 1656460800000,
-        "F\u00e4lle_Meldedatum": 617,
+        "F\u00e4lle_Meldedatum": 619,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 490.8,
@@ -32392,7 +32392,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.81,
+        "H_Inzidenz": 3.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.06.2022"
@@ -32414,7 +32414,7 @@
         "BelegteBetten": null,
         "Inzidenz": 612.450159847696,
         "Datum_neu": 1656547200000,
-        "F\u00e4lle_Meldedatum": 484,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 532.2,
@@ -32430,7 +32430,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.96,
+        "H_Inzidenz": 3.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.06.2022"
@@ -32441,34 +32441,34 @@
         "Datum": "01.07.2022",
         "Fallzahl": 222923,
         "ObjectId": 847,
-        "Sterbefall": 1729,
-        "Genesungsfall": 215004,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5724,
-        "Zuwachs_Fallzahl": 425,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 381,
         "BelegteBetten": null,
         "Inzidenz": 600.057473328783,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 463,
+        "F\u00e4lle_Meldedatum": 470,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 541.9,
-        "Fallzahl_aktiv": 6190,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 44,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.96,
+        "H_Inzidenz": 4.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.06.2022"
@@ -32480,7 +32480,7 @@
         "Fallzahl": 223611,
         "ObjectId": 848,
         "Sterbefall": null,
-        "Genesungsfall": 215223,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -32490,7 +32490,7 @@
         "BelegteBetten": null,
         "Inzidenz": 618.37709687848,
         "Datum_neu": 1656720000000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 170,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 509.5,
@@ -32506,7 +32506,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.3,
+        "H_Inzidenz": 9.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.07.2022"
@@ -32518,7 +32518,7 @@
         "Fallzahl": 223668,
         "ObjectId": 849,
         "Sterbefall": null,
-        "Genesungsfall": 215393,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -32528,7 +32528,7 @@
         "BelegteBetten": null,
         "Inzidenz": 604.00876468264,
         "Datum_neu": 1656806400000,
-        "F\u00e4lle_Meldedatum": 57,
+        "F\u00e4lle_Meldedatum": 101,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 469.8,
@@ -32544,7 +32544,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
+        "H_Inzidenz": 10.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.07.2022"
@@ -32557,7 +32557,7 @@
         "ObjectId": 850,
         "Sterbefall": 1729,
         "Genesungsfall": 216089,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5731,
         "Zuwachs_Fallzahl": 771,
         "Zuwachs_Sterbefall": 0,
@@ -32566,13 +32566,13 @@
         "BelegteBetten": null,
         "Inzidenz": 589.101620029455,
         "Datum_neu": 1656892800000,
-        "F\u00e4lle_Meldedatum": 26,
-        "Zeitraum": "27.06.2022 - 03.07.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 493,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 444.8,
         "Fallzahl_aktiv": 5876,
-        "Krh_N_belegt": 339,
-        "Krh_I_belegt": 51,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 75,
         "Krh_I": null,
@@ -32582,11 +32582,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.66,
-        "H_Zeitraum": "27.06.2022 - 03.07.2022",
-        "H_Datum": "30.06.2022",
+        "H_Inzidenz": 10.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.07.2022",
+        "Fallzahl": 224359,
+        "ObjectId": 851,
+        "Sterbefall": 1729,
+        "Genesungsfall": 216677,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5747,
+        "Zuwachs_Fallzahl": 665,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 588,
+        "BelegteBetten": null,
+        "Inzidenz": 561.083372247566,
+        "Datum_neu": 1656979200000,
+        "F\u00e4lle_Meldedatum": 115,
+        "Zeitraum": "28.06.2022 - 04.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 471.2,
+        "Fallzahl_aktiv": 5953,
+        "Krh_N_belegt": 360,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 77,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.38,
+        "H_Zeitraum": "28.06.2022 - 04.07.2022",
+        "H_Datum": "04.07.2022",
+        "Datum_Bett": "04.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
