### PR TITLE
New data set: 2022-08-12T100903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-11T101303Z.json
+pjson/2022-08-12T100903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-11T101303Z.json pjson/2022-08-12T100903Z.json```:
```
--- pjson/2022-08-11T101303Z.json	2022-08-11 10:13:03.473827306 +0000
+++ pjson/2022-08-12T100903Z.json	2022-08-12 10:09:03.543631936 +0000
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1530,
+        "F\u00e4lle_Meldedatum": 1529,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28614,7 +28614,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647907200000,
-        "F\u00e4lle_Meldedatum": 2969,
+        "F\u00e4lle_Meldedatum": 2968,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -33300,7 +33300,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33414,7 +33414,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33452,7 +33452,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33490,7 +33490,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33680,7 +33680,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33706,7 +33706,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659484800000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -33742,12 +33742,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 535,
         "BelegteBetten": null,
-        "Inzidenz": 431.049965875211,
+        "Inzidenz": null,
         "Datum_neu": 1659571200000,
         "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 388.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33760,7 +33760,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.47,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.08.2022"
@@ -33798,7 +33798,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.9,
+        "H_Inzidenz": 7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.08.2022"
@@ -33836,7 +33836,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.24,
+        "H_Inzidenz": 6.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.08.2022"
@@ -33870,11 +33870,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.14,
+        "H_Inzidenz": 6.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.08.2022"
@@ -33896,9 +33896,9 @@
         "BelegteBetten": null,
         "Inzidenz": 410.395488343691,
         "Datum_neu": 1659916800000,
-        "F\u00e4lle_Meldedatum": 458,
+        "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 321.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33912,7 +33912,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.09,
+        "H_Inzidenz": 6.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.08.2022"
@@ -33934,9 +33934,9 @@
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 447,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 320,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33950,7 +33950,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.77,
+        "H_Inzidenz": 5.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.08.2022"
@@ -33961,26 +33961,26 @@
         "Datum": "10.08.2022",
         "Fallzahl": 240930,
         "ObjectId": 887,
-        "Sterbefall": 1740,
-        "Genesungsfall": 234681,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6132,
-        "Zuwachs_Fallzahl": 469,
-        "Zuwachs_Sterbefall": 1740,
-        "Zuwachs_Krankenhauseinweisung": 6132,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 526,
         "BelegteBetten": null,
         "Inzidenz": 387.04694852545,
         "Datum_neu": 1660089600000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 406,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 321.3,
-        "Fallzahl_aktiv": 4509,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1797,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -33988,7 +33988,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.54,
+        "H_Inzidenz": 4.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.08.2022"
@@ -34001,7 +34001,7 @@
         "ObjectId": 888,
         "Sterbefall": 1742,
         "Genesungsfall": 235074,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6132,
         "Zuwachs_Fallzahl": 389,
         "Zuwachs_Sterbefall": 2,
@@ -34010,15 +34010,53 @@
         "BelegteBetten": null,
         "Inzidenz": 396.745572757642,
         "Datum_neu": 1660176000000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "04.08.2022 - 10.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 284,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 353.5,
         "Fallzahl_aktiv": 4503,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -6,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.02,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "10.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.08.2022",
+        "Fallzahl": 241645,
+        "ObjectId": 889,
+        "Sterbefall": 1750,
+        "Genesungsfall": 235489,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6168,
+        "Zuwachs_Fallzahl": 326,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 36,
+        "Zuwachs_Genesung": 415,
+        "BelegteBetten": null,
+        "Inzidenz": 392.614677251338,
+        "Datum_neu": 1660262400000,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": "05.08.2022 - 11.08.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 355.4,
+        "Fallzahl_aktiv": 4406,
         "Krh_N_belegt": 808,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -6,
+        "Fallzahl_aktiv_Zuwachs": -97,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34026,10 +34064,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.65,
-        "H_Zeitraum": "04.08.2022 - 10.08.2022",
+        "H_Inzidenz": 3.13,
+        "H_Zeitraum": "05.08.2022 - 11.08.2022",
         "H_Datum": "09.08.2022",
-        "Datum_Bett": "10.08.2022"
+        "Datum_Bett": "11.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
