### PR TITLE
New data set: 2022-07-19T101703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-18T101005Z.json
+pjson/2022-07-19T101703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-19T101604Z.json pjson/2022-07-19T101703Z.json```:
```
--- pjson/2022-07-19T101604Z.json	2022-07-19 10:16:04.186604113 +0000
+++ pjson/2022-07-19T101703Z.json	2022-07-19 10:17:03.822634166 +0000
@@ -33130,7 +33130,7 @@
         "Anzeige_Indikator": "x",
         "Hospitalisierung": 5878,
         "Zuwachs_Fallzahl": 941,
-        "Zuwachs_Sterbefall": 1729,
+        "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 15,
         "Zuwachs_Genesung": 710,
         "BelegteBetten": null,
@@ -33144,9 +33144,9 @@
         "Krh_N_belegt": 532,
         "Krh_I_belegt": 57,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1498,
+        "Fallzahl_aktiv_Zuwachs": 231,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
