### PR TITLE
New data set: 2022-08-18T100703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-17T100104Z.json
+pjson/2022-08-18T100703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-17T100104Z.json pjson/2022-08-18T100703Z.json```:
```
--- pjson/2022-08-17T100104Z.json	2022-08-17 10:01:04.422154776 +0000
+++ pjson/2022-08-18T100703Z.json	2022-08-18 10:07:03.322084155 +0000
@@ -33970,12 +33970,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 526,
         "BelegteBetten": null,
-        "Inzidenz": 387.04694852545,
+        "Inzidenz": null,
         "Datum_neu": 1660089600000,
         "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 321.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -33988,7 +33988,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.84,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.08.2022"
@@ -34010,7 +34010,7 @@
         "BelegteBetten": null,
         "Inzidenz": 396.745572757642,
         "Datum_neu": 1660176000000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 353.5,
@@ -34026,7 +34026,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": 5.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.08.2022"
@@ -34048,7 +34048,7 @@
         "BelegteBetten": null,
         "Inzidenz": 392.614677251338,
         "Datum_neu": 1660262400000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 355.4,
@@ -34064,7 +34064,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.71,
+        "H_Inzidenz": 4.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.08.2022"
@@ -34102,7 +34102,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": 4.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.08.2022"
@@ -34140,7 +34140,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.36,
+        "H_Inzidenz": 4.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.08.2022"
@@ -34162,9 +34162,9 @@
         "BelegteBetten": null,
         "Inzidenz": 374.654262006538,
         "Datum_neu": 1660521600000,
-        "F\u00e4lle_Meldedatum": 445,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 294.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34178,7 +34178,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.39,
+        "H_Inzidenz": 4.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.08.2022"
@@ -34189,26 +34189,26 @@
         "Datum": "16.08.2022",
         "Fallzahl": 242607,
         "ObjectId": 893,
-        "Sterbefall": 1750,
-        "Genesungsfall": 236795,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6180,
-        "Zuwachs_Fallzahl": 515,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 550,
         "BelegteBetten": null,
         "Inzidenz": 380.581199037322,
         "Datum_neu": 1660608000000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 302.6,
-        "Fallzahl_aktiv": 4062,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -35,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34216,7 +34216,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": 4.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.08.2022"
@@ -34229,7 +34229,7 @@
         "ObjectId": 894,
         "Sterbefall": 1753,
         "Genesungsfall": 237157,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6193,
         "Zuwachs_Fallzahl": 416,
         "Zuwachs_Sterbefall": 3,
@@ -34238,13 +34238,13 @@
         "BelegteBetten": null,
         "Inzidenz": 375.013470311434,
         "Datum_neu": 1660694400000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "10.08.2022 - 16.08.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 252,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 317.7,
         "Fallzahl_aktiv": 4113,
-        "Krh_N_belegt": 698,
-        "Krh_I_belegt": 74,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 51,
         "Krh_I": null,
@@ -34254,11 +34254,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.18,
-        "H_Zeitraum": "10.08.2022 - 16.08.2022",
-        "H_Datum": "16.08.2022",
+        "H_Inzidenz": 3.62,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.08.2022",
+        "Fallzahl": 243342,
+        "ObjectId": 895,
+        "Sterbefall": 1753,
+        "Genesungsfall": 237489,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6201,
+        "Zuwachs_Fallzahl": 319,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 332,
+        "BelegteBetten": null,
+        "Inzidenz": 351.305722188297,
+        "Datum_neu": 1660780800000,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": "11.08.2022 - 17.08.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 315.9,
+        "Fallzahl_aktiv": 4100,
+        "Krh_N_belegt": 698,
+        "Krh_I_belegt": 74,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -13,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.25,
+        "H_Zeitraum": "11.08.2022 - 17.08.2022",
+        "H_Datum": "16.08.2022",
+        "Datum_Bett": "17.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
