### PR TITLE
New data set: 2022-07-26T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-25T102203Z.json
+pjson/2022-07-26T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-25T102203Z.json pjson/2022-07-26T100903Z.json```:
```
--- pjson/2022-07-25T102203Z.json	2022-07-25 10:22:03.684664609 +0000
+++ pjson/2022-07-26T100903Z.json	2022-07-26 10:09:03.769911746 +0000
@@ -29918,7 +29918,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -32376,7 +32376,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656460800000,
-        "F\u00e4lle_Meldedatum": 620,
+        "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -32718,7 +32718,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657238400000,
-        "F\u00e4lle_Meldedatum": 394,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -32870,7 +32870,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 720,
+        "F\u00e4lle_Meldedatum": 721,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -32920,7 +32920,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -32984,7 +32984,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1120,
+        "F\u00e4lle_Meldedatum": 1121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -33060,7 +33060,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658016000000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -33096,12 +33096,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 603,
         "BelegteBetten": null,
-        "Inzidenz": 665.074176514961,
+        "Inzidenz": null,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 802,
+        "F\u00e4lle_Meldedatum": 803,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 432.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33114,7 +33114,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.03,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.07.2022"
@@ -33152,7 +33152,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.36,
+        "H_Inzidenz": 6.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.07.2022"
@@ -33190,7 +33190,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.99,
+        "H_Inzidenz": 6.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.07.2022"
@@ -33212,7 +33212,7 @@
         "BelegteBetten": null,
         "Inzidenz": 724.882359280147,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 547,
+        "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 629.6,
@@ -33228,7 +33228,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.3,
+        "H_Inzidenz": 5.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.07.2022"
@@ -33239,34 +33239,34 @@
         "Datum": "22.07.2022",
         "Fallzahl": 233667,
         "ObjectId": 868,
-        "Sterbefall": 1729,
-        "Genesungsfall": 224685,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5936,
-        "Zuwachs_Fallzahl": 595,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 29,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 388,
         "BelegteBetten": null,
         "Inzidenz": 780.739250691476,
         "Datum_neu": 1658448000000,
-        "F\u00e4lle_Meldedatum": 540,
+        "F\u00e4lle_Meldedatum": 560,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 697.7,
-        "Fallzahl_aktiv": 7253,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 207,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 5.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.07.2022"
@@ -33278,7 +33278,7 @@
         "Fallzahl": 234416,
         "ObjectId": 869,
         "Sterbefall": null,
-        "Genesungsfall": 224940,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33288,9 +33288,9 @@
         "BelegteBetten": null,
         "Inzidenz": 691.29638277237,
         "Datum_neu": 1658534400000,
-        "F\u00e4lle_Meldedatum": 203,
+        "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 582,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33304,7 +33304,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.02,
+        "H_Inzidenz": 5.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.07.2022"
@@ -33316,7 +33316,7 @@
         "Fallzahl": 234477,
         "ObjectId": 870,
         "Sterbefall": null,
-        "Genesungsfall": 225074,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33326,7 +33326,7 @@
         "BelegteBetten": null,
         "Inzidenz": 685.728654046482,
         "Datum_neu": 1658620800000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 540.4,
@@ -33342,7 +33342,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 4.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.07.2022"
@@ -33355,7 +33355,7 @@
         "ObjectId": 871,
         "Sterbefall": 1729,
         "Genesungsfall": 225842,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5945,
         "Zuwachs_Fallzahl": 842,
         "Zuwachs_Sterbefall": 0,
@@ -33364,13 +33364,13 @@
         "BelegteBetten": null,
         "Inzidenz": 662.918926685585,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 32,
-        "Zeitraum": "18.07.2022 - 24.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 685,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 507,
         "Fallzahl_aktiv": 6938,
-        "Krh_N_belegt": 628,
-        "Krh_I_belegt": 60,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 74,
         "Krh_I": null,
@@ -33380,11 +33380,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.5,
-        "H_Zeitraum": "18.07.2022 - 24.07.2022",
-        "H_Datum": "19.07.2025",
+        "H_Inzidenz": 4.58,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.07.2022",
+        "Fallzahl": 235387,
+        "ObjectId": 872,
+        "Sterbefall": 1729,
+        "Genesungsfall": 226531,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5951,
+        "Zuwachs_Fallzahl": 878,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 689,
+        "BelegteBetten": null,
+        "Inzidenz": 664.176155752721,
+        "Datum_neu": 1658793600000,
+        "F\u00e4lle_Meldedatum": 97,
+        "Zeitraum": "19.07.2022 - 25.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 545.3,
+        "Fallzahl_aktiv": 7127,
+        "Krh_N_belegt": 628,
+        "Krh_I_belegt": 60,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 189,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.4,
+        "H_Zeitraum": "19.07.2022 - 25.07.2022",
+        "H_Datum": "19.07.2022",
+        "Datum_Bett": "25.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
