### PR TITLE
New data set: 2022-07-13T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-12T100404Z.json
+pjson/2022-07-13T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-12T100404Z.json pjson/2022-07-13T100203Z.json```:
```
--- pjson/2022-07-12T100404Z.json	2022-07-12 10:04:04.356902809 +0000
+++ pjson/2022-07-13T100203Z.json	2022-07-13 10:02:03.887001117 +0000
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 936,
+        "F\u00e4lle_Meldedatum": 935,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2199,
+        "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1810,
+        "F\u00e4lle_Meldedatum": 1811,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -29184,7 +29184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1064,
+        "F\u00e4lle_Meldedatum": 1063,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -29298,7 +29298,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649462400000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -29412,7 +29412,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1263,
+        "F\u00e4lle_Meldedatum": 1262,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -30438,7 +30438,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652054400000,
-        "F\u00e4lle_Meldedatum": 510,
+        "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -32602,12 +32602,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 588,
         "BelegteBetten": null,
-        "Inzidenz": 561.083372247566,
+        "Inzidenz": null,
         "Datum_neu": 1656979200000,
         "F\u00e4lle_Meldedatum": 716,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 471.2,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32620,7 +32620,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.26,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.07.2022"
@@ -32642,7 +32642,7 @@
         "BelegteBetten": null,
         "Inzidenz": 563.957038686735,
         "Datum_neu": 1657065600000,
-        "F\u00e4lle_Meldedatum": 564,
+        "F\u00e4lle_Meldedatum": 563,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 474.3,
@@ -32658,7 +32658,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.94,
+        "H_Inzidenz": 4.04,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.07.2022"
@@ -32680,7 +32680,7 @@
         "BelegteBetten": null,
         "Inzidenz": 551.384748015374,
         "Datum_neu": 1657152000000,
-        "F\u00e4lle_Meldedatum": 459,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 477,
@@ -32696,7 +32696,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.94,
+        "H_Inzidenz": 4.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.07.2022"
@@ -32734,7 +32734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
+        "H_Inzidenz": 4.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.07.2022"
@@ -32756,7 +32756,7 @@
         "BelegteBetten": null,
         "Inzidenz": 545.098602679694,
         "Datum_neu": 1657324800000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 472.468973998026,
@@ -32772,7 +32772,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 4.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.07.2022"
@@ -32794,7 +32794,7 @@
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1657411200000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 440.108085368024,
@@ -32810,7 +32810,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.67,
+        "H_Inzidenz": 4.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.07.2022"
@@ -32821,26 +32821,26 @@
         "Datum": "11.07.2022",
         "Fallzahl": 226791,
         "ObjectId": 857,
-        "Sterbefall": 1729,
-        "Genesungsfall": 219312,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5776,
-        "Zuwachs_Fallzahl": 635,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 714,
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1657497600000,
-        "F\u00e4lle_Meldedatum": 673,
+        "F\u00e4lle_Meldedatum": 757,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 419.073507758523,
-        "Fallzahl_aktiv": 5750,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -79,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -32848,7 +32848,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.45,
+        "H_Inzidenz": 4.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.07.2022"
@@ -32861,7 +32861,7 @@
         "ObjectId": 858,
         "Sterbefall": 1729,
         "Genesungsfall": 220091,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5794,
         "Zuwachs_Fallzahl": 874,
         "Zuwachs_Sterbefall": 0,
@@ -32870,15 +32870,53 @@
         "BelegteBetten": null,
         "Inzidenz": 567.369517583247,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 103,
-        "Zeitraum": "05.07.2022 - 11.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 662,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 450.4,
         "Fallzahl_aktiv": 5845,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 95,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.55,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.07.2022",
+        "Fallzahl": 228344,
+        "ObjectId": 859,
+        "Sterbefall": 1729,
+        "Genesungsfall": 220713,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5826,
+        "Zuwachs_Fallzahl": 679,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 32,
+        "Zuwachs_Genesung": 622,
+        "BelegteBetten": null,
+        "Inzidenz": 574.374079528719,
+        "Datum_neu": 1657670400000,
+        "F\u00e4lle_Meldedatum": 32,
+        "Zeitraum": "06.07.2022 - 12.07.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 469.2,
+        "Fallzahl_aktiv": 5902,
         "Krh_N_belegt": 449,
         "Krh_I_belegt": 47,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 95,
+        "Fallzahl_aktiv_Zuwachs": 57,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -32886,10 +32924,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.46,
-        "H_Zeitraum": "05.07.2022 - 11.07.2022",
+        "H_Inzidenz": 2.98,
+        "H_Zeitraum": "06.07.2022 - 12.07.2022",
         "H_Datum": "11.07.2022",
-        "Datum_Bett": "11.07.2022"
+        "Datum_Bett": "12.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
