### PR TITLE
New data set: 2022-07-28T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-27T100103Z.json
+pjson/2022-07-28T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-27T100103Z.json pjson/2022-07-28T100903Z.json```:
```
--- pjson/2022-07-27T100103Z.json	2022-07-27 10:01:03.544450579 +0000
+++ pjson/2022-07-28T100903Z.json	2022-07-28 10:09:03.699931103 +0000
@@ -31882,7 +31882,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 451,
+        "F\u00e4lle_Meldedatum": 452,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -33134,7 +33134,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 710,
         "BelegteBetten": null,
-        "Inzidenz": 670.641905240849,
+        "Inzidenz": null,
         "Datum_neu": 1658188800000,
         "F\u00e4lle_Meldedatum": 853,
         "Zeitraum": null,
@@ -33172,12 +33172,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 561,
         "BelegteBetten": null,
-        "Inzidenz": 709.25679801717,
+        "Inzidenz": null,
         "Datum_neu": 1658275200000,
         "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 604.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33190,7 +33190,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.07.2022"
@@ -33212,7 +33212,7 @@
         "BelegteBetten": null,
         "Inzidenz": 724.882359280147,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 557,
+        "F\u00e4lle_Meldedatum": 558,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 629.6,
@@ -33228,7 +33228,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.04,
+        "H_Inzidenz": 6.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.07.2022"
@@ -33250,7 +33250,7 @@
         "BelegteBetten": null,
         "Inzidenz": 780.739250691476,
         "Datum_neu": 1658448000000,
-        "F\u00e4lle_Meldedatum": 565,
+        "F\u00e4lle_Meldedatum": 568,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 697.7,
@@ -33266,7 +33266,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": 6.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.07.2022"
@@ -33304,7 +33304,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": 5.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.07.2022"
@@ -33326,7 +33326,7 @@
         "BelegteBetten": null,
         "Inzidenz": 685.728654046482,
         "Datum_neu": 1658620800000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 540.4,
@@ -33342,7 +33342,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.82,
+        "H_Inzidenz": 6.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.07.2022"
@@ -33364,9 +33364,9 @@
         "BelegteBetten": null,
         "Inzidenz": 662.918926685585,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 741,
+        "F\u00e4lle_Meldedatum": 755,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 507,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33380,7 +33380,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.84,
+        "H_Inzidenz": 6.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.07.2022"
@@ -33391,36 +33391,36 @@
         "Datum": "26.07.2022",
         "Fallzahl": 235387,
         "ObjectId": 872,
-        "Sterbefall": 1729,
-        "Genesungsfall": 226531,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5951,
-        "Zuwachs_Fallzahl": 878,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 689,
         "BelegteBetten": null,
         "Inzidenz": 664.176155752721,
         "Datum_neu": 1658793600000,
-        "F\u00e4lle_Meldedatum": 627,
-        "Zeitraum": "19.07.2022 - 25.07.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 666,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 545.3,
-        "Fallzahl_aktiv": 7127,
-        "Krh_N_belegt": 628,
-        "Krh_I_belegt": 60,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 189,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
-        "H_Zeitraum": "19.07.2022 - 25.07.2022",
-        "H_Datum": "19.07.2022",
+        "H_Inzidenz": 6.36,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.07.2022"
       }
     },
@@ -33429,26 +33429,64 @@
         "Datum": "27.07.2022",
         "Fallzahl": 236079,
         "ObjectId": 873,
-        "Sterbefall": 1729,
-        "Genesungsfall": 227106,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 5961,
-        "Zuwachs_Fallzahl": 692,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 575,
         "BelegteBetten": null,
         "Inzidenz": 637.774345342864,
         "Datum_neu": 1658880000000,
-        "F\u00e4lle_Meldedatum": 82,
-        "Zeitraum": "20.07.2022 - 26.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 497,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 547.4,
-        "Fallzahl_aktiv": 7244,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.07.2022",
+        "Fallzahl": 236594,
+        "ObjectId": 874,
+        "Sterbefall": 1729,
+        "Genesungsfall": 227373,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5969,
+        "Zuwachs_Fallzahl": 515,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 267,
+        "BelegteBetten": null,
+        "Inzidenz": 614.066597219728,
+        "Datum_neu": 1658966400000,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": "21.07.2022 - 27.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 554.2,
+        "Fallzahl_aktiv": 7492,
         "Krh_N_belegt": 771,
         "Krh_I_belegt": 75,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 117,
+        "Fallzahl_aktiv_Zuwachs": 248,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -33456,10 +33494,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
-        "H_Zeitraum": "20.07.2022 - 26.07.2022",
+        "H_Inzidenz": 4.61,
+        "H_Zeitraum": "21.07.2022 - 27.07.2022",
         "H_Datum": "26.07.2022",
-        "Datum_Bett": "26.07.2022"
+        "Datum_Bett": "27.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
