### PR TITLE
New data set: 2022-07-15T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-14T103704Z.json
+pjson/2022-07-15T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-14T103704Z.json pjson/2022-07-15T100303Z.json```:
```
--- pjson/2022-07-14T103704Z.json	2022-07-14 10:37:04.332240608 +0000
+++ pjson/2022-07-15T100303Z.json	2022-07-15 10:03:03.809582371 +0000
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2137,
+        "F\u00e4lle_Meldedatum": 2136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -32262,7 +32262,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656201600000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -32530,7 +32530,7 @@
         "Datum_neu": 1656806400000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32604,7 +32604,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656979200000,
-        "F\u00e4lle_Meldedatum": 716,
+        "F\u00e4lle_Meldedatum": 717,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -32658,7 +32658,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.04,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.07.2022"
@@ -32678,12 +32678,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 500,
         "BelegteBetten": null,
-        "Inzidenz": 551.384748015374,
+        "Inzidenz": null,
         "Datum_neu": 1657152000000,
         "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 477,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32696,7 +32696,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.09,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.07.2022"
@@ -32734,7 +32734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.24,
+        "H_Inzidenz": 4.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.07.2022"
@@ -32756,7 +32756,7 @@
         "BelegteBetten": null,
         "Inzidenz": 545.098602679694,
         "Datum_neu": 1657324800000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 472.468973998026,
@@ -32772,7 +32772,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.09,
+        "H_Inzidenz": 4.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.07.2022"
@@ -32794,7 +32794,7 @@
         "BelegteBetten": null,
         "Inzidenz": 547.433456661518,
         "Datum_neu": 1657411200000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 440.108085368024,
@@ -32810,7 +32810,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.17,
+        "H_Inzidenz": 4.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.07.2022"
@@ -32832,9 +32832,9 @@
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1657497600000,
-        "F\u00e4lle_Meldedatum": 774,
+        "F\u00e4lle_Meldedatum": 779,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 419.073507758523,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32848,7 +32848,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.09,
+        "H_Inzidenz": 4.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.07.2022"
@@ -32870,7 +32870,7 @@
         "BelegteBetten": null,
         "Inzidenz": 567.369517583247,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 694,
+        "F\u00e4lle_Meldedatum": 709,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 450.4,
@@ -32886,7 +32886,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.55,
+        "H_Inzidenz": 4.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.07.2022"
@@ -32897,34 +32897,34 @@
         "Datum": "13.07.2022",
         "Fallzahl": 228344,
         "ObjectId": 859,
-        "Sterbefall": 1729,
-        "Genesungsfall": 220713,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5826,
-        "Zuwachs_Fallzahl": 679,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 32,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 622,
         "BelegteBetten": null,
         "Inzidenz": 574.374079528719,
         "Datum_neu": 1657670400000,
-        "F\u00e4lle_Meldedatum": 495,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 469.2,
-        "Fallzahl_aktiv": 5902,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 57,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
+        "H_Inzidenz": 4.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.07.2022"
@@ -32937,7 +32937,7 @@
         "ObjectId": 860,
         "Sterbefall": 1729,
         "Genesungsfall": 221190,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5834,
         "Zuwachs_Fallzahl": 536,
         "Zuwachs_Sterbefall": 0,
@@ -32946,13 +32946,13 @@
         "BelegteBetten": null,
         "Inzidenz": 571.320808937103,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "07.07.2022 - 13.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 208,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 477,
         "Fallzahl_aktiv": 5961,
-        "Krh_N_belegt": 449,
-        "Krh_I_belegt": 47,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 59,
         "Krh_I": null,
@@ -32962,11 +32962,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
-        "H_Zeitraum": "06.07.2022 - 12.07.2022",
-        "H_Datum": "11.07.2022",
+        "H_Inzidenz": 4.29,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.07.2022",
+        "Fallzahl": 229570,
+        "ObjectId": 861,
+        "Sterbefall": 1729,
+        "Genesungsfall": 221663,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5854,
+        "Zuwachs_Fallzahl": 690,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 473,
+        "BelegteBetten": null,
+        "Inzidenz": 537.734832429326,
+        "Datum_neu": 1657843200000,
+        "F\u00e4lle_Meldedatum": 438,
+        "Zeitraum": "08.07.2022 - 14.07.2022",
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 516.7,
+        "Fallzahl_aktiv": 6178,
+        "Krh_N_belegt": 532,
+        "Krh_I_belegt": 57,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 217,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.62,
+        "H_Zeitraum": "08.07.2022 - 14.07.2022",
+        "H_Datum": "14.07.2022",
+        "Datum_Bett": "14.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
