### PR TITLE
New data set: 2022-07-12T100404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-11T100303Z.json
+pjson/2022-07-12T100404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-11T100303Z.json pjson/2022-07-12T100404Z.json```:
```
--- pjson/2022-07-11T100303Z.json	2022-07-11 10:03:04.019265670 +0000
+++ pjson/2022-07-12T100404Z.json	2022-07-12 10:04:04.356902809 +0000
@@ -32110,7 +32110,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655856000000,
-        "F\u00e4lle_Meldedatum": 560,
+        "F\u00e4lle_Meldedatum": 561,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -32564,12 +32564,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 696,
         "BelegteBetten": null,
-        "Inzidenz": 589.101620029455,
+        "Inzidenz": null,
         "Datum_neu": 1656892800000,
-        "F\u00e4lle_Meldedatum": 619,
+        "F\u00e4lle_Meldedatum": 620,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 444.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32582,7 +32582,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.07.2022"
@@ -32604,7 +32604,7 @@
         "BelegteBetten": null,
         "Inzidenz": 561.083372247566,
         "Datum_neu": 1656979200000,
-        "F\u00e4lle_Meldedatum": 715,
+        "F\u00e4lle_Meldedatum": 716,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 471.2,
@@ -32620,7 +32620,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.94,
+        "H_Inzidenz": 4.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.07.2022"
@@ -32658,7 +32658,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.48,
+        "H_Inzidenz": 3.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.07.2022"
@@ -32680,7 +32680,7 @@
         "BelegteBetten": null,
         "Inzidenz": 551.384748015374,
         "Datum_neu": 1657152000000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 477,
@@ -32696,7 +32696,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.28,
+        "H_Inzidenz": 3.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.07.2022"
@@ -32707,26 +32707,26 @@
         "Datum": "08.07.2022",
         "Fallzahl": 226156,
         "ObjectId": 854,
-        "Sterbefall": 1729,
-        "Genesungsfall": 218233,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5770,
-        "Zuwachs_Fallzahl": 485,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 497,
         "BelegteBetten": null,
         "Inzidenz": 550.666331405582,
         "Datum_neu": 1657238400000,
-        "F\u00e4lle_Meldedatum": 382,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 491,
-        "Fallzahl_aktiv": 6194,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -32734,7 +32734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.3,
+        "H_Inzidenz": 4.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.07.2022"
@@ -32746,7 +32746,7 @@
         "Fallzahl": 226713,
         "ObjectId": 855,
         "Sterbefall": null,
-        "Genesungsfall": 218456,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -32756,7 +32756,7 @@
         "BelegteBetten": null,
         "Inzidenz": 545.098602679694,
         "Datum_neu": 1657324800000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 472.468973998026,
@@ -32772,7 +32772,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.71,
+        "H_Inzidenz": 3.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.07.2022"
@@ -32784,7 +32784,7 @@
         "Fallzahl": 226783,
         "ObjectId": 856,
         "Sterbefall": null,
-        "Genesungsfall": 218598,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -32794,7 +32794,7 @@
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1657411200000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 440.108085368024,
@@ -32810,7 +32810,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
+        "H_Inzidenz": 3.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.07.2022"
@@ -32823,7 +32823,7 @@
         "ObjectId": 857,
         "Sterbefall": 1729,
         "Genesungsfall": 219312,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5776,
         "Zuwachs_Fallzahl": 635,
         "Zuwachs_Sterbefall": 0,
@@ -32832,13 +32832,13 @@
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1657497600000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "04.07.2022 - 10.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 673,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 419.073507758523,
         "Fallzahl_aktiv": 5750,
-        "Krh_N_belegt": 368,
-        "Krh_I_belegt": 53,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -79,
         "Krh_I": null,
@@ -32848,11 +32848,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.17,
-        "H_Zeitraum": "04.07.2022 - 10.07.2022",
-        "H_Datum": "07.07.2022",
+        "H_Inzidenz": 3.45,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.07.2022",
+        "Fallzahl": 227665,
+        "ObjectId": 858,
+        "Sterbefall": 1729,
+        "Genesungsfall": 220091,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5794,
+        "Zuwachs_Fallzahl": 874,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 779,
+        "BelegteBetten": null,
+        "Inzidenz": 567.369517583247,
+        "Datum_neu": 1657584000000,
+        "F\u00e4lle_Meldedatum": 103,
+        "Zeitraum": "05.07.2022 - 11.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 450.4,
+        "Fallzahl_aktiv": 5845,
+        "Krh_N_belegt": 449,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 95,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.46,
+        "H_Zeitraum": "05.07.2022 - 11.07.2022",
+        "H_Datum": "11.07.2022",
+        "Datum_Bett": "11.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
