### PR TITLE
New data set: 2022-08-08T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-05T100703Z.json
+pjson/2022-08-08T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-05T100703Z.json pjson/2022-08-08T100203Z.json```:
```
--- pjson/2022-08-05T100703Z.json	2022-08-05 10:07:03.898792712 +0000
+++ pjson/2022-08-08T100203Z.json	2022-08-08 10:02:03.917848814 +0000
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2085,
+        "F\u00e4lle_Meldedatum": 2086,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2805,
+        "F\u00e4lle_Meldedatum": 2806,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28538,7 +28538,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647734400000,
-        "F\u00e4lle_Meldedatum": 377,
+        "F\u00e4lle_Meldedatum": 378,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2136,
+        "F\u00e4lle_Meldedatum": 2137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2198,
+        "F\u00e4lle_Meldedatum": 2199,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -32566,7 +32566,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656892800000,
-        "F\u00e4lle_Meldedatum": 620,
+        "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -33364,7 +33364,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 757,
+        "F\u00e4lle_Meldedatum": 758,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -33478,7 +33478,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 369,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -33514,12 +33514,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1084,
         "BelegteBetten": null,
-        "Inzidenz": 577.606954272783,
+        "Inzidenz": null,
         "Datum_neu": 1659052800000,
         "F\u00e4lle_Meldedatum": 429,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 528.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33532,7 +33532,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.49,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.07.2022"
@@ -33552,12 +33552,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 265,
         "BelegteBetten": null,
-        "Inzidenz": 557.491289198606,
+        "Inzidenz": null,
         "Datum_neu": 1659139200000,
         "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 481.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33570,7 +33570,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.93,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.07.2022"
@@ -33590,12 +33590,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 192,
         "BelegteBetten": null,
-        "Inzidenz": 529.473041416718,
+        "Inzidenz": null,
         "Datum_neu": 1659225600000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 437.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33608,7 +33608,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.07.2022"
@@ -33630,9 +33630,9 @@
         "BelegteBetten": null,
         "Inzidenz": 510.435001257229,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 563,
+        "F\u00e4lle_Meldedatum": 566,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": 413.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33646,7 +33646,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.19,
+        "H_Inzidenz": 9.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.07.2022"
@@ -33668,7 +33668,7 @@
         "BelegteBetten": null,
         "Inzidenz": 484.931211609612,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 552,
+        "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 381.9,
@@ -33684,7 +33684,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.2,
+        "H_Inzidenz": 7.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.08.2022"
@@ -33706,9 +33706,9 @@
         "BelegteBetten": null,
         "Inzidenz": 461.582671791372,
         "Datum_neu": 1659484800000,
-        "F\u00e4lle_Meldedatum": 351,
+        "F\u00e4lle_Meldedatum": 353,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 392.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33722,7 +33722,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
+        "H_Inzidenz": 6.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.08.2022"
@@ -33733,26 +33733,26 @@
         "Datum": "04.08.2022",
         "Fallzahl": 239051,
         "ObjectId": 881,
-        "Sterbefall": 1739,
-        "Genesungsfall": 231781,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6091,
-        "Zuwachs_Fallzahl": 353,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 535,
         "BelegteBetten": null,
         "Inzidenz": 431.049965875211,
         "Datum_neu": 1659571200000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 388.5,
-        "Fallzahl_aktiv": 5531,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -182,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33760,7 +33760,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.09,
+        "H_Inzidenz": 6.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.08.2022"
@@ -33773,7 +33773,7 @@
         "ObjectId": 882,
         "Sterbefall": 1740,
         "Genesungsfall": 232341,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6104,
         "Zuwachs_Fallzahl": 351,
         "Zuwachs_Sterbefall": 1,
@@ -33782,15 +33782,129 @@
         "BelegteBetten": null,
         "Inzidenz": 428.176299436043,
         "Datum_neu": 1659657600000,
-        "F\u00e4lle_Meldedatum": 25,
-        "Zeitraum": "29.07.2022 - 04.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 299,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 382.8,
         "Fallzahl_aktiv": 5321,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -210,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.55,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.08.2022",
+        "Fallzahl": 239848,
+        "ObjectId": 883,
+        "Sterbefall": null,
+        "Genesungsfall": 232590,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 249,
+        "BelegteBetten": null,
+        "Inzidenz": 408.779050971659,
+        "Datum_neu": 1659744000000,
+        "F\u00e4lle_Meldedatum": 142,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 353.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.29,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "05.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.08.2022",
+        "Fallzahl": 239892,
+        "ObjectId": 884,
+        "Sterbefall": null,
+        "Genesungsfall": 232726,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 136,
+        "BelegteBetten": null,
+        "Inzidenz": 412.909946477963,
+        "Datum_neu": 1659830400000,
+        "F\u00e4lle_Meldedatum": 44,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 332.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.89,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "06.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.08.2022",
+        "Fallzahl": 239901,
+        "ObjectId": 885,
+        "Sterbefall": 1740,
+        "Genesungsfall": 233464,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6107,
+        "Zuwachs_Fallzahl": 499,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 738,
+        "BelegteBetten": null,
+        "Inzidenz": 410.395488343691,
+        "Datum_neu": 1659916800000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "01.08.2022 - 07.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 321.6,
+        "Fallzahl_aktiv": 4697,
         "Krh_N_belegt": 848,
         "Krh_I_belegt": 104,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -210,
+        "Fallzahl_aktiv_Zuwachs": -239,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33798,10 +33912,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.95,
-        "H_Zeitraum": "29.07.2022 - 04.08.2022",
+        "H_Inzidenz": 3.67,
+        "H_Zeitraum": "01.08.2022 - 07.08.2022",
         "H_Datum": "02.08.2022",
-        "Datum_Bett": "04.08.2022"
+        "Datum_Bett": "07.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
