### PR TITLE
New data set: 2022-08-17T100104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-15T100303Z.json
+pjson/2022-08-17T100104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-16T100604Z.json pjson/2022-08-17T100104Z.json```:
```
--- pjson/2022-08-16T100604Z.json	2022-08-16 10:06:05.110407558 +0000
+++ pjson/2022-08-17T100104Z.json	2022-08-17 10:01:04.422154776 +0000
@@ -33034,7 +33034,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33490,7 +33490,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33554,7 +33554,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659139200000,
-        "F\u00e4lle_Meldedatum": 118,
+        "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -33630,7 +33630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659312000000,
-        "F\u00e4lle_Meldedatum": 572,
+        "F\u00e4lle_Meldedatum": 573,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -33718,7 +33718,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33756,7 +33756,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33898,7 +33898,7 @@
         "Datum_neu": 1659916800000,
         "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33932,12 +33932,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 680,
         "BelegteBetten": null,
-        "Inzidenz": 399.978447501706,
+        "Inzidenz": null,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 456,
+        "F\u00e4lle_Meldedatum": 457,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 320,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33950,7 +33950,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.08.2022"
@@ -33972,7 +33972,7 @@
         "BelegteBetten": null,
         "Inzidenz": 387.04694852545,
         "Datum_neu": 1660089600000,
-        "F\u00e4lle_Meldedatum": 412,
+        "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 321.3,
@@ -33988,7 +33988,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": 5.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.08.2022"
@@ -34010,7 +34010,7 @@
         "BelegteBetten": null,
         "Inzidenz": 396.745572757642,
         "Datum_neu": 1660176000000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 353.5,
@@ -34026,7 +34026,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.1,
+        "H_Inzidenz": 5.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.08.2022"
@@ -34048,7 +34048,7 @@
         "BelegteBetten": null,
         "Inzidenz": 392.614677251338,
         "Datum_neu": 1660262400000,
-        "F\u00e4lle_Meldedatum": 352,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 355.4,
@@ -34064,7 +34064,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 4.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.08.2022"
@@ -34086,9 +34086,9 @@
         "BelegteBetten": null,
         "Inzidenz": 401.235676568842,
         "Datum_neu": 1660348800000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 342.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34102,7 +34102,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.19,
+        "H_Inzidenz": 4.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.08.2022"
@@ -34124,9 +34124,9 @@
         "BelegteBetten": null,
         "Inzidenz": 380.401594884874,
         "Datum_neu": 1660435200000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 309.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34140,7 +34140,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.85,
+        "H_Inzidenz": 4.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.08.2022"
@@ -34151,26 +34151,26 @@
         "Datum": "15.08.2022",
         "Fallzahl": 242092,
         "ObjectId": 892,
-        "Sterbefall": 1750,
-        "Genesungsfall": 236245,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6173,
-        "Zuwachs_Fallzahl": 447,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 545,
         "BelegteBetten": null,
         "Inzidenz": 374.654262006538,
         "Datum_neu": 1660521600000,
-        "F\u00e4lle_Meldedatum": 423,
+        "F\u00e4lle_Meldedatum": 445,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 294.5,
-        "Fallzahl_aktiv": 4097,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -98,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34178,7 +34178,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.77,
+        "H_Inzidenz": 4.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.08.2022"
@@ -34191,7 +34191,7 @@
         "ObjectId": 893,
         "Sterbefall": 1750,
         "Genesungsfall": 236795,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6180,
         "Zuwachs_Fallzahl": 515,
         "Zuwachs_Sterbefall": 0,
@@ -34200,13 +34200,13 @@
         "BelegteBetten": null,
         "Inzidenz": 380.581199037322,
         "Datum_neu": 1660608000000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "09.08.2022 - 15.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 392,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 302.6,
         "Fallzahl_aktiv": 4062,
-        "Krh_N_belegt": 808,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -35,
         "Krh_I": null,
@@ -34216,11 +34216,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.56,
-        "H_Zeitraum": "09.08.2022 - 15.08.2022",
-        "H_Datum": "09.08.2022",
+        "H_Inzidenz": 3.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.08.2022",
+        "Fallzahl": 243023,
+        "ObjectId": 894,
+        "Sterbefall": 1753,
+        "Genesungsfall": 237157,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6193,
+        "Zuwachs_Fallzahl": 416,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 362,
+        "BelegteBetten": null,
+        "Inzidenz": 375.013470311434,
+        "Datum_neu": 1660694400000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "10.08.2022 - 16.08.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 317.7,
+        "Fallzahl_aktiv": 4113,
+        "Krh_N_belegt": 698,
+        "Krh_I_belegt": 74,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 51,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.18,
+        "H_Zeitraum": "10.08.2022 - 16.08.2022",
+        "H_Datum": "16.08.2022",
+        "Datum_Bett": "16.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
