### PR TITLE
New data set: 2022-07-07T100704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-06T100403Z.json
+pjson/2022-07-07T100704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-06T100403Z.json pjson/2022-07-07T100704Z.json```:
```
--- pjson/2022-07-06T100403Z.json	2022-07-06 10:04:03.631189657 +0000
+++ pjson/2022-07-07T100704Z.json	2022-07-07 10:07:04.362972066 +0000
@@ -29678,7 +29678,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650326400000,
-        "F\u00e4lle_Meldedatum": 1406,
+        "F\u00e4lle_Meldedatum": 1405,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -30210,7 +30210,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651536000000,
-        "F\u00e4lle_Meldedatum": 583,
+        "F\u00e4lle_Meldedatum": 582,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -31768,7 +31768,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655078400000,
-        "F\u00e4lle_Meldedatum": 530,
+        "F\u00e4lle_Meldedatum": 531,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -32374,12 +32374,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 370,
         "BelegteBetten": null,
-        "Inzidenz": 592.693703078415,
+        "Inzidenz": null,
         "Datum_neu": 1656460800000,
         "F\u00e4lle_Meldedatum": 619,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 490.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32392,7 +32392,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.67,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.06.2022"
@@ -32430,7 +32430,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.04,
+        "H_Inzidenz": 4.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.06.2022"
@@ -32452,7 +32452,7 @@
         "BelegteBetten": null,
         "Inzidenz": 600.057473328783,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 472,
+        "F\u00e4lle_Meldedatum": 474,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 541.9,
@@ -32468,7 +32468,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.29,
+        "H_Inzidenz": 4.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.06.2022"
@@ -32490,7 +32490,7 @@
         "BelegteBetten": null,
         "Inzidenz": 618.37709687848,
         "Datum_neu": 1656720000000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 509.5,
@@ -32506,7 +32506,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.51,
+        "H_Inzidenz": 9.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.07.2022"
@@ -32528,7 +32528,7 @@
         "BelegteBetten": null,
         "Inzidenz": 604.00876468264,
         "Datum_neu": 1656806400000,
-        "F\u00e4lle_Meldedatum": 112,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 469.8,
@@ -32544,7 +32544,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.14,
+        "H_Inzidenz": 11.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.07.2022"
@@ -32566,7 +32566,7 @@
         "BelegteBetten": null,
         "Inzidenz": 589.101620029455,
         "Datum_neu": 1656892800000,
-        "F\u00e4lle_Meldedatum": 612,
+        "F\u00e4lle_Meldedatum": 618,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 444.8,
@@ -32582,7 +32582,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.14,
+        "H_Inzidenz": 11.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.07.2022"
@@ -32593,34 +32593,34 @@
         "Datum": "05.07.2022",
         "Fallzahl": 224359,
         "ObjectId": 851,
-        "Sterbefall": 1729,
-        "Genesungsfall": 216677,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5747,
-        "Zuwachs_Fallzahl": 665,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 588,
         "BelegteBetten": null,
         "Inzidenz": 561.083372247566,
         "Datum_neu": 1656979200000,
-        "F\u00e4lle_Meldedatum": 659,
+        "F\u00e4lle_Meldedatum": 705,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 471.2,
-        "Fallzahl_aktiv": 5953,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 77,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.92,
+        "H_Inzidenz": 11.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.07.2022"
@@ -32633,7 +32633,7 @@
         "ObjectId": 852,
         "Sterbefall": 1729,
         "Genesungsfall": 217236,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5749,
         "Zuwachs_Fallzahl": 748,
         "Zuwachs_Sterbefall": 0,
@@ -32642,15 +32642,53 @@
         "BelegteBetten": null,
         "Inzidenz": 563.957038686735,
         "Datum_neu": 1657065600000,
-        "F\u00e4lle_Meldedatum": 62,
-        "Zeitraum": "29.06.2022 - 05.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 490,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 474.3,
         "Fallzahl_aktiv": 6142,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 189,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.85,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "05.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.07.2022",
+        "Fallzahl": 225671,
+        "ObjectId": 853,
+        "Sterbefall": 1729,
+        "Genesungsfall": 217736,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5754,
+        "Zuwachs_Fallzahl": 564,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 500,
+        "BelegteBetten": null,
+        "Inzidenz": 551.384748015374,
+        "Datum_neu": 1657152000000,
+        "F\u00e4lle_Meldedatum": 78,
+        "Zeitraum": "30.06.2022 - 06.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 477,
+        "Fallzahl_aktiv": 6206,
         "Krh_N_belegt": 360,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 189,
+        "Fallzahl_aktiv_Zuwachs": 64,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -32658,10 +32696,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.18,
-        "H_Zeitraum": "29.06.2022 - 05.07.2022",
+        "H_Inzidenz": 10.13,
+        "H_Zeitraum": "30.06.2022 - 06.07.2022",
         "H_Datum": "04.07.2022",
-        "Datum_Bett": "05.07.2022"
+        "Datum_Bett": "06.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
