### PR TITLE
New data set: 2022-07-25T102203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-22T100403Z.json
+pjson/2022-07-25T102203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-22T100403Z.json pjson/2022-07-25T102203Z.json```:
```
--- pjson/2022-07-22T100403Z.json	2022-07-22 10:04:03.528757898 +0000
+++ pjson/2022-07-25T102203Z.json	2022-07-25 10:22:03.684664609 +0000
@@ -32604,7 +32604,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656979200000,
-        "F\u00e4lle_Meldedatum": 717,
+        "F\u00e4lle_Meldedatum": 718,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -32870,7 +32870,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 719,
+        "F\u00e4lle_Meldedatum": 720,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -32944,7 +32944,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 477,
         "BelegteBetten": null,
-        "Inzidenz": 571.320808937103,
+        "Inzidenz": null,
         "Datum_neu": 1657756800000,
         "F\u00e4lle_Meldedatum": 267,
         "Zeitraum": null,
@@ -32982,12 +32982,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 473,
         "BelegteBetten": null,
-        "Inzidenz": 537.734832429326,
+        "Inzidenz": null,
         "Datum_neu": 1657843200000,
         "F\u00e4lle_Meldedatum": 1120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
-        "Inzidenz_RKI": 516.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33000,7 +33000,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.43,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.07.2022"
@@ -33020,12 +33020,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 187,
         "BelegteBetten": null,
-        "Inzidenz": 687.165487266066,
+        "Inzidenz": null,
         "Datum_neu": 1657929600000,
-        "F\u00e4lle_Meldedatum": 231,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 499.076815760472,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33038,7 +33038,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.75,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.07.2022"
@@ -33058,12 +33058,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 120,
         "BelegteBetten": null,
-        "Inzidenz": 685.01023743669,
+        "Inzidenz": null,
         "Datum_neu": 1658016000000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 455.928964253803,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33076,7 +33076,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.63,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.07.2022"
@@ -33098,7 +33098,7 @@
         "BelegteBetten": null,
         "Inzidenz": 665.074176514961,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 799,
+        "F\u00e4lle_Meldedatum": 802,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 432.9,
@@ -33114,7 +33114,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.51,
+        "H_Inzidenz": 7.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.07.2022"
@@ -33136,7 +33136,7 @@
         "BelegteBetten": null,
         "Inzidenz": 670.641905240849,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 848,
+        "F\u00e4lle_Meldedatum": 851,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 514,
@@ -33152,7 +33152,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": 6.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.07.2022"
@@ -33174,7 +33174,7 @@
         "BelegteBetten": null,
         "Inzidenz": 709.25679801717,
         "Datum_neu": 1658275200000,
-        "F\u00e4lle_Meldedatum": 678,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 604.1,
@@ -33190,7 +33190,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.1,
+        "H_Inzidenz": 5.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.07.2022"
@@ -33201,36 +33201,36 @@
         "Datum": "21.07.2022",
         "Fallzahl": 233072,
         "ObjectId": 867,
-        "Sterbefall": 1729,
-        "Genesungsfall": 224297,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5907,
-        "Zuwachs_Fallzahl": 626,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 453,
         "BelegteBetten": null,
         "Inzidenz": 724.882359280147,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 485,
-        "Zeitraum": "14.07.2022 - 20.07.2022",
-        "Hosp_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 547,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 629.6,
-        "Fallzahl_aktiv": 7046,
-        "Krh_N_belegt": 628,
-        "Krh_I_belegt": 60,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 173,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.12,
-        "H_Zeitraum": "14.07.2022 - 20.07.2022",
-        "H_Datum": "19.07.2022",
+        "H_Inzidenz": 5.3,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.07.2022"
       }
     },
@@ -33241,7 +33241,7 @@
         "ObjectId": 868,
         "Sterbefall": 1729,
         "Genesungsfall": 224685,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5936,
         "Zuwachs_Fallzahl": 595,
         "Zuwachs_Sterbefall": 0,
@@ -33250,13 +33250,13 @@
         "BelegteBetten": null,
         "Inzidenz": 780.739250691476,
         "Datum_neu": 1658448000000,
-        "F\u00e4lle_Meldedatum": 78,
-        "Zeitraum": "15.07.2022 - 21.07.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 540,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 697.7,
         "Fallzahl_aktiv": 7253,
-        "Krh_N_belegt": 628,
-        "Krh_I_belegt": 60,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 207,
         "Krh_I": null,
@@ -33266,11 +33266,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
-        "H_Zeitraum": "15.07.2022 - 21.07.2022",
-        "H_Datum": "19.07.2022",
+        "H_Inzidenz": 5.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.07.2022",
+        "Fallzahl": 234416,
+        "ObjectId": 869,
+        "Sterbefall": null,
+        "Genesungsfall": 224940,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 255,
+        "BelegteBetten": null,
+        "Inzidenz": 691.29638277237,
+        "Datum_neu": 1658534400000,
+        "F\u00e4lle_Meldedatum": 203,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 582,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.02,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.07.2022",
+        "Fallzahl": 234477,
+        "ObjectId": 870,
+        "Sterbefall": null,
+        "Genesungsfall": 225074,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 134,
+        "BelegteBetten": null,
+        "Inzidenz": 685.728654046482,
+        "Datum_neu": 1658620800000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 540.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.8,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.07.2022",
+        "Fallzahl": 234509,
+        "ObjectId": 871,
+        "Sterbefall": 1729,
+        "Genesungsfall": 225842,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5945,
+        "Zuwachs_Fallzahl": 842,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 768,
+        "BelegteBetten": null,
+        "Inzidenz": 662.918926685585,
+        "Datum_neu": 1658707200000,
+        "F\u00e4lle_Meldedatum": 32,
+        "Zeitraum": "18.07.2022 - 24.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 507,
+        "Fallzahl_aktiv": 6938,
+        "Krh_N_belegt": 628,
+        "Krh_I_belegt": 60,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 74,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.5,
+        "H_Zeitraum": "18.07.2022 - 24.07.2022",
+        "H_Datum": "19.07.2025",
+        "Datum_Bett": "24.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
