### PR TITLE
New data set: 2022-08-05T100703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-04T100303Z.json
+pjson/2022-08-05T100703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-04T100303Z.json pjson/2022-08-05T100703Z.json```:
```
--- pjson/2022-08-04T100303Z.json	2022-08-04 10:03:03.660444737 +0000
+++ pjson/2022-08-05T100703Z.json	2022-08-05 10:07:03.898792712 +0000
@@ -30020,7 +30020,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651104000000,
-        "F\u00e4lle_Meldedatum": 499,
+        "F\u00e4lle_Meldedatum": 501,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -31958,7 +31958,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655510400000,
-        "F\u00e4lle_Meldedatum": 215,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -32920,7 +32920,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33148,7 +33148,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33300,7 +33300,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33476,12 +33476,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 267,
         "BelegteBetten": null,
-        "Inzidenz": 614.066597219728,
+        "Inzidenz": null,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 367,
+        "F\u00e4lle_Meldedatum": 369,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 544.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33494,7 +33494,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.44,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.07.2022"
@@ -33516,7 +33516,7 @@
         "BelegteBetten": null,
         "Inzidenz": 577.606954272783,
         "Datum_neu": 1659052800000,
-        "F\u00e4lle_Meldedatum": 427,
+        "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 528.7,
@@ -33532,7 +33532,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.22,
+        "H_Inzidenz": 9.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.07.2022"
@@ -33570,7 +33570,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.61,
+        "H_Inzidenz": 9.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.07.2022"
@@ -33608,7 +33608,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.49,
+        "H_Inzidenz": 9.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.07.2022"
@@ -33630,7 +33630,7 @@
         "BelegteBetten": null,
         "Inzidenz": 510.435001257229,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 557,
+        "F\u00e4lle_Meldedatum": 563,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 413.7,
@@ -33646,7 +33646,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.85,
+        "H_Inzidenz": 9.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.07.2022"
@@ -33668,7 +33668,7 @@
         "BelegteBetten": null,
         "Inzidenz": 484.931211609612,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 547,
+        "F\u00e4lle_Meldedatum": 552,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 381.9,
@@ -33684,7 +33684,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": 7.2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.08.2022"
@@ -33695,26 +33695,26 @@
         "Datum": "03.08.2022",
         "Fallzahl": 238698,
         "ObjectId": 880,
-        "Sterbefall": 1739,
-        "Genesungsfall": 231246,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6075,
-        "Zuwachs_Fallzahl": 486,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 32,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 695,
         "BelegteBetten": null,
         "Inzidenz": 461.582671791372,
         "Datum_neu": 1659484800000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 351,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 392.8,
-        "Fallzahl_aktiv": 5713,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -214,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33722,7 +33722,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.64,
+        "H_Inzidenz": 6.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.08.2022"
@@ -33735,7 +33735,7 @@
         "ObjectId": 881,
         "Sterbefall": 1739,
         "Genesungsfall": 231781,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6091,
         "Zuwachs_Fallzahl": 353,
         "Zuwachs_Sterbefall": 0,
@@ -33744,13 +33744,13 @@
         "BelegteBetten": null,
         "Inzidenz": 431.049965875211,
         "Datum_neu": 1659571200000,
-        "F\u00e4lle_Meldedatum": 30,
-        "Zeitraum": "28.07.2022 - 03.08.2022",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 312,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 388.5,
         "Fallzahl_aktiv": 5531,
-        "Krh_N_belegt": 848,
-        "Krh_I_belegt": 104,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -182,
         "Krh_I": null,
@@ -33760,11 +33760,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
-        "H_Zeitraum": "28.07.2022 - 03.08.2022",
-        "H_Datum": "04.08.2022",
+        "H_Inzidenz": 6.09,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.08.2022",
+        "Fallzahl": 239402,
+        "ObjectId": 882,
+        "Sterbefall": 1740,
+        "Genesungsfall": 232341,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6104,
+        "Zuwachs_Fallzahl": 351,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 560,
+        "BelegteBetten": null,
+        "Inzidenz": 428.176299436043,
+        "Datum_neu": 1659657600000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "29.07.2022 - 04.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 382.8,
+        "Fallzahl_aktiv": 5321,
+        "Krh_N_belegt": 848,
+        "Krh_I_belegt": 104,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -210,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.95,
+        "H_Zeitraum": "29.07.2022 - 04.08.2022",
+        "H_Datum": "02.08.2022",
+        "Datum_Bett": "04.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
