### PR TITLE
New data set: 2022-07-19T101604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-18T101005Z.json
+pjson/2022-07-19T101604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-18T101005Z.json pjson/2022-07-19T101604Z.json```:
```
--- pjson/2022-07-18T101005Z.json	2022-07-18 10:10:05.533113184 +0000
+++ pjson/2022-07-19T101604Z.json	2022-07-19 10:16:04.186604113 +0000
@@ -10032,7 +10032,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1605657600000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -11666,7 +11666,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609372800000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
@@ -11742,7 +11742,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1609545600000,
-        "F\u00e4lle_Meldedatum": 136,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -12236,7 +12236,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1610668800000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -14744,7 +14744,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616371200000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -14820,7 +14820,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616544000000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -15086,7 +15086,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617148800000,
-        "F\u00e4lle_Meldedatum": 104,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -16150,7 +16150,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1619568000000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 153,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -23180,7 +23180,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635552000000,
-        "F\u00e4lle_Meldedatum": 290,
+        "F\u00e4lle_Meldedatum": 289,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -32830,12 +32830,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 714,
         "BelegteBetten": null,
-        "Inzidenz": 538.992061496462,
+        "Inzidenz": null,
         "Datum_neu": 1657497600000,
-        "F\u00e4lle_Meldedatum": 784,
+        "F\u00e4lle_Meldedatum": 785,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 419.073507758523,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32848,7 +32848,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.07.2022"
@@ -32870,7 +32870,7 @@
         "BelegteBetten": null,
         "Inzidenz": 567.369517583247,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 713,
+        "F\u00e4lle_Meldedatum": 716,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 450.4,
@@ -32886,7 +32886,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.42,
+        "H_Inzidenz": 5.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.07.2022"
@@ -32908,7 +32908,7 @@
         "BelegteBetten": null,
         "Inzidenz": 574.374079528719,
         "Datum_neu": 1657670400000,
-        "F\u00e4lle_Meldedatum": 556,
+        "F\u00e4lle_Meldedatum": 565,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 469.2,
@@ -32924,7 +32924,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.47,
+        "H_Inzidenz": 6.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.07.2022"
@@ -32946,9 +32946,9 @@
         "BelegteBetten": null,
         "Inzidenz": 571.320808937103,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 253,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 477,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32962,7 +32962,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.6,
+        "H_Inzidenz": 6.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.07.2022"
@@ -32973,34 +32973,34 @@
         "Datum": "15.07.2022",
         "Fallzahl": 229570,
         "ObjectId": 861,
-        "Sterbefall": 1729,
-        "Genesungsfall": 221663,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5854,
-        "Zuwachs_Fallzahl": 690,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 473,
         "BelegteBetten": null,
         "Inzidenz": 537.734832429326,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1123,
+        "F\u00e4lle_Meldedatum": 1122,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": 516.7,
-        "Fallzahl_aktiv": 6178,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 217,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.13,
+        "H_Inzidenz": 6.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.07.2022"
@@ -33009,10 +33009,10 @@
     {
       "attributes": {
         "Datum": "16.07.2022",
-        "Fallzahl": 230497,
+        "Fallzahl": 230551,
         "ObjectId": 862,
         "Sterbefall": null,
-        "Genesungsfall": 221850,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33020,9 +33020,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 187,
         "BelegteBetten": null,
-        "Inzidenz": 679.801717015698,
+        "Inzidenz": 684.651029131794,
         "Datum_neu": 1657929600000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 499.076815760472,
@@ -33038,7 +33038,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 5.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.07.2022"
@@ -33047,10 +33047,10 @@
     {
       "attributes": {
         "Datum": "17.07.2022",
-        "Fallzahl": 230606,
+        "Fallzahl": 230711,
         "ObjectId": 863,
         "Sterbefall": null,
-        "Genesungsfall": 221970,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33058,9 +33058,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 120,
         "BelegteBetten": null,
-        "Inzidenz": 668.666259563921,
+        "Inzidenz": 678.364883796113,
         "Datum_neu": 1658016000000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 455.928964253803,
@@ -33076,7 +33076,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": 5.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.07.2022"
@@ -33087,37 +33087,75 @@
         "Datum": "18.07.2022",
         "Fallzahl": 230612,
         "ObjectId": 864,
-        "Sterbefall": 1729,
-        "Genesungsfall": 222573,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 5863,
-        "Zuwachs_Fallzahl": 1042,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 603,
         "BelegteBetten": null,
         "Inzidenz": 665.074176514961,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 6,
-        "Zeitraum": "11.07.2022 - 17.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 711,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 432.9,
-        "Fallzahl_aktiv": 6310,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.27,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.07.2022",
+        "Fallzahl": 231553,
+        "ObjectId": 865,
+        "Sterbefall": 1729,
+        "Genesungsfall": 223283,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5878,
+        "Zuwachs_Fallzahl": 941,
+        "Zuwachs_Sterbefall": 1729,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 710,
+        "BelegteBetten": null,
+        "Inzidenz": 670.641905240849,
+        "Datum_neu": 1658188800000,
+        "F\u00e4lle_Meldedatum": 131,
+        "Zeitraum": "12.07.2022 - 18.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 514,
+        "Fallzahl_aktiv": 6541,
         "Krh_N_belegt": 532,
         "Krh_I_belegt": 57,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 439,
+        "Fallzahl_aktiv_Zuwachs": -1498,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
-        "H_Zeitraum": "11.07.2022 - 17.07.2022",
+        "H_Inzidenz": 3.43,
+        "H_Zeitraum": "12.07.2022 - 18.07.2022",
         "H_Datum": "14.07.2022",
-        "Datum_Bett": "17.07.2022"
+        "Datum_Bett": "18.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
