### PR TITLE
New data set: 2022-07-29T105604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-28T100903Z.json
+pjson/2022-07-29T105604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-28T100903Z.json pjson/2022-07-29T105604Z.json```:
```
--- pjson/2022-07-28T100903Z.json	2022-07-28 10:09:03.699931103 +0000
+++ pjson/2022-07-29T105604Z.json	2022-07-29 10:56:04.770732169 +0000
@@ -33210,12 +33210,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 453,
         "BelegteBetten": null,
-        "Inzidenz": 724.882359280147,
+        "Inzidenz": null,
         "Datum_neu": 1658361600000,
         "F\u00e4lle_Meldedatum": 558,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 629.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33228,7 +33228,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.19,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.07.2022"
@@ -33266,7 +33266,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.58,
+        "H_Inzidenz": 6.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.07.2022"
@@ -33288,7 +33288,7 @@
         "BelegteBetten": null,
         "Inzidenz": 691.29638277237,
         "Datum_neu": 1658534400000,
-        "F\u00e4lle_Meldedatum": 244,
+        "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 582,
@@ -33304,7 +33304,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.97,
+        "H_Inzidenz": 6.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.07.2022"
@@ -33342,7 +33342,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.14,
+        "H_Inzidenz": 6.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.07.2022"
@@ -33380,7 +33380,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.16,
+        "H_Inzidenz": 6.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.07.2022"
@@ -33402,7 +33402,7 @@
         "BelegteBetten": null,
         "Inzidenz": 664.176155752721,
         "Datum_neu": 1658793600000,
-        "F\u00e4lle_Meldedatum": 666,
+        "F\u00e4lle_Meldedatum": 671,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 545.3,
@@ -33418,7 +33418,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.36,
+        "H_Inzidenz": 6.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.07.2022"
@@ -33440,9 +33440,9 @@
         "BelegteBetten": null,
         "Inzidenz": 637.774345342864,
         "Datum_neu": 1658880000000,
-        "F\u00e4lle_Meldedatum": 497,
+        "F\u00e4lle_Meldedatum": 518,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 547.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33456,7 +33456,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.6,
+        "H_Inzidenz": 5.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.07.2022"
@@ -33467,37 +33467,75 @@
         "Datum": "28.07.2022",
         "Fallzahl": 236594,
         "ObjectId": 874,
-        "Sterbefall": 1729,
-        "Genesungsfall": 227373,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 5969,
-        "Zuwachs_Fallzahl": 515,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 267,
         "BelegteBetten": null,
         "Inzidenz": 614.066597219728,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 41,
-        "Zeitraum": "21.07.2022 - 27.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 328,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 554.2,
-        "Fallzahl_aktiv": 7492,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.45,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.07.2022",
+        "Fallzahl": 236959,
+        "ObjectId": 875,
+        "Sterbefall": 1729,
+        "Genesungsfall": 228457,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5972,
+        "Zuwachs_Fallzahl": 365,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 1084,
+        "BelegteBetten": null,
+        "Inzidenz": 577.606954272783,
+        "Datum_neu": 1659052800000,
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": "22.07.2022 - 28.07.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 528.7,
+        "Fallzahl_aktiv": 6773,
         "Krh_N_belegt": 771,
         "Krh_I_belegt": 75,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 248,
+        "Fallzahl_aktiv_Zuwachs": -719,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.61,
-        "H_Zeitraum": "21.07.2022 - 27.07.2022",
+        "H_Inzidenz": 4.46,
+        "H_Zeitraum": "22.07.2022 - 28.07.2022",
         "H_Datum": "26.07.2022",
-        "Datum_Bett": "27.07.2022"
+        "Datum_Bett": "28.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
