### PR TITLE
New data set: 2022-08-04T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-03T101303Z.json
+pjson/2022-08-04T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-03T101303Z.json pjson/2022-08-04T100303Z.json```:
```
--- pjson/2022-08-03T101303Z.json	2022-08-03 10:13:03.536391729 +0000
+++ pjson/2022-08-04T100303Z.json	2022-08-04 10:03:03.660444737 +0000
@@ -32414,7 +32414,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656547200000,
-        "F\u00e4lle_Meldedatum": 488,
+        "F\u00e4lle_Meldedatum": 490,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -32680,7 +32680,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657152000000,
-        "F\u00e4lle_Meldedatum": 461,
+        "F\u00e4lle_Meldedatum": 462,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -32718,7 +32718,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657238400000,
-        "F\u00e4lle_Meldedatum": 393,
+        "F\u00e4lle_Meldedatum": 395,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -32832,7 +32832,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657497600000,
-        "F\u00e4lle_Meldedatum": 785,
+        "F\u00e4lle_Meldedatum": 786,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -32870,7 +32870,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657584000000,
-        "F\u00e4lle_Meldedatum": 722,
+        "F\u00e4lle_Meldedatum": 723,
         "Zeitraum": null,
         "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
@@ -32908,7 +32908,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657670400000,
-        "F\u00e4lle_Meldedatum": 565,
+        "F\u00e4lle_Meldedatum": 566,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -32946,9 +32946,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 267,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32984,9 +32984,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1123,
+        "F\u00e4lle_Meldedatum": 1124,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33174,7 +33174,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658275200000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 688,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -33214,7 +33214,7 @@
         "Datum_neu": 1658361600000,
         "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33250,7 +33250,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658448000000,
-        "F\u00e4lle_Meldedatum": 569,
+        "F\u00e4lle_Meldedatum": 570,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33288,9 +33288,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658534400000,
-        "F\u00e4lle_Meldedatum": 245,
+        "F\u00e4lle_Meldedatum": 246,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33404,7 +33404,7 @@
         "Datum_neu": 1658793600000,
         "F\u00e4lle_Meldedatum": 676,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33438,12 +33438,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 575,
         "BelegteBetten": null,
-        "Inzidenz": 637.774345342864,
+        "Inzidenz": null,
         "Datum_neu": 1658880000000,
-        "F\u00e4lle_Meldedatum": 522,
+        "F\u00e4lle_Meldedatum": 523,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 547.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33456,7 +33456,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.75,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.07.2022"
@@ -33494,7 +33494,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.82,
+        "H_Inzidenz": 9.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.07.2022"
@@ -33516,9 +33516,9 @@
         "BelegteBetten": null,
         "Inzidenz": 577.606954272783,
         "Datum_neu": 1659052800000,
-        "F\u00e4lle_Meldedatum": 426,
+        "F\u00e4lle_Meldedatum": 427,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 528.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33532,7 +33532,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.55,
+        "H_Inzidenz": 9.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.07.2022"
@@ -33554,7 +33554,7 @@
         "BelegteBetten": null,
         "Inzidenz": 557.491289198606,
         "Datum_neu": 1659139200000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 481.2,
@@ -33570,7 +33570,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9,
+        "H_Inzidenz": 9.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.07.2022"
@@ -33608,7 +33608,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.9,
+        "H_Inzidenz": 9.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.07.2022"
@@ -33630,9 +33630,9 @@
         "BelegteBetten": null,
         "Inzidenz": 510.435001257229,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 556,
+        "F\u00e4lle_Meldedatum": 557,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 31,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 413.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33646,7 +33646,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.26,
+        "H_Inzidenz": 8.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.07.2022"
@@ -33657,26 +33657,26 @@
         "Datum": "02.08.2022",
         "Fallzahl": 238212,
         "ObjectId": 879,
-        "Sterbefall": 1734,
-        "Genesungsfall": 230551,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6043,
-        "Zuwachs_Fallzahl": 711,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 64,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 850,
         "BelegteBetten": null,
         "Inzidenz": 484.931211609612,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 523,
+        "F\u00e4lle_Meldedatum": 547,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 381.9,
-        "Fallzahl_aktiv": 5927,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -144,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33684,7 +33684,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.56,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.08.2022"
@@ -33697,7 +33697,7 @@
         "ObjectId": 880,
         "Sterbefall": 1739,
         "Genesungsfall": 231246,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6075,
         "Zuwachs_Fallzahl": 486,
         "Zuwachs_Sterbefall": 5,
@@ -33706,13 +33706,13 @@
         "BelegteBetten": null,
         "Inzidenz": 461.582671791372,
         "Datum_neu": 1659484800000,
-        "F\u00e4lle_Meldedatum": 41,
-        "Zeitraum": "27.07.2022 - 02.08.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 325,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 392.8,
         "Fallzahl_aktiv": 5713,
-        "Krh_N_belegt": 848,
-        "Krh_I_belegt": 104,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -214,
         "Krh_I": null,
@@ -33722,11 +33722,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.15,
-        "H_Zeitraum": "27.07.2022 - 02.08.2022",
-        "H_Datum": "02.08.2022",
+        "H_Inzidenz": 5.64,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.08.2022",
+        "Fallzahl": 239051,
+        "ObjectId": 881,
+        "Sterbefall": 1739,
+        "Genesungsfall": 231781,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6091,
+        "Zuwachs_Fallzahl": 353,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 535,
+        "BelegteBetten": null,
+        "Inzidenz": 431.049965875211,
+        "Datum_neu": 1659571200000,
+        "F\u00e4lle_Meldedatum": 30,
+        "Zeitraum": "28.07.2022 - 03.08.2022",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 388.5,
+        "Fallzahl_aktiv": 5531,
+        "Krh_N_belegt": 848,
+        "Krh_I_belegt": 104,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -182,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.58,
+        "H_Zeitraum": "28.07.2022 - 03.08.2022",
+        "H_Datum": "04.08.2022",
+        "Datum_Bett": "03.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
