### PR TITLE
New data set: 2022-07-11T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-08T100204Z.json
+pjson/2022-07-11T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-08T100204Z.json pjson/2022-07-11T100303Z.json```:
```
--- pjson/2022-07-08T100204Z.json	2022-07-08 10:02:04.324751420 +0000
+++ pjson/2022-07-11T100303Z.json	2022-07-11 10:03:04.019265670 +0000
@@ -26486,7 +26486,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643068800000,
-        "F\u00e4lle_Meldedatum": 1318,
+        "F\u00e4lle_Meldedatum": 1317,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1484,
+        "F\u00e4lle_Meldedatum": 1483,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -29070,7 +29070,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648944000000,
-        "F\u00e4lle_Meldedatum": 217,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -30742,7 +30742,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652745600000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 291,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -31350,7 +31350,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654128000000,
-        "F\u00e4lle_Meldedatum": 217,
+        "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -32376,7 +32376,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656460800000,
-        "F\u00e4lle_Meldedatum": 619,
+        "F\u00e4lle_Meldedatum": 620,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -32414,7 +32414,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656547200000,
-        "F\u00e4lle_Meldedatum": 487,
+        "F\u00e4lle_Meldedatum": 488,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -32450,12 +32450,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 381,
         "BelegteBetten": null,
-        "Inzidenz": 600.057473328783,
+        "Inzidenz": null,
         "Datum_neu": 1656633600000,
         "F\u00e4lle_Meldedatum": 475,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 541.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32468,7 +32468,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.06.2022"
@@ -32488,12 +32488,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 219,
         "BelegteBetten": null,
-        "Inzidenz": 618.37709687848,
+        "Inzidenz": null,
         "Datum_neu": 1656720000000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 509.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32506,7 +32506,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.07.2022"
@@ -32526,12 +32526,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 170,
         "BelegteBetten": null,
-        "Inzidenz": 604.00876468264,
+        "Inzidenz": null,
         "Datum_neu": 1656806400000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 469.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32544,7 +32544,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.07.2022"
@@ -32566,7 +32566,7 @@
         "BelegteBetten": null,
         "Inzidenz": 589.101620029455,
         "Datum_neu": 1656892800000,
-        "F\u00e4lle_Meldedatum": 618,
+        "F\u00e4lle_Meldedatum": 619,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 444.8,
@@ -32582,7 +32582,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.85,
+        "H_Inzidenz": 3.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.07.2022"
@@ -32604,7 +32604,7 @@
         "BelegteBetten": null,
         "Inzidenz": 561.083372247566,
         "Datum_neu": 1656979200000,
-        "F\u00e4lle_Meldedatum": 713,
+        "F\u00e4lle_Meldedatum": 715,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 471.2,
@@ -32620,7 +32620,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": 3.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.07.2022"
@@ -32642,7 +32642,7 @@
         "BelegteBetten": null,
         "Inzidenz": 563.957038686735,
         "Datum_neu": 1657065600000,
-        "F\u00e4lle_Meldedatum": 558,
+        "F\u00e4lle_Meldedatum": 564,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 474.3,
@@ -32658,7 +32658,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.35,
+        "H_Inzidenz": 3.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.07.2022"
@@ -32669,34 +32669,34 @@
         "Datum": "07.07.2022",
         "Fallzahl": 225671,
         "ObjectId": 853,
-        "Sterbefall": 1729,
-        "Genesungsfall": 217736,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5754,
-        "Zuwachs_Fallzahl": 564,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 500,
         "BelegteBetten": null,
         "Inzidenz": 551.384748015374,
         "Datum_neu": 1657152000000,
-        "F\u00e4lle_Meldedatum": 405,
+        "F\u00e4lle_Meldedatum": 457,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 477,
-        "Fallzahl_aktiv": 6206,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 64,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.13,
+        "H_Inzidenz": 3.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.07.2022"
@@ -32709,7 +32709,7 @@
         "ObjectId": 854,
         "Sterbefall": 1729,
         "Genesungsfall": 218233,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5770,
         "Zuwachs_Fallzahl": 485,
         "Zuwachs_Sterbefall": 0,
@@ -32718,15 +32718,129 @@
         "BelegteBetten": null,
         "Inzidenz": 550.666331405582,
         "Datum_neu": 1657238400000,
-        "F\u00e4lle_Meldedatum": 80,
-        "Zeitraum": "01.07.2022 - 07.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 382,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 491,
         "Fallzahl_aktiv": 6194,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.3,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "07.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.07.2022",
+        "Fallzahl": 226713,
+        "ObjectId": 855,
+        "Sterbefall": null,
+        "Genesungsfall": 218456,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 223,
+        "BelegteBetten": null,
+        "Inzidenz": 545.098602679694,
+        "Datum_neu": 1657324800000,
+        "F\u00e4lle_Meldedatum": 194,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 472.468973998026,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.71,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "08.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.07.2022",
+        "Fallzahl": 226783,
+        "ObjectId": 856,
+        "Sterbefall": null,
+        "Genesungsfall": 218598,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 142,
+        "BelegteBetten": null,
+        "Inzidenz": 547.433456661518,
+        "Datum_neu": 1657411200000,
+        "F\u00e4lle_Meldedatum": 70,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 440.108085368024,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.49,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "09.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.07.2022",
+        "Fallzahl": 226791,
+        "ObjectId": 857,
+        "Sterbefall": 1729,
+        "Genesungsfall": 219312,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5776,
+        "Zuwachs_Fallzahl": 635,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 714,
+        "BelegteBetten": null,
+        "Inzidenz": 538.992061496462,
+        "Datum_neu": 1657497600000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "04.07.2022 - 10.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 419.073507758523,
+        "Fallzahl_aktiv": 5750,
         "Krh_N_belegt": 368,
         "Krh_I_belegt": 53,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -12,
+        "Fallzahl_aktiv_Zuwachs": -79,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -32734,10 +32848,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
-        "H_Zeitraum": "01.07.2022 - 07.07.2022",
+        "H_Inzidenz": 2.17,
+        "H_Zeitraum": "04.07.2022 - 10.07.2022",
         "H_Datum": "07.07.2022",
-        "Datum_Bett": "07.07.2022"
+        "Datum_Bett": "10.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
