### PR TITLE
New data set: 2022-08-15T100303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-12T100903Z.json
+pjson/2022-08-15T100303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-12T100903Z.json pjson/2022-08-15T100303Z.json```:
```
--- pjson/2022-08-12T100903Z.json	2022-08-12 10:09:03.543631936 +0000
+++ pjson/2022-08-15T100303Z.json	2022-08-15 10:03:04.160963375 +0000
@@ -33668,7 +33668,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 555,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -33780,12 +33780,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 560,
         "BelegteBetten": null,
-        "Inzidenz": 428.176299436043,
+        "Inzidenz": null,
         "Datum_neu": 1659657600000,
         "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 382.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33798,7 +33798,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.08.2022"
@@ -33818,12 +33818,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 249,
         "BelegteBetten": null,
-        "Inzidenz": 408.779050971659,
+        "Inzidenz": null,
         "Datum_neu": 1659744000000,
         "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 353.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33836,7 +33836,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.08.2022"
@@ -33856,12 +33856,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 136,
         "BelegteBetten": null,
-        "Inzidenz": 412.909946477963,
+        "Inzidenz": null,
         "Datum_neu": 1659830400000,
         "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 332.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33874,7 +33874,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.26,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.08.2022"
@@ -33912,7 +33912,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.21,
+        "H_Inzidenz": 6.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.08.2022"
@@ -33934,7 +33934,7 @@
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 455,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 320,
@@ -33950,7 +33950,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.94,
+        "H_Inzidenz": 6.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.08.2022"
@@ -33972,9 +33972,9 @@
         "BelegteBetten": null,
         "Inzidenz": 387.04694852545,
         "Datum_neu": 1660089600000,
-        "F\u00e4lle_Meldedatum": 406,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 321.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33988,7 +33988,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 5.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.08.2022"
@@ -33999,26 +33999,26 @@
         "Datum": "11.08.2022",
         "Fallzahl": 241319,
         "ObjectId": 888,
-        "Sterbefall": 1742,
-        "Genesungsfall": 235074,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6132,
-        "Zuwachs_Fallzahl": 389,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 393,
         "BelegteBetten": null,
         "Inzidenz": 396.745572757642,
         "Datum_neu": 1660176000000,
-        "F\u00e4lle_Meldedatum": 284,
+        "F\u00e4lle_Meldedatum": 305,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 353.5,
-        "Fallzahl_aktiv": 4503,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -6,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34026,7 +34026,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.02,
+        "H_Inzidenz": 4.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.08.2022"
@@ -34039,7 +34039,7 @@
         "ObjectId": 889,
         "Sterbefall": 1750,
         "Genesungsfall": 235489,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6168,
         "Zuwachs_Fallzahl": 326,
         "Zuwachs_Sterbefall": 8,
@@ -34048,15 +34048,129 @@
         "BelegteBetten": null,
         "Inzidenz": 392.614677251338,
         "Datum_neu": 1660262400000,
-        "F\u00e4lle_Meldedatum": 38,
-        "Zeitraum": "05.08.2022 - 11.08.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 334,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 355.4,
         "Fallzahl_aktiv": 4406,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -97,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.02,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.08.2022",
+        "Fallzahl": 242033,
+        "ObjectId": 890,
+        "Sterbefall": null,
+        "Genesungsfall": 235617,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 128,
+        "BelegteBetten": null,
+        "Inzidenz": 401.235676568842,
+        "Datum_neu": 1660348800000,
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 342.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.28,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "12.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.08.2022",
+        "Fallzahl": 242087,
+        "ObjectId": 891,
+        "Sterbefall": null,
+        "Genesungsfall": 235700,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 83,
+        "BelegteBetten": null,
+        "Inzidenz": 380.401594884874,
+        "Datum_neu": 1660435200000,
+        "F\u00e4lle_Meldedatum": 54,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 309.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.74,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "13.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.08.2022",
+        "Fallzahl": 242092,
+        "ObjectId": 892,
+        "Sterbefall": 1750,
+        "Genesungsfall": 236245,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6173,
+        "Zuwachs_Fallzahl": 447,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 545,
+        "BelegteBetten": null,
+        "Inzidenz": 374.654262006538,
+        "Datum_neu": 1660521600000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": "08.08.2022 - 14.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 294.5,
+        "Fallzahl_aktiv": 4097,
         "Krh_N_belegt": 808,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -97,
+        "Fallzahl_aktiv_Zuwachs": -98,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34064,10 +34178,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.13,
-        "H_Zeitraum": "05.08.2022 - 11.08.2022",
+        "H_Inzidenz": 2.54,
+        "H_Zeitraum": "08.08.2022 - 14.08.2022",
         "H_Datum": "09.08.2022",
-        "Datum_Bett": "11.08.2022"
+        "Datum_Bett": "14.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
