### PR TITLE
New data set: 2022-07-20T102004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-19T101703Z.json
+pjson/2022-07-20T102004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-19T101703Z.json pjson/2022-07-20T102004Z.json```:
```
--- pjson/2022-07-19T101703Z.json	2022-07-19 10:17:03.822634166 +0000
+++ pjson/2022-07-20T102004Z.json	2022-07-20 10:20:04.332149607 +0000
@@ -32452,7 +32452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 475,
+        "F\u00e4lle_Meldedatum": 476,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -32794,7 +32794,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657411200000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -32868,12 +32868,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 779,
         "BelegteBetten": null,
-        "Inzidenz": 567.369517583247,
+        "Inzidenz": null,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 716,
+        "F\u00e4lle_Meldedatum": 719,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
-        "Inzidenz_RKI": 450.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32886,7 +32886,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.07.2022"
@@ -32924,7 +32924,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.01,
+        "H_Inzidenz": 6.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.07.2022"
@@ -32946,9 +32946,9 @@
         "BelegteBetten": null,
         "Inzidenz": 571.320808937103,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 253,
+        "F\u00e4lle_Meldedatum": 265,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 477,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32962,7 +32962,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.33,
+        "H_Inzidenz": 6.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.07.2022"
@@ -32984,9 +32984,9 @@
         "BelegteBetten": null,
         "Inzidenz": 537.734832429326,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1122,
+        "F\u00e4lle_Meldedatum": 1117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 516.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33000,7 +33000,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.01,
+        "H_Inzidenz": 6.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.07.2022"
@@ -33009,7 +33009,7 @@
     {
       "attributes": {
         "Datum": "16.07.2022",
-        "Fallzahl": 230551,
+        "Fallzahl": 230587,
         "ObjectId": 862,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -33020,9 +33020,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 187,
         "BelegteBetten": null,
-        "Inzidenz": 684.651029131794,
+        "Inzidenz": 686.626674808722,
         "Datum_neu": 1657929600000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 499.076815760472,
@@ -33038,7 +33038,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.82,
+        "H_Inzidenz": 6.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.07.2022"
@@ -33047,7 +33047,7 @@
     {
       "attributes": {
         "Datum": "17.07.2022",
-        "Fallzahl": 230711,
+        "Fallzahl": 230772,
         "ObjectId": 863,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -33058,11 +33058,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 120,
         "BelegteBetten": null,
-        "Inzidenz": 678.364883796113,
+        "Inzidenz": 684.651029131794,
         "Datum_neu": 1658016000000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 455.928964253803,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33076,7 +33076,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.6,
+        "H_Inzidenz": 6.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.07.2022"
@@ -33098,9 +33098,9 @@
         "BelegteBetten": null,
         "Inzidenz": 665.074176514961,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 711,
+        "F\u00e4lle_Meldedatum": 780,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 432.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33114,7 +33114,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.27,
+        "H_Inzidenz": 5.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.07.2022"
@@ -33127,7 +33127,7 @@
         "ObjectId": 865,
         "Sterbefall": 1729,
         "Genesungsfall": 223283,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5878,
         "Zuwachs_Fallzahl": 941,
         "Zuwachs_Sterbefall": 0,
@@ -33136,13 +33136,13 @@
         "BelegteBetten": null,
         "Inzidenz": 670.641905240849,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 131,
-        "Zeitraum": "12.07.2022 - 18.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 806,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 514,
         "Fallzahl_aktiv": 6541,
-        "Krh_N_belegt": 532,
-        "Krh_I_belegt": 57,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 231,
         "Krh_I": null,
@@ -33152,11 +33152,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.43,
-        "H_Zeitraum": "12.07.2022 - 18.07.2022",
-        "H_Datum": "14.07.2022",
+        "H_Inzidenz": 4.68,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "18.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.07.2022",
+        "Fallzahl": 232446,
+        "ObjectId": 866,
+        "Sterbefall": 1729,
+        "Genesungsfall": 223844,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5892,
+        "Zuwachs_Fallzahl": 893,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 561,
+        "BelegteBetten": null,
+        "Inzidenz": 709.25679801717,
+        "Datum_neu": 1658275200000,
+        "F\u00e4lle_Meldedatum": 88,
+        "Zeitraum": "13.07.2022 - 19.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 604.1,
+        "Fallzahl_aktiv": 6873,
+        "Krh_N_belegt": 628,
+        "Krh_I_belegt": 60,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 332,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.52,
+        "H_Zeitraum": "13.07.2022 - 19.07.2022",
+        "H_Datum": "20.07.2022",
+        "Datum_Bett": "19.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
