### PR TITLE
New data set: 2022-07-22T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-21T100403Z.json
+pjson/2022-07-22T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-21T100403Z.json pjson/2022-07-22T100403Z.json```:
```
--- pjson/2022-07-21T100403Z.json	2022-07-21 10:04:03.444629055 +0000
+++ pjson/2022-07-22T100403Z.json	2022-07-22 10:04:03.528757898 +0000
@@ -32946,10 +32946,10 @@
         "BelegteBetten": null,
         "Inzidenz": 571.320808937103,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 267,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 477,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -32962,7 +32962,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.73,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.07.2022"
@@ -32984,7 +32984,7 @@
         "BelegteBetten": null,
         "Inzidenz": 537.734832429326,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1119,
+        "F\u00e4lle_Meldedatum": 1120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": 516.7,
@@ -33022,7 +33022,7 @@
         "BelegteBetten": null,
         "Inzidenz": 687.165487266066,
         "Datum_neu": 1657929600000,
-        "F\u00e4lle_Meldedatum": 230,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 499.076815760472,
@@ -33038,7 +33038,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.63,
+        "H_Inzidenz": 6.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.07.2022"
@@ -33076,7 +33076,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.51,
+        "H_Inzidenz": 6.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.07.2022"
@@ -33098,7 +33098,7 @@
         "BelegteBetten": null,
         "Inzidenz": 665.074176514961,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 794,
+        "F\u00e4lle_Meldedatum": 799,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 432.9,
@@ -33114,7 +33114,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.36,
+        "H_Inzidenz": 6.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.07.2022"
@@ -33136,7 +33136,7 @@
         "BelegteBetten": null,
         "Inzidenz": 670.641905240849,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 832,
+        "F\u00e4lle_Meldedatum": 848,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 514,
@@ -33152,7 +33152,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.3,
+        "H_Inzidenz": 5.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.07.2022"
@@ -33163,34 +33163,34 @@
         "Datum": "20.07.2022",
         "Fallzahl": 232446,
         "ObjectId": 866,
-        "Sterbefall": 1729,
-        "Genesungsfall": 223844,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5892,
-        "Zuwachs_Fallzahl": 893,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 561,
         "BelegteBetten": null,
         "Inzidenz": 709.25679801717,
         "Datum_neu": 1658275200000,
-        "F\u00e4lle_Meldedatum": 609,
+        "F\u00e4lle_Meldedatum": 678,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 604.1,
-        "Fallzahl_aktiv": 6873,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 332,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.34,
+        "H_Inzidenz": 5.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.07.2022"
@@ -33203,7 +33203,7 @@
         "ObjectId": 867,
         "Sterbefall": 1729,
         "Genesungsfall": 224297,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5907,
         "Zuwachs_Fallzahl": 626,
         "Zuwachs_Sterbefall": 0,
@@ -33212,9 +33212,9 @@
         "BelegteBetten": null,
         "Inzidenz": 724.882359280147,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 485,
         "Zeitraum": "14.07.2022 - 20.07.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 629.6,
         "Fallzahl_aktiv": 7046,
         "Krh_N_belegt": 628,
@@ -33228,11 +33228,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.06,
+        "H_Inzidenz": 4.12,
         "H_Zeitraum": "14.07.2022 - 20.07.2022",
         "H_Datum": "19.07.2022",
         "Datum_Bett": "20.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.07.2022",
+        "Fallzahl": 233667,
+        "ObjectId": 868,
+        "Sterbefall": 1729,
+        "Genesungsfall": 224685,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5936,
+        "Zuwachs_Fallzahl": 595,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 29,
+        "Zuwachs_Genesung": 388,
+        "BelegteBetten": null,
+        "Inzidenz": 780.739250691476,
+        "Datum_neu": 1658448000000,
+        "F\u00e4lle_Meldedatum": 78,
+        "Zeitraum": "15.07.2022 - 21.07.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 697.7,
+        "Fallzahl_aktiv": 7253,
+        "Krh_N_belegt": 628,
+        "Krh_I_belegt": 60,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 207,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.75,
+        "H_Zeitraum": "15.07.2022 - 21.07.2022",
+        "H_Datum": "19.07.2022",
+        "Datum_Bett": "21.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
