### PR TITLE
New data set: 2022-07-08T100204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-07T100704Z.json
+pjson/2022-07-08T100204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-07T100704Z.json pjson/2022-07-08T100204Z.json```:
```
--- pjson/2022-07-07T100704Z.json	2022-07-07 10:07:04.362972066 +0000
+++ pjson/2022-07-08T100204Z.json	2022-07-08 10:02:04.324751420 +0000
@@ -28312,7 +28312,7 @@
         "Datum_neu": 1647216000000,
         "F\u00e4lle_Meldedatum": 2866,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28350,7 +28350,7 @@
         "Datum_neu": 1647302400000,
         "F\u00e4lle_Meldedatum": 2596,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28388,7 +28388,7 @@
         "Datum_neu": 1647388800000,
         "F\u00e4lle_Meldedatum": 2806,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28464,7 +28464,7 @@
         "Datum_neu": 1647561600000,
         "F\u00e4lle_Meldedatum": 2600,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28540,7 +28540,7 @@
         "Datum_neu": 1647734400000,
         "F\u00e4lle_Meldedatum": 377,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28578,7 +28578,7 @@
         "Datum_neu": 1647820800000,
         "F\u00e4lle_Meldedatum": 3064,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 38,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28654,7 +28654,7 @@
         "Datum_neu": 1647993600000,
         "F\u00e4lle_Meldedatum": 2137,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28692,7 +28692,7 @@
         "Datum_neu": 1648080000000,
         "F\u00e4lle_Meldedatum": 2199,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28730,7 +28730,7 @@
         "Datum_neu": 1648166400000,
         "F\u00e4lle_Meldedatum": 1781,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28806,7 +28806,7 @@
         "Datum_neu": 1648339200000,
         "F\u00e4lle_Meldedatum": 426,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28844,7 +28844,7 @@
         "Datum_neu": 1648425600000,
         "F\u00e4lle_Meldedatum": 2364,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28920,7 +28920,7 @@
         "Datum_neu": 1648598400000,
         "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -28958,7 +28958,7 @@
         "Datum_neu": 1648684800000,
         "F\u00e4lle_Meldedatum": 1289,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29072,7 +29072,7 @@
         "Datum_neu": 1648944000000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29110,7 +29110,7 @@
         "Datum_neu": 1649030400000,
         "F\u00e4lle_Meldedatum": 1810,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29186,7 +29186,7 @@
         "Datum_neu": 1649203200000,
         "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29262,7 +29262,7 @@
         "Datum_neu": 1649376000000,
         "F\u00e4lle_Meldedatum": 887,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29300,7 +29300,7 @@
         "Datum_neu": 1649462400000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29338,7 +29338,7 @@
         "Datum_neu": 1649548800000,
         "F\u00e4lle_Meldedatum": 272,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29376,7 +29376,7 @@
         "Datum_neu": 1649635200000,
         "F\u00e4lle_Meldedatum": 1316,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -29414,7 +29414,7 @@
         "Datum_neu": 1649721600000,
         "F\u00e4lle_Meldedatum": 1263,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32412,12 +32412,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 449,
         "BelegteBetten": null,
-        "Inzidenz": 612.450159847696,
+        "Inzidenz": null,
         "Datum_neu": 1656547200000,
         "F\u00e4lle_Meldedatum": 487,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 532.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32430,7 +32430,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.29,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.06.2022"
@@ -32452,7 +32452,7 @@
         "BelegteBetten": null,
         "Inzidenz": 600.057473328783,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 474,
+        "F\u00e4lle_Meldedatum": 475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 541.9,
@@ -32468,7 +32468,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.54,
+        "H_Inzidenz": 3.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.06.2022"
@@ -32506,7 +32506,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.84,
+        "H_Inzidenz": 4.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.07.2022"
@@ -32528,9 +32528,9 @@
         "BelegteBetten": null,
         "Inzidenz": 604.00876468264,
         "Datum_neu": 1656806400000,
-        "F\u00e4lle_Meldedatum": 116,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 469.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32544,7 +32544,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.56,
+        "H_Inzidenz": 3.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.07.2022"
@@ -32582,7 +32582,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.68,
+        "H_Inzidenz": 3.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.07.2022"
@@ -32604,9 +32604,9 @@
         "BelegteBetten": null,
         "Inzidenz": 561.083372247566,
         "Datum_neu": 1656979200000,
-        "F\u00e4lle_Meldedatum": 705,
+        "F\u00e4lle_Meldedatum": 713,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 471.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32620,7 +32620,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.49,
+        "H_Inzidenz": 3.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.07.2022"
@@ -32631,34 +32631,34 @@
         "Datum": "06.07.2022",
         "Fallzahl": 225107,
         "ObjectId": 852,
-        "Sterbefall": 1729,
-        "Genesungsfall": 217236,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5749,
-        "Zuwachs_Fallzahl": 748,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 559,
         "BelegteBetten": null,
         "Inzidenz": 563.957038686735,
         "Datum_neu": 1657065600000,
-        "F\u00e4lle_Meldedatum": 490,
+        "F\u00e4lle_Meldedatum": 558,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 474.3,
-        "Fallzahl_aktiv": 6142,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 189,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.85,
+        "H_Inzidenz": 3.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.07.2022"
@@ -32671,7 +32671,7 @@
         "ObjectId": 853,
         "Sterbefall": 1729,
         "Genesungsfall": 217736,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5754,
         "Zuwachs_Fallzahl": 564,
         "Zuwachs_Sterbefall": 0,
@@ -32680,13 +32680,13 @@
         "BelegteBetten": null,
         "Inzidenz": 551.384748015374,
         "Datum_neu": 1657152000000,
-        "F\u00e4lle_Meldedatum": 78,
-        "Zeitraum": "30.06.2022 - 06.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 405,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 477,
         "Fallzahl_aktiv": 6206,
-        "Krh_N_belegt": 360,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 64,
         "Krh_I": null,
@@ -32696,11 +32696,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.13,
-        "H_Zeitraum": "30.06.2022 - 06.07.2022",
-        "H_Datum": "04.07.2022",
+        "H_Inzidenz": 3.13,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.07.2022",
+        "Fallzahl": 226156,
+        "ObjectId": 854,
+        "Sterbefall": 1729,
+        "Genesungsfall": 218233,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5770,
+        "Zuwachs_Fallzahl": 485,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 497,
+        "BelegteBetten": null,
+        "Inzidenz": 550.666331405582,
+        "Datum_neu": 1657238400000,
+        "F\u00e4lle_Meldedatum": 80,
+        "Zeitraum": "01.07.2022 - 07.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 491,
+        "Fallzahl_aktiv": 6194,
+        "Krh_N_belegt": 368,
+        "Krh_I_belegt": 53,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.79,
+        "H_Zeitraum": "01.07.2022 - 07.07.2022",
+        "H_Datum": "07.07.2022",
+        "Datum_Bett": "07.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
