### PR TITLE
New data set: 2022-08-11T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-10T101603Z.json
+pjson/2022-08-11T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-10T101603Z.json pjson/2022-08-11T101303Z.json```:
```
--- pjson/2022-08-10T101603Z.json	2022-08-10 10:16:04.059472005 +0000
+++ pjson/2022-08-11T101303Z.json	2022-08-11 10:13:03.473827306 +0000
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1250,
+        "F\u00e4lle_Meldedatum": 1249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27398,7 +27398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 903,
+        "F\u00e4lle_Meldedatum": 902,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -27512,7 +27512,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645401600000,
-        "F\u00e4lle_Meldedatum": 1483,
+        "F\u00e4lle_Meldedatum": 1482,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -28044,7 +28044,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646611200000,
-        "F\u00e4lle_Meldedatum": 2045,
+        "F\u00e4lle_Meldedatum": 2044,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2806,
+        "F\u00e4lle_Meldedatum": 2805,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2364,
+        "F\u00e4lle_Meldedatum": 2362,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -29108,7 +29108,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649030400000,
-        "F\u00e4lle_Meldedatum": 1811,
+        "F\u00e4lle_Meldedatum": 1810,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -29374,7 +29374,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649635200000,
-        "F\u00e4lle_Meldedatum": 1316,
+        "F\u00e4lle_Meldedatum": 1315,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -29412,7 +29412,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649721600000,
-        "F\u00e4lle_Meldedatum": 1262,
+        "F\u00e4lle_Meldedatum": 1261,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -29602,7 +29602,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650153600000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -29906,7 +29906,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650844800000,
-        "F\u00e4lle_Meldedatum": 1110,
+        "F\u00e4lle_Meldedatum": 1108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -29944,7 +29944,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1650931200000,
-        "F\u00e4lle_Meldedatum": 608,
+        "F\u00e4lle_Meldedatum": 606,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -31996,7 +31996,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655596800000,
-        "F\u00e4lle_Meldedatum": 169,
+        "F\u00e4lle_Meldedatum": 168,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -32920,7 +32920,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -32958,7 +32958,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33024,7 +33024,7 @@
         "Datum_neu": 1657929600000,
         "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33136,7 +33136,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 854,
+        "F\u00e4lle_Meldedatum": 855,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33176,7 +33176,7 @@
         "Datum_neu": 1658275200000,
         "F\u00e4lle_Meldedatum": 689,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33214,7 +33214,7 @@
         "Datum_neu": 1658361600000,
         "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33554,7 +33554,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659139200000,
-        "F\u00e4lle_Meldedatum": 119,
+        "F\u00e4lle_Meldedatum": 118,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -33630,7 +33630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 571,
+        "F\u00e4lle_Meldedatum": 572,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -33668,7 +33668,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 553,
+        "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -33704,12 +33704,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 695,
         "BelegteBetten": null,
-        "Inzidenz": 461.582671791372,
+        "Inzidenz": null,
         "Datum_neu": 1659484800000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 392.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33722,7 +33722,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.64,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.08.2022"
@@ -33760,7 +33760,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.39,
+        "H_Inzidenz": 7.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.08.2022"
@@ -33782,7 +33782,7 @@
         "BelegteBetten": null,
         "Inzidenz": 428.176299436043,
         "Datum_neu": 1659657600000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 382.8,
@@ -33798,7 +33798,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.78,
+        "H_Inzidenz": 6.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.08.2022"
@@ -33836,7 +33836,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.11,
+        "H_Inzidenz": 6.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.08.2022"
@@ -33858,7 +33858,7 @@
         "BelegteBetten": null,
         "Inzidenz": 412.909946477963,
         "Datum_neu": 1659830400000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 332.1,
@@ -33874,7 +33874,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.97,
+        "H_Inzidenz": 6.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.08.2022"
@@ -33896,7 +33896,7 @@
         "BelegteBetten": null,
         "Inzidenz": 410.395488343691,
         "Datum_neu": 1659916800000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 458,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 321.6,
@@ -33912,7 +33912,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.89,
+        "H_Inzidenz": 6.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.08.2022"
@@ -33923,26 +33923,26 @@
         "Datum": "09.08.2022",
         "Fallzahl": 240461,
         "ObjectId": 886,
-        "Sterbefall": 1740,
-        "Genesungsfall": 234144,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6126,
-        "Zuwachs_Fallzahl": 560,
-        "Zuwachs_Sterbefall": 1740,
-        "Zuwachs_Krankenhauseinweisung": 6126,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 680,
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 432,
+        "F\u00e4lle_Meldedatum": 447,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 320,
-        "Fallzahl_aktiv": 4577,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1860,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33950,7 +33950,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.08,
+        "H_Inzidenz": 5.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.08.2022"
@@ -33962,25 +33962,63 @@
         "Fallzahl": 240930,
         "ObjectId": 887,
         "Sterbefall": 1740,
-        "Genesungsfall": 234670,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 234681,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6132,
         "Zuwachs_Fallzahl": 469,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Sterbefall": 1740,
+        "Zuwachs_Krankenhauseinweisung": 6132,
         "Zuwachs_Genesung": 526,
         "BelegteBetten": null,
         "Inzidenz": 387.04694852545,
         "Datum_neu": 1660089600000,
-        "F\u00e4lle_Meldedatum": 30,
-        "Zeitraum": "03.08.2022 - 09.08.2022",
+        "F\u00e4lle_Meldedatum": 390,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 321.3,
-        "Fallzahl_aktiv": 4520,
+        "Fallzahl_aktiv": 4509,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1797,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.54,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "09.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.08.2022",
+        "Fallzahl": 241319,
+        "ObjectId": 888,
+        "Sterbefall": 1742,
+        "Genesungsfall": 235074,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6132,
+        "Zuwachs_Fallzahl": 389,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 393,
+        "BelegteBetten": null,
+        "Inzidenz": 396.745572757642,
+        "Datum_neu": 1660176000000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": "04.08.2022 - 10.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 353.5,
+        "Fallzahl_aktiv": 4503,
         "Krh_N_belegt": 808,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -57,
+        "Fallzahl_aktiv_Zuwachs": -6,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33988,10 +34026,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.52,
-        "H_Zeitraum": "03.08.2022 - 09.08.2022",
+        "H_Inzidenz": 3.65,
+        "H_Zeitraum": "04.08.2022 - 10.08.2022",
         "H_Datum": "09.08.2022",
-        "Datum_Bett": "09.08.2022"
+        "Datum_Bett": "10.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
