### PR TITLE
New data set: 2022-08-16T100604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-15T100303Z.json
+pjson/2022-08-16T100604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-15T100303Z.json pjson/2022-08-16T100604Z.json```:
```
--- pjson/2022-08-15T100303Z.json	2022-08-15 10:03:04.160963375 +0000
+++ pjson/2022-08-16T100604Z.json	2022-08-16 10:06:05.110407558 +0000
@@ -33894,12 +33894,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 738,
         "BelegteBetten": null,
-        "Inzidenz": 410.395488343691,
+        "Inzidenz": null,
         "Datum_neu": 1659916800000,
         "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
-        "Inzidenz_RKI": 321.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33912,7 +33912,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.08.2022"
@@ -33934,7 +33934,7 @@
         "BelegteBetten": null,
         "Inzidenz": 399.978447501706,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 455,
+        "F\u00e4lle_Meldedatum": 456,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 320,
@@ -33950,7 +33950,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
+        "H_Inzidenz": 6.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.08.2022"
@@ -33972,7 +33972,7 @@
         "BelegteBetten": null,
         "Inzidenz": 387.04694852545,
         "Datum_neu": 1660089600000,
-        "F\u00e4lle_Meldedatum": 410,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 321.3,
@@ -33988,7 +33988,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.37,
+        "H_Inzidenz": 5.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.08.2022"
@@ -34010,7 +34010,7 @@
         "BelegteBetten": null,
         "Inzidenz": 396.745572757642,
         "Datum_neu": 1660176000000,
-        "F\u00e4lle_Meldedatum": 305,
+        "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 353.5,
@@ -34026,7 +34026,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": 5.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.08.2022"
@@ -34037,26 +34037,26 @@
         "Datum": "12.08.2022",
         "Fallzahl": 241645,
         "ObjectId": 889,
-        "Sterbefall": 1750,
-        "Genesungsfall": 235489,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6168,
-        "Zuwachs_Fallzahl": 326,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 36,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 415,
         "BelegteBetten": null,
         "Inzidenz": 392.614677251338,
         "Datum_neu": 1660262400000,
-        "F\u00e4lle_Meldedatum": 334,
+        "F\u00e4lle_Meldedatum": 352,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 355.4,
-        "Fallzahl_aktiv": 4406,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -97,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34064,7 +34064,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.02,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.08.2022"
@@ -34076,7 +34076,7 @@
         "Fallzahl": 242033,
         "ObjectId": 890,
         "Sterbefall": null,
-        "Genesungsfall": 235617,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -34086,9 +34086,9 @@
         "BelegteBetten": null,
         "Inzidenz": 401.235676568842,
         "Datum_neu": 1660348800000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 342.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34102,7 +34102,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.28,
+        "H_Inzidenz": 4.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.08.2022"
@@ -34114,7 +34114,7 @@
         "Fallzahl": 242087,
         "ObjectId": 891,
         "Sterbefall": null,
-        "Genesungsfall": 235700,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -34124,7 +34124,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.401594884874,
         "Datum_neu": 1660435200000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 309.9,
@@ -34140,7 +34140,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.74,
+        "H_Inzidenz": 3.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.08.2022"
@@ -34153,7 +34153,7 @@
         "ObjectId": 892,
         "Sterbefall": 1750,
         "Genesungsfall": 236245,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6173,
         "Zuwachs_Fallzahl": 447,
         "Zuwachs_Sterbefall": 0,
@@ -34162,15 +34162,53 @@
         "BelegteBetten": null,
         "Inzidenz": 374.654262006538,
         "Datum_neu": 1660521600000,
-        "F\u00e4lle_Meldedatum": 5,
-        "Zeitraum": "08.08.2022 - 14.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 423,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 294.5,
         "Fallzahl_aktiv": 4097,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -98,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.77,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "14.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.08.2022",
+        "Fallzahl": 242607,
+        "ObjectId": 893,
+        "Sterbefall": 1750,
+        "Genesungsfall": 236795,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6180,
+        "Zuwachs_Fallzahl": 515,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 550,
+        "BelegteBetten": null,
+        "Inzidenz": 380.581199037322,
+        "Datum_neu": 1660608000000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "09.08.2022 - 15.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 302.6,
+        "Fallzahl_aktiv": 4062,
         "Krh_N_belegt": 808,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -98,
+        "Fallzahl_aktiv_Zuwachs": -35,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34178,10 +34216,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.54,
-        "H_Zeitraum": "08.08.2022 - 14.08.2022",
+        "H_Inzidenz": 2.56,
+        "H_Zeitraum": "09.08.2022 - 15.08.2022",
         "H_Datum": "09.08.2022",
-        "Datum_Bett": "14.08.2022"
+        "Datum_Bett": "15.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
