### PR TITLE
New data set: 2022-07-21T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-20T102004Z.json
+pjson/2022-07-21T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-20T102004Z.json pjson/2022-07-21T100403Z.json```:
```
--- pjson/2022-07-20T102004Z.json	2022-07-20 10:20:04.332149607 +0000
+++ pjson/2022-07-21T100403Z.json	2022-07-21 10:04:03.444629055 +0000
@@ -32452,7 +32452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 476,
+        "F\u00e4lle_Meldedatum": 477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -32906,12 +32906,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 622,
         "BelegteBetten": null,
-        "Inzidenz": 574.374079528719,
+        "Inzidenz": null,
         "Datum_neu": 1657670400000,
         "F\u00e4lle_Meldedatum": 565,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 469.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32924,7 +32924,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.14,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.07.2022"
@@ -32946,7 +32946,7 @@
         "BelegteBetten": null,
         "Inzidenz": 571.320808937103,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 265,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 477,
@@ -32962,7 +32962,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
+        "H_Inzidenz": 6.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.07.2022"
@@ -32984,7 +32984,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.734832429326,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1117,
+        "F\u00e4lle_Meldedatum": 1119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 516.7,
@@ -33000,7 +33000,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.19,
+        "H_Inzidenz": 6.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.07.2022"
@@ -33009,7 +33009,7 @@
     {
       "attributes": {
         "Datum": "16.07.2022",
-        "Fallzahl": 230587,
+        "Fallzahl": 230590,
         "ObjectId": 862,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -33020,11 +33020,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 187,
         "BelegteBetten": null,
-        "Inzidenz": 686.626674808722,
+        "Inzidenz": 687.165487266066,
         "Datum_neu": 1657929600000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 499.076815760472,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33038,7 +33038,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.31,
+        "H_Inzidenz": 6.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.07.2022"
@@ -33047,7 +33047,7 @@
     {
       "attributes": {
         "Datum": "17.07.2022",
-        "Fallzahl": 230772,
+        "Fallzahl": 230776,
         "ObjectId": 863,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -33058,11 +33058,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 120,
         "BelegteBetten": null,
-        "Inzidenz": 684.651029131794,
+        "Inzidenz": 685.01023743669,
         "Datum_neu": 1658016000000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 455.928964253803,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33076,7 +33076,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.11,
+        "H_Inzidenz": 6.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.07.2022"
@@ -33098,9 +33098,9 @@
         "BelegteBetten": null,
         "Inzidenz": 665.074176514961,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 780,
+        "F\u00e4lle_Meldedatum": 794,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 432.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33114,7 +33114,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.92,
+        "H_Inzidenz": 6.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.07.2022"
@@ -33125,34 +33125,34 @@
         "Datum": "19.07.2022",
         "Fallzahl": 231553,
         "ObjectId": 865,
-        "Sterbefall": 1729,
-        "Genesungsfall": 223283,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5878,
-        "Zuwachs_Fallzahl": 941,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 710,
         "BelegteBetten": null,
         "Inzidenz": 670.641905240849,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 806,
+        "F\u00e4lle_Meldedatum": 832,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 514,
-        "Fallzahl_aktiv": 6541,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 231,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": 5.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.07.2022"
@@ -33165,7 +33165,7 @@
         "ObjectId": 866,
         "Sterbefall": 1729,
         "Genesungsfall": 223844,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5892,
         "Zuwachs_Fallzahl": 893,
         "Zuwachs_Sterbefall": 0,
@@ -33174,13 +33174,13 @@
         "BelegteBetten": null,
         "Inzidenz": 709.25679801717,
         "Datum_neu": 1658275200000,
-        "F\u00e4lle_Meldedatum": 88,
-        "Zeitraum": "13.07.2022 - 19.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 609,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 604.1,
         "Fallzahl_aktiv": 6873,
-        "Krh_N_belegt": 628,
-        "Krh_I_belegt": 60,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 332,
         "Krh_I": null,
@@ -33190,11 +33190,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.52,
-        "H_Zeitraum": "13.07.2022 - 19.07.2022",
-        "H_Datum": "20.07.2022",
+        "H_Inzidenz": 4.34,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.07.2022",
+        "Fallzahl": 233072,
+        "ObjectId": 867,
+        "Sterbefall": 1729,
+        "Genesungsfall": 224297,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5907,
+        "Zuwachs_Fallzahl": 626,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 453,
+        "BelegteBetten": null,
+        "Inzidenz": 724.882359280147,
+        "Datum_neu": 1658361600000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": "14.07.2022 - 20.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 629.6,
+        "Fallzahl_aktiv": 7046,
+        "Krh_N_belegt": 628,
+        "Krh_I_belegt": 60,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 173,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.06,
+        "H_Zeitraum": "14.07.2022 - 20.07.2022",
+        "H_Datum": "19.07.2022",
+        "Datum_Bett": "20.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
