### PR TITLE
New data set: 2022-07-27T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-26T100903Z.json
+pjson/2022-07-27T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-26T100903Z.json pjson/2022-07-27T100103Z.json```:
```
--- pjson/2022-07-26T100903Z.json	2022-07-26 10:09:03.769911746 +0000
+++ pjson/2022-07-27T100103Z.json	2022-07-27 10:01:03.544450579 +0000
@@ -32984,9 +32984,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1121,
+        "F\u00e4lle_Meldedatum": 1122,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33136,10 +33136,10 @@
         "BelegteBetten": null,
         "Inzidenz": 670.641905240849,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 851,
+        "F\u00e4lle_Meldedatum": 853,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 514,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33152,7 +33152,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.07.2022"
@@ -33190,7 +33190,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.29,
+        "H_Inzidenz": 6.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.07.2022"
@@ -33212,7 +33212,7 @@
         "BelegteBetten": null,
         "Inzidenz": 724.882359280147,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 629.6,
@@ -33228,7 +33228,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.67,
+        "H_Inzidenz": 6.04,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.07.2022"
@@ -33250,7 +33250,7 @@
         "BelegteBetten": null,
         "Inzidenz": 780.739250691476,
         "Datum_neu": 1658448000000,
-        "F\u00e4lle_Meldedatum": 560,
+        "F\u00e4lle_Meldedatum": 565,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 697.7,
@@ -33266,7 +33266,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.92,
+        "H_Inzidenz": 6.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.07.2022"
@@ -33288,7 +33288,7 @@
         "BelegteBetten": null,
         "Inzidenz": 691.29638277237,
         "Datum_neu": 1658534400000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 244,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 582,
@@ -33304,7 +33304,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.05,
+        "H_Inzidenz": 5.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.07.2022"
@@ -33326,9 +33326,9 @@
         "BelegteBetten": null,
         "Inzidenz": 685.728654046482,
         "Datum_neu": 1658620800000,
-        "F\u00e4lle_Meldedatum": 120,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 540.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33342,7 +33342,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.88,
+        "H_Inzidenz": 5.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.07.2022"
@@ -33353,34 +33353,34 @@
         "Datum": "25.07.2022",
         "Fallzahl": 234509,
         "ObjectId": 871,
-        "Sterbefall": 1729,
-        "Genesungsfall": 225842,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5945,
-        "Zuwachs_Fallzahl": 842,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 768,
         "BelegteBetten": null,
         "Inzidenz": 662.918926685585,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 685,
+        "F\u00e4lle_Meldedatum": 741,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 507,
-        "Fallzahl_aktiv": 6938,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 74,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 5.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.07.2022"
@@ -33393,7 +33393,7 @@
         "ObjectId": 872,
         "Sterbefall": 1729,
         "Genesungsfall": 226531,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5951,
         "Zuwachs_Fallzahl": 878,
         "Zuwachs_Sterbefall": 0,
@@ -33402,9 +33402,9 @@
         "BelegteBetten": null,
         "Inzidenz": 664.176155752721,
         "Datum_neu": 1658793600000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 627,
         "Zeitraum": "19.07.2022 - 25.07.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 545.3,
         "Fallzahl_aktiv": 7127,
         "Krh_N_belegt": 628,
@@ -33418,11 +33418,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.4,
+        "H_Inzidenz": 5.79,
         "H_Zeitraum": "19.07.2022 - 25.07.2022",
         "H_Datum": "19.07.2022",
         "Datum_Bett": "25.07.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.07.2022",
+        "Fallzahl": 236079,
+        "ObjectId": 873,
+        "Sterbefall": 1729,
+        "Genesungsfall": 227106,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5961,
+        "Zuwachs_Fallzahl": 692,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 575,
+        "BelegteBetten": null,
+        "Inzidenz": 637.774345342864,
+        "Datum_neu": 1658880000000,
+        "F\u00e4lle_Meldedatum": 82,
+        "Zeitraum": "20.07.2022 - 26.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 547.4,
+        "Fallzahl_aktiv": 7244,
+        "Krh_N_belegt": 771,
+        "Krh_I_belegt": 75,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 117,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.63,
+        "H_Zeitraum": "20.07.2022 - 26.07.2022",
+        "H_Datum": "26.07.2022",
+        "Datum_Bett": "26.07.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
