### PR TITLE
New data set: 2022-08-01T100004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-07-29T105604Z.json
+pjson/2022-08-01T100004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-07-29T105604Z.json pjson/2022-08-01T100004Z.json```:
```
--- pjson/2022-07-29T105604Z.json	2022-07-29 10:56:04.770732169 +0000
+++ pjson/2022-08-01T100004Z.json	2022-08-01 10:00:05.066708235 +0000
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1365,
+        "F\u00e4lle_Meldedatum": 1364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2046,
+        "F\u00e4lle_Meldedatum": 2045,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28272,7 +28272,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647129600000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 393,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2806,
+        "F\u00e4lle_Meldedatum": 2805,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2704,
+        "F\u00e4lle_Meldedatum": 2705,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -33248,12 +33248,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 388,
         "BelegteBetten": null,
-        "Inzidenz": 780.739250691476,
+        "Inzidenz": null,
         "Datum_neu": 1658448000000,
         "F\u00e4lle_Meldedatum": 568,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 697.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33266,7 +33266,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.78,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.07.2022"
@@ -33286,12 +33286,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 255,
         "BelegteBetten": null,
-        "Inzidenz": 691.29638277237,
+        "Inzidenz": null,
         "Datum_neu": 1658534400000,
         "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 582,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33304,7 +33304,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.16,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.07.2022"
@@ -33324,12 +33324,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 134,
         "BelegteBetten": null,
-        "Inzidenz": 685.728654046482,
+        "Inzidenz": null,
         "Datum_neu": 1658620800000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 540.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33342,7 +33342,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.33,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.07.2022"
@@ -33364,7 +33364,7 @@
         "BelegteBetten": null,
         "Inzidenz": 662.918926685585,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 755,
+        "F\u00e4lle_Meldedatum": 756,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 507,
@@ -33380,7 +33380,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
+        "H_Inzidenz": 7.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.07.2022"
@@ -33402,7 +33402,7 @@
         "BelegteBetten": null,
         "Inzidenz": 664.176155752721,
         "Datum_neu": 1658793600000,
-        "F\u00e4lle_Meldedatum": 671,
+        "F\u00e4lle_Meldedatum": 675,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 545.3,
@@ -33418,7 +33418,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
+        "H_Inzidenz": 7.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.07.2022"
@@ -33440,7 +33440,7 @@
         "BelegteBetten": null,
         "Inzidenz": 637.774345342864,
         "Datum_neu": 1658880000000,
-        "F\u00e4lle_Meldedatum": 518,
+        "F\u00e4lle_Meldedatum": 521,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 547.4,
@@ -33456,7 +33456,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.97,
+        "H_Inzidenz": 7.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.07.2022"
@@ -33478,10 +33478,10 @@
         "BelegteBetten": null,
         "Inzidenz": 614.066597219728,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 364,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 554.2,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 544.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33494,7 +33494,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.45,
+        "H_Inzidenz": 7.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.07.2022"
@@ -33507,7 +33507,7 @@
         "ObjectId": 875,
         "Sterbefall": 1729,
         "Genesungsfall": 228457,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5972,
         "Zuwachs_Fallzahl": 365,
         "Zuwachs_Sterbefall": 0,
@@ -33516,15 +33516,129 @@
         "BelegteBetten": null,
         "Inzidenz": 577.606954272783,
         "Datum_neu": 1659052800000,
-        "F\u00e4lle_Meldedatum": 51,
-        "Zeitraum": "22.07.2022 - 28.07.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 412,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 528.7,
         "Fallzahl_aktiv": 6773,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -719,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.26,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "28.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.07.2022",
+        "Fallzahl": 237452,
+        "ObjectId": 876,
+        "Sterbefall": null,
+        "Genesungsfall": 228722,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 265,
+        "BelegteBetten": null,
+        "Inzidenz": 557.491289198606,
+        "Datum_neu": 1659139200000,
+        "F\u00e4lle_Meldedatum": 89,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 481.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "29.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.07.2022",
+        "Fallzahl": 237477,
+        "ObjectId": 877,
+        "Sterbefall": null,
+        "Genesungsfall": 228914,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 192,
+        "BelegteBetten": null,
+        "Inzidenz": 529.473041416718,
+        "Datum_neu": 1659225600000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 437.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.15,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.08.2022",
+        "Fallzahl": 237501,
+        "ObjectId": 878,
+        "Sterbefall": 1729,
+        "Genesungsfall": 229701,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 5979,
+        "Zuwachs_Fallzahl": 542,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 787,
+        "BelegteBetten": null,
+        "Inzidenz": 510.435001257229,
+        "Datum_neu": 1659312000000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "25.07.2022 - 31.07.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 413.7,
+        "Fallzahl_aktiv": 6071,
         "Krh_N_belegt": 771,
         "Krh_I_belegt": 75,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -719,
+        "Fallzahl_aktiv_Zuwachs": -245,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33532,10 +33646,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.46,
-        "H_Zeitraum": "22.07.2022 - 28.07.2022",
+        "H_Inzidenz": 4.41,
+        "H_Zeitraum": "25.07.2022 - 31.07.2022",
         "H_Datum": "26.07.2022",
-        "Datum_Bett": "28.07.2022"
+        "Datum_Bett": "31.07.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
