### PR TITLE
New data set: 2022-08-09T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-08T100203Z.json
+pjson/2022-08-09T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-08T100203Z.json pjson/2022-08-09T100403Z.json```:
```
--- pjson/2022-08-08T100203Z.json	2022-08-08 10:02:03.917848814 +0000
+++ pjson/2022-08-09T100403Z.json	2022-08-09 10:04:04.136536277 +0000
@@ -33136,7 +33136,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 853,
+        "F\u00e4lle_Meldedatum": 854,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33402,7 +33402,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658793600000,
-        "F\u00e4lle_Meldedatum": 676,
+        "F\u00e4lle_Meldedatum": 675,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33478,7 +33478,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 370,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -33628,12 +33628,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 787,
         "BelegteBetten": null,
-        "Inzidenz": 510.435001257229,
+        "Inzidenz": null,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 566,
+        "F\u00e4lle_Meldedatum": 569,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
-        "Inzidenz_RKI": 413.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33646,7 +33646,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.27,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.07.2022"
@@ -33668,7 +33668,7 @@
         "BelegteBetten": null,
         "Inzidenz": 484.931211609612,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 553,
+        "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 381.9,
@@ -33684,7 +33684,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.37,
+        "H_Inzidenz": 7.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.08.2022"
@@ -33706,7 +33706,7 @@
         "BelegteBetten": null,
         "Inzidenz": 461.582671791372,
         "Datum_neu": 1659484800000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 392.8,
@@ -33722,7 +33722,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.95,
+        "H_Inzidenz": 7.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.08.2022"
@@ -33744,7 +33744,7 @@
         "BelegteBetten": null,
         "Inzidenz": 431.049965875211,
         "Datum_neu": 1659571200000,
-        "F\u00e4lle_Meldedatum": 328,
+        "F\u00e4lle_Meldedatum": 333,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 388.5,
@@ -33760,7 +33760,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
+        "H_Inzidenz": 7.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.08.2022"
@@ -33771,26 +33771,26 @@
         "Datum": "05.08.2022",
         "Fallzahl": 239402,
         "ObjectId": 882,
-        "Sterbefall": 1740,
-        "Genesungsfall": 232341,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6104,
-        "Zuwachs_Fallzahl": 351,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 560,
         "BelegteBetten": null,
         "Inzidenz": 428.176299436043,
         "Datum_neu": 1659657600000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 382.8,
-        "Fallzahl_aktiv": 5321,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -210,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33798,7 +33798,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.55,
+        "H_Inzidenz": 6.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.08.2022"
@@ -33810,7 +33810,7 @@
         "Fallzahl": 239848,
         "ObjectId": 883,
         "Sterbefall": null,
-        "Genesungsfall": 232590,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33820,9 +33820,9 @@
         "BelegteBetten": null,
         "Inzidenz": 408.779050971659,
         "Datum_neu": 1659744000000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 353.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33836,7 +33836,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.29,
+        "H_Inzidenz": 5.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.08.2022"
@@ -33848,7 +33848,7 @@
         "Fallzahl": 239892,
         "ObjectId": 884,
         "Sterbefall": null,
-        "Genesungsfall": 232726,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -33858,9 +33858,9 @@
         "BelegteBetten": null,
         "Inzidenz": 412.909946477963,
         "Datum_neu": 1659830400000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 332.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33874,7 +33874,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
+        "H_Inzidenz": 5.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.08.2022"
@@ -33887,7 +33887,7 @@
         "ObjectId": 885,
         "Sterbefall": 1740,
         "Genesungsfall": 233464,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6107,
         "Zuwachs_Fallzahl": 499,
         "Zuwachs_Sterbefall": 0,
@@ -33896,15 +33896,53 @@
         "BelegteBetten": null,
         "Inzidenz": 410.395488343691,
         "Datum_neu": 1659916800000,
-        "F\u00e4lle_Meldedatum": 9,
-        "Zeitraum": "01.08.2022 - 07.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 419,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 321.6,
         "Fallzahl_aktiv": 4697,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -239,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.88,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "07.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.08.2022",
+        "Fallzahl": 240461,
+        "ObjectId": 886,
+        "Sterbefall": 1740,
+        "Genesungsfall": 234144,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6126,
+        "Zuwachs_Fallzahl": 560,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 680,
+        "BelegteBetten": null,
+        "Inzidenz": 399.978447501706,
+        "Datum_neu": 1660003200000,
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": "02.08.2022 - 08.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 320,
+        "Fallzahl_aktiv": 4577,
         "Krh_N_belegt": 848,
         "Krh_I_belegt": 104,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -239,
+        "Fallzahl_aktiv_Zuwachs": -120,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33912,10 +33950,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.67,
-        "H_Zeitraum": "01.08.2022 - 07.08.2022",
+        "H_Inzidenz": 3.92,
+        "H_Zeitraum": "02.08.2022 - 08.08.2022",
         "H_Datum": "02.08.2022",
-        "Datum_Bett": "07.08.2022"
+        "Datum_Bett": "08.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
