### PR TITLE
New data set: 2022-07-18T101005Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-15T100303Z.json
+pjson/2022-07-18T101005Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-15T100303Z.json pjson/2022-07-18T101005Z.json```:
```
--- pjson/2022-07-15T100303Z.json	2022-07-15 10:03:03.809582371 +0000
+++ pjson/2022-07-18T101005Z.json	2022-07-18 10:10:05.533113184 +0000
@@ -23826,7 +23826,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637020800000,
-        "F\u00e4lle_Meldedatum": 1570,
+        "F\u00e4lle_Meldedatum": 1569,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
@@ -24244,7 +24244,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637971200000,
-        "F\u00e4lle_Meldedatum": 769,
+        "F\u00e4lle_Meldedatum": 768,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -32300,7 +32300,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656288000000,
-        "F\u00e4lle_Meldedatum": 729,
+        "F\u00e4lle_Meldedatum": 730,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -32680,7 +32680,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657152000000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -32716,12 +32716,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 497,
         "BelegteBetten": null,
-        "Inzidenz": 550.666331405582,
+        "Inzidenz": null,
         "Datum_neu": 1657238400000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 394,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 491,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32734,7 +32734,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.07.2022"
@@ -32754,12 +32754,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 223,
         "BelegteBetten": null,
-        "Inzidenz": 545.098602679694,
+        "Inzidenz": null,
         "Datum_neu": 1657324800000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 472.468973998026,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32772,7 +32772,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.54,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.07.2022"
@@ -32792,12 +32792,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 142,
         "BelegteBetten": null,
-        "Inzidenz": 547.433456661518,
+        "Inzidenz": null,
         "Datum_neu": 1657411200000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 440.108085368024,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32810,7 +32810,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.07.2022"
@@ -32832,7 +32832,7 @@
         "BelegteBetten": null,
         "Inzidenz": 538.992061496462,
         "Datum_neu": 1657497600000,
-        "F\u00e4lle_Meldedatum": 779,
+        "F\u00e4lle_Meldedatum": 784,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 419.073507758523,
@@ -32848,7 +32848,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.66,
+        "H_Inzidenz": 4.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.07.2022"
@@ -32870,7 +32870,7 @@
         "BelegteBetten": null,
         "Inzidenz": 567.369517583247,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 709,
+        "F\u00e4lle_Meldedatum": 713,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 450.4,
@@ -32886,7 +32886,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.91,
+        "H_Inzidenz": 5.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.07.2022"
@@ -32908,9 +32908,9 @@
         "BelegteBetten": null,
         "Inzidenz": 574.374079528719,
         "Datum_neu": 1657670400000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 556,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 469.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32924,7 +32924,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 5.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.07.2022"
@@ -32935,34 +32935,34 @@
         "Datum": "14.07.2022",
         "Fallzahl": 228880,
         "ObjectId": 860,
-        "Sterbefall": 1729,
-        "Genesungsfall": 221190,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5834,
-        "Zuwachs_Fallzahl": 536,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 477,
         "BelegteBetten": null,
         "Inzidenz": 571.320808937103,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 238,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 477,
-        "Fallzahl_aktiv": 5961,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 59,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.29,
+        "H_Inzidenz": 5.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.07.2022"
@@ -32975,7 +32975,7 @@
         "ObjectId": 861,
         "Sterbefall": 1729,
         "Genesungsfall": 221663,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5854,
         "Zuwachs_Fallzahl": 690,
         "Zuwachs_Sterbefall": 0,
@@ -32984,15 +32984,129 @@
         "BelegteBetten": null,
         "Inzidenz": 537.734832429326,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 438,
-        "Zeitraum": "08.07.2022 - 14.07.2022",
-        "Hosp_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 1123,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 516.7,
         "Fallzahl_aktiv": 6178,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 217,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.13,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "14.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.07.2022",
+        "Fallzahl": 230497,
+        "ObjectId": 862,
+        "Sterbefall": null,
+        "Genesungsfall": 221850,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 187,
+        "BelegteBetten": null,
+        "Inzidenz": 679.801717015698,
+        "Datum_neu": 1657929600000,
+        "F\u00e4lle_Meldedatum": 180,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 499.076815760472,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.76,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "15.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.07.2022",
+        "Fallzahl": 230606,
+        "ObjectId": 863,
+        "Sterbefall": null,
+        "Genesungsfall": 221970,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 120,
+        "BelegteBetten": null,
+        "Inzidenz": 668.666259563921,
+        "Datum_neu": 1658016000000,
+        "F\u00e4lle_Meldedatum": 109,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 455.928964253803,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "16.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.07.2022",
+        "Fallzahl": 230612,
+        "ObjectId": 864,
+        "Sterbefall": 1729,
+        "Genesungsfall": 222573,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5863,
+        "Zuwachs_Fallzahl": 1042,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 603,
+        "BelegteBetten": null,
+        "Inzidenz": 665.074176514961,
+        "Datum_neu": 1658102400000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "11.07.2022 - 17.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 432.9,
+        "Fallzahl_aktiv": 6310,
         "Krh_N_belegt": 532,
         "Krh_I_belegt": 57,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 217,
+        "Fallzahl_aktiv_Zuwachs": 439,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -33000,10 +33114,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.62,
-        "H_Zeitraum": "08.07.2022 - 14.07.2022",
+        "H_Inzidenz": 4.07,
+        "H_Zeitraum": "11.07.2022 - 17.07.2022",
         "H_Datum": "14.07.2022",
-        "Datum_Bett": "14.07.2022"
+        "Datum_Bett": "17.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
