### PR TITLE
New data set: 2022-08-03T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-02T113403Z.json
+pjson/2022-08-03T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-02T113403Z.json pjson/2022-08-03T101303Z.json```:
```
--- pjson/2022-08-02T113403Z.json	2022-08-02 11:34:03.801805594 +0000
+++ pjson/2022-08-03T101303Z.json	2022-08-03 10:13:03.536391729 +0000
@@ -32148,7 +32148,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655942400000,
-        "F\u00e4lle_Meldedatum": 507,
+        "F\u00e4lle_Meldedatum": 508,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -32186,7 +32186,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656028800000,
-        "F\u00e4lle_Meldedatum": 492,
+        "F\u00e4lle_Meldedatum": 493,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -32948,7 +32948,7 @@
         "Datum_neu": 1657756800000,
         "F\u00e4lle_Meldedatum": 267,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32996,7 +32996,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33034,7 +33034,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33148,7 +33148,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33214,7 +33214,7 @@
         "Datum_neu": 1658361600000,
         "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33252,7 +33252,7 @@
         "Datum_neu": 1658448000000,
         "F\u00e4lle_Meldedatum": 569,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33366,7 +33366,7 @@
         "Datum_neu": 1658707200000,
         "F\u00e4lle_Meldedatum": 757,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33400,12 +33400,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 689,
         "BelegteBetten": null,
-        "Inzidenz": 664.176155752721,
+        "Inzidenz": null,
         "Datum_neu": 1658793600000,
         "F\u00e4lle_Meldedatum": 676,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 545.3,
+        "Hosp_Meldedatum": 15,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33418,7 +33418,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.07.2022"
@@ -33440,9 +33440,9 @@
         "BelegteBetten": null,
         "Inzidenz": 637.774345342864,
         "Datum_neu": 1658880000000,
-        "F\u00e4lle_Meldedatum": 521,
+        "F\u00e4lle_Meldedatum": 522,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 547.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33452,11 +33452,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
+        "H_Inzidenz": 8.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.07.2022"
@@ -33478,9 +33478,9 @@
         "BelegteBetten": null,
         "Inzidenz": 614.066597219728,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 366,
+        "F\u00e4lle_Meldedatum": 367,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 544.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33494,7 +33494,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.52,
+        "H_Inzidenz": 8.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.07.2022"
@@ -33516,7 +33516,7 @@
         "BelegteBetten": null,
         "Inzidenz": 577.606954272783,
         "Datum_neu": 1659052800000,
-        "F\u00e4lle_Meldedatum": 422,
+        "F\u00e4lle_Meldedatum": 426,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 528.7,
@@ -33532,7 +33532,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.05,
+        "H_Inzidenz": 8.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.07.2022"
@@ -33554,7 +33554,7 @@
         "BelegteBetten": null,
         "Inzidenz": 557.491289198606,
         "Datum_neu": 1659139200000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 481.2,
@@ -33570,7 +33570,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.85,
+        "H_Inzidenz": 9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.07.2022"
@@ -33592,7 +33592,7 @@
         "BelegteBetten": null,
         "Inzidenz": 529.473041416718,
         "Datum_neu": 1659225600000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 437.2,
@@ -33608,7 +33608,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
+        "H_Inzidenz": 8.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.07.2022"
@@ -33619,26 +33619,26 @@
         "Datum": "01.08.2022",
         "Fallzahl": 237501,
         "ObjectId": 878,
-        "Sterbefall": 1729,
-        "Genesungsfall": 229701,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 5979,
-        "Zuwachs_Fallzahl": 542,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 787,
         "BelegteBetten": null,
         "Inzidenz": 510.435001257229,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 556,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": 413.7,
-        "Fallzahl_aktiv": 6071,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -245,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33646,7 +33646,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": 8.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.07.2022"
@@ -33659,7 +33659,7 @@
         "ObjectId": 879,
         "Sterbefall": 1734,
         "Genesungsfall": 230551,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6043,
         "Zuwachs_Fallzahl": 711,
         "Zuwachs_Sterbefall": 5,
@@ -33668,13 +33668,13 @@
         "BelegteBetten": null,
         "Inzidenz": 484.931211609612,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 103,
-        "Zeitraum": "26.07.2022 - 01.08.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 523,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 381.9,
         "Fallzahl_aktiv": 5927,
-        "Krh_N_belegt": 771,
-        "Krh_I_belegt": 75,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -144,
         "Krh_I": null,
@@ -33684,11 +33684,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
-        "H_Zeitraum": "26.07.2022 - 01.08.2022",
-        "H_Datum": "26.07.2022",
+        "H_Inzidenz": 6.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.08.2022",
+        "Fallzahl": 238698,
+        "ObjectId": 880,
+        "Sterbefall": 1739,
+        "Genesungsfall": 231246,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6075,
+        "Zuwachs_Fallzahl": 486,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 32,
+        "Zuwachs_Genesung": 695,
+        "BelegteBetten": null,
+        "Inzidenz": 461.582671791372,
+        "Datum_neu": 1659484800000,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": "27.07.2022 - 02.08.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 392.8,
+        "Fallzahl_aktiv": 5713,
+        "Krh_N_belegt": 848,
+        "Krh_I_belegt": 104,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -214,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.15,
+        "H_Zeitraum": "27.07.2022 - 02.08.2022",
+        "H_Datum": "02.08.2022",
+        "Datum_Bett": "02.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
