### PR TITLE
New data set: 2022-07-06T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-05T100403Z.json
+pjson/2022-07-06T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-05T100403Z.json pjson/2022-07-06T100403Z.json```:
```
--- pjson/2022-07-05T100403Z.json	2022-07-05 10:04:03.610762451 +0000
+++ pjson/2022-07-06T100403Z.json	2022-07-06 10:04:03.631189657 +0000
@@ -24092,7 +24092,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637625600000,
-        "F\u00e4lle_Meldedatum": 1661,
+        "F\u00e4lle_Meldedatum": 1660,
         "Zeitraum": null,
         "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
@@ -25232,7 +25232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 403,
+        "F\u00e4lle_Meldedatum": 401,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 657,
+        "F\u00e4lle_Meldedatum": 656,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -31502,7 +31502,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654473600000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -32336,12 +32336,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 526,
         "BelegteBetten": null,
-        "Inzidenz": 559.646539027982,
+        "Inzidenz": null,
         "Datum_neu": 1656374400000,
         "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 441.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32354,7 +32354,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.18,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.06.2022"
@@ -32392,7 +32392,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 3.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.06.2022"
@@ -32414,7 +32414,7 @@
         "BelegteBetten": null,
         "Inzidenz": 612.450159847696,
         "Datum_neu": 1656547200000,
-        "F\u00e4lle_Meldedatum": 483,
+        "F\u00e4lle_Meldedatum": 487,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 532.2,
@@ -32430,7 +32430,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": 4.04,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.06.2022"
@@ -32452,7 +32452,7 @@
         "BelegteBetten": null,
         "Inzidenz": 600.057473328783,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 470,
+        "F\u00e4lle_Meldedatum": 472,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 541.9,
@@ -32468,7 +32468,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
+        "H_Inzidenz": 4.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.06.2022"
@@ -32490,7 +32490,7 @@
         "BelegteBetten": null,
         "Inzidenz": 618.37709687848,
         "Datum_neu": 1656720000000,
-        "F\u00e4lle_Meldedatum": 170,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 509.5,
@@ -32506,7 +32506,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.32,
+        "H_Inzidenz": 9.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.07.2022"
@@ -32528,7 +32528,7 @@
         "BelegteBetten": null,
         "Inzidenz": 604.00876468264,
         "Datum_neu": 1656806400000,
-        "F\u00e4lle_Meldedatum": 101,
+        "F\u00e4lle_Meldedatum": 112,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 469.8,
@@ -32544,7 +32544,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.94,
+        "H_Inzidenz": 11.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.07.2022"
@@ -32555,34 +32555,34 @@
         "Datum": "04.07.2022",
         "Fallzahl": 223694,
         "ObjectId": 850,
-        "Sterbefall": 1729,
-        "Genesungsfall": 216089,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5731,
-        "Zuwachs_Fallzahl": 771,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 696,
         "BelegteBetten": null,
         "Inzidenz": 589.101620029455,
         "Datum_neu": 1656892800000,
-        "F\u00e4lle_Meldedatum": 493,
+        "F\u00e4lle_Meldedatum": 612,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 444.8,
-        "Fallzahl_aktiv": 5876,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 75,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.87,
+        "H_Inzidenz": 11.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.07.2022"
@@ -32595,7 +32595,7 @@
         "ObjectId": 851,
         "Sterbefall": 1729,
         "Genesungsfall": 216677,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5747,
         "Zuwachs_Fallzahl": 665,
         "Zuwachs_Sterbefall": 0,
@@ -32604,15 +32604,53 @@
         "BelegteBetten": null,
         "Inzidenz": 561.083372247566,
         "Datum_neu": 1656979200000,
-        "F\u00e4lle_Meldedatum": 115,
-        "Zeitraum": "28.06.2022 - 04.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 659,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 471.2,
         "Fallzahl_aktiv": 5953,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 77,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.92,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.07.2022",
+        "Fallzahl": 225107,
+        "ObjectId": 852,
+        "Sterbefall": 1729,
+        "Genesungsfall": 217236,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5749,
+        "Zuwachs_Fallzahl": 748,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 559,
+        "BelegteBetten": null,
+        "Inzidenz": 563.957038686735,
+        "Datum_neu": 1657065600000,
+        "F\u00e4lle_Meldedatum": 62,
+        "Zeitraum": "29.06.2022 - 05.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 474.3,
+        "Fallzahl_aktiv": 6142,
         "Krh_N_belegt": 360,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 77,
+        "Fallzahl_aktiv_Zuwachs": 189,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -32620,10 +32658,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.38,
-        "H_Zeitraum": "28.06.2022 - 04.07.2022",
+        "H_Inzidenz": 10.18,
+        "H_Zeitraum": "29.06.2022 - 05.07.2022",
         "H_Datum": "04.07.2022",
-        "Datum_Bett": "04.07.2022"
+        "Datum_Bett": "05.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
