### PR TITLE
New data set: 2022-08-02T113403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-01T100004Z.json
+pjson/2022-08-02T113403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-01T100004Z.json pjson/2022-08-02T113403Z.json```:
```
--- pjson/2022-08-01T100004Z.json	2022-08-01 10:00:05.066708235 +0000
+++ pjson/2022-08-02T113403Z.json	2022-08-02 11:34:03.801805594 +0000
@@ -32186,7 +32186,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656028800000,
-        "F\u00e4lle_Meldedatum": 491,
+        "F\u00e4lle_Meldedatum": 492,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -32300,7 +32300,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656288000000,
-        "F\u00e4lle_Meldedatum": 730,
+        "F\u00e4lle_Meldedatum": 742,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -32870,7 +32870,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 721,
+        "F\u00e4lle_Meldedatum": 722,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -32984,9 +32984,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1122,
+        "F\u00e4lle_Meldedatum": 1123,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33098,7 +33098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 803,
+        "F\u00e4lle_Meldedatum": 804,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33138,7 +33138,7 @@
         "Datum_neu": 1658188800000,
         "F\u00e4lle_Meldedatum": 853,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33212,7 +33212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 558,
+        "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -33250,9 +33250,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658448000000,
-        "F\u00e4lle_Meldedatum": 568,
+        "F\u00e4lle_Meldedatum": 569,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33300,7 +33300,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33326,7 +33326,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658620800000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -33362,12 +33362,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 768,
         "BelegteBetten": null,
-        "Inzidenz": 662.918926685585,
+        "Inzidenz": null,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 756,
+        "F\u00e4lle_Meldedatum": 757,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 507,
+        "Hosp_Meldedatum": 11,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33380,7 +33380,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.12,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.07.2022"
@@ -33402,9 +33402,9 @@
         "BelegteBetten": null,
         "Inzidenz": 664.176155752721,
         "Datum_neu": 1658793600000,
-        "F\u00e4lle_Meldedatum": 675,
+        "F\u00e4lle_Meldedatum": 676,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 545.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33414,11 +33414,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.54,
+        "H_Inzidenz": 7.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.07.2022"
@@ -33442,7 +33442,7 @@
         "Datum_neu": 1658880000000,
         "F\u00e4lle_Meldedatum": 521,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 547.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33456,7 +33456,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.47,
+        "H_Inzidenz": 7.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.07.2022"
@@ -33478,9 +33478,9 @@
         "BelegteBetten": null,
         "Inzidenz": 614.066597219728,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 364,
+        "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 544.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33490,11 +33490,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.07,
+        "H_Inzidenz": 7.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.07.2022"
@@ -33505,26 +33505,26 @@
         "Datum": "29.07.2022",
         "Fallzahl": 236959,
         "ObjectId": 875,
-        "Sterbefall": 1729,
-        "Genesungsfall": 228457,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5972,
-        "Zuwachs_Fallzahl": 365,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1084,
         "BelegteBetten": null,
         "Inzidenz": 577.606954272783,
         "Datum_neu": 1659052800000,
-        "F\u00e4lle_Meldedatum": 412,
+        "F\u00e4lle_Meldedatum": 422,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 528.7,
-        "Fallzahl_aktiv": 6773,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -719,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33532,7 +33532,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.26,
+        "H_Inzidenz": 7.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.07.2022"
@@ -33544,7 +33544,7 @@
         "Fallzahl": 237452,
         "ObjectId": 876,
         "Sterbefall": null,
-        "Genesungsfall": 228722,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33554,9 +33554,9 @@
         "BelegteBetten": null,
         "Inzidenz": 557.491289198606,
         "Datum_neu": 1659139200000,
-        "F\u00e4lle_Meldedatum": 89,
+        "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 481.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33566,11 +33566,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.6,
+        "H_Inzidenz": 6.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.07.2022"
@@ -33582,7 +33582,7 @@
         "Fallzahl": 237477,
         "ObjectId": 877,
         "Sterbefall": null,
-        "Genesungsfall": 228914,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33592,9 +33592,9 @@
         "BelegteBetten": null,
         "Inzidenz": 529.473041416718,
         "Datum_neu": 1659225600000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 437.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33608,7 +33608,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.15,
+        "H_Inzidenz": 6.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.07.2022"
@@ -33621,7 +33621,7 @@
         "ObjectId": 878,
         "Sterbefall": 1729,
         "Genesungsfall": 229701,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 5979,
         "Zuwachs_Fallzahl": 542,
         "Zuwachs_Sterbefall": 0,
@@ -33630,15 +33630,53 @@
         "BelegteBetten": null,
         "Inzidenz": 510.435001257229,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "25.07.2022 - 31.07.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 542,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 413.7,
         "Fallzahl_aktiv": 6071,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -245,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.74,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "31.07.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.08.2022",
+        "Fallzahl": 238212,
+        "ObjectId": 879,
+        "Sterbefall": 1734,
+        "Genesungsfall": 230551,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6043,
+        "Zuwachs_Fallzahl": 711,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 64,
+        "Zuwachs_Genesung": 850,
+        "BelegteBetten": null,
+        "Inzidenz": 484.931211609612,
+        "Datum_neu": 1659398400000,
+        "F\u00e4lle_Meldedatum": 103,
+        "Zeitraum": "26.07.2022 - 01.08.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 381.9,
+        "Fallzahl_aktiv": 5927,
         "Krh_N_belegt": 771,
         "Krh_I_belegt": 75,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -245,
+        "Fallzahl_aktiv_Zuwachs": -144,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33646,10 +33684,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
-        "H_Zeitraum": "25.07.2022 - 31.07.2022",
+        "H_Inzidenz": 3.75,
+        "H_Zeitraum": "26.07.2022 - 01.08.2022",
         "H_Datum": "26.07.2022",
-        "Datum_Bett": "31.07.2022"
+        "Datum_Bett": "01.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
