### PR TITLE
New data set: 2022-08-10T101603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-09T100403Z.json
+pjson/2022-08-10T101603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-09T100403Z.json pjson/2022-08-10T101603Z.json```:
```
--- pjson/2022-08-09T100403Z.json	2022-08-09 10:04:04.136536277 +0000
+++ pjson/2022-08-10T101603Z.json	2022-08-10 10:16:04.059472005 +0000
@@ -33174,7 +33174,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658275200000,
-        "F\u00e4lle_Meldedatum": 688,
+        "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -33212,7 +33212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 557,
+        "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -33250,7 +33250,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658448000000,
-        "F\u00e4lle_Meldedatum": 570,
+        "F\u00e4lle_Meldedatum": 571,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33326,7 +33326,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658620800000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -33364,7 +33364,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 758,
+        "F\u00e4lle_Meldedatum": 761,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -33630,7 +33630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 569,
+        "F\u00e4lle_Meldedatum": 571,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -33666,12 +33666,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 850,
         "BelegteBetten": null,
-        "Inzidenz": 484.931211609612,
+        "Inzidenz": null,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 381.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33684,7 +33684,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.46,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.08.2022"
@@ -33722,7 +33722,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.32,
+        "H_Inzidenz": 7.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.08.2022"
@@ -33744,9 +33744,9 @@
         "BelegteBetten": null,
         "Inzidenz": 431.049965875211,
         "Datum_neu": 1659571200000,
-        "F\u00e4lle_Meldedatum": 333,
+        "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 388.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33760,7 +33760,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.05,
+        "H_Inzidenz": 7.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.08.2022"
@@ -33782,7 +33782,7 @@
         "BelegteBetten": null,
         "Inzidenz": 428.176299436043,
         "Datum_neu": 1659657600000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 382.8,
@@ -33798,7 +33798,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.31,
+        "H_Inzidenz": 6.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.08.2022"
@@ -33820,9 +33820,9 @@
         "BelegteBetten": null,
         "Inzidenz": 408.779050971659,
         "Datum_neu": 1659744000000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 353.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33836,7 +33836,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.25,
+        "H_Inzidenz": 6.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.08.2022"
@@ -33858,7 +33858,7 @@
         "BelegteBetten": null,
         "Inzidenz": 412.909946477963,
         "Datum_neu": 1659830400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 332.1,
@@ -33874,7 +33874,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.05,
+        "H_Inzidenz": 5.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.08.2022"
@@ -33885,26 +33885,26 @@
         "Datum": "08.08.2022",
         "Fallzahl": 239901,
         "ObjectId": 885,
-        "Sterbefall": 1740,
-        "Genesungsfall": 233464,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6107,
-        "Zuwachs_Fallzahl": 499,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 738,
         "BelegteBetten": null,
         "Inzidenz": 410.395488343691,
         "Datum_neu": 1659916800000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 321.6,
-        "Fallzahl_aktiv": 4697,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -239,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33912,7 +33912,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.88,
+        "H_Inzidenz": 5.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.08.2022"
@@ -33925,24 +33925,24 @@
         "ObjectId": 886,
         "Sterbefall": 1740,
         "Genesungsfall": 234144,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6126,
         "Zuwachs_Fallzahl": 560,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Sterbefall": 1740,
+        "Zuwachs_Krankenhauseinweisung": 6126,
         "Zuwachs_Genesung": 680,
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 55,
-        "Zeitraum": "02.08.2022 - 08.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 432,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 320,
         "Fallzahl_aktiv": 4577,
-        "Krh_N_belegt": 848,
-        "Krh_I_belegt": 104,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -120,
+        "Fallzahl_aktiv_Zuwachs": -1860,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33950,11 +33950,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
-        "H_Zeitraum": "02.08.2022 - 08.08.2022",
-        "H_Datum": "02.08.2022",
+        "H_Inzidenz": 5.08,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.08.2022",
+        "Fallzahl": 240930,
+        "ObjectId": 887,
+        "Sterbefall": 1740,
+        "Genesungsfall": 234670,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6132,
+        "Zuwachs_Fallzahl": 469,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 526,
+        "BelegteBetten": null,
+        "Inzidenz": 387.04694852545,
+        "Datum_neu": 1660089600000,
+        "F\u00e4lle_Meldedatum": 30,
+        "Zeitraum": "03.08.2022 - 09.08.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 321.3,
+        "Fallzahl_aktiv": 4520,
+        "Krh_N_belegt": 808,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -57,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.52,
+        "H_Zeitraum": "03.08.2022 - 09.08.2022",
+        "H_Datum": "09.08.2022",
+        "Datum_Bett": "09.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
