### PR TITLE
New data set: 2022-08-19T095504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-17T100104Z.json
+pjson/2022-08-19T095504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-18T100703Z.json pjson/2022-08-19T095504Z.json```:
```
--- pjson/2022-08-18T100703Z.json	2022-08-18 10:07:03.322084155 +0000
+++ pjson/2022-08-19T095504Z.json	2022-08-19 09:55:04.973347016 +0000
@@ -33898,7 +33898,7 @@
         "Datum_neu": 1659916800000,
         "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34013,7 +34013,7 @@
         "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 353.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34026,7 +34026,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.27,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.08.2022"
@@ -34050,7 +34050,7 @@
         "Datum_neu": 1660262400000,
         "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 355.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34064,7 +34064,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 4.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.08.2022"
@@ -34102,7 +34102,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.68,
+        "H_Inzidenz": 4.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.08.2022"
@@ -34140,7 +34140,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.44,
+        "H_Inzidenz": 4.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.08.2022"
@@ -34178,7 +34178,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.46,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.08.2022"
@@ -34200,7 +34200,7 @@
         "BelegteBetten": null,
         "Inzidenz": 380.581199037322,
         "Datum_neu": 1660608000000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 302.6,
@@ -34216,7 +34216,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.02,
+        "H_Inzidenz": 4.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.08.2022"
@@ -34227,34 +34227,34 @@
         "Datum": "17.08.2022",
         "Fallzahl": 243023,
         "ObjectId": 894,
-        "Sterbefall": 1753,
-        "Genesungsfall": 237157,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6193,
-        "Zuwachs_Fallzahl": 416,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 362,
         "BelegteBetten": null,
         "Inzidenz": 375.013470311434,
         "Datum_neu": 1660694400000,
-        "F\u00e4lle_Meldedatum": 252,
+        "F\u00e4lle_Meldedatum": 273,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 317.7,
-        "Fallzahl_aktiv": 4113,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 51,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.62,
+        "H_Inzidenz": 4.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.08.2022"
@@ -34267,7 +34267,7 @@
         "ObjectId": 895,
         "Sterbefall": 1753,
         "Genesungsfall": 237489,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6201,
         "Zuwachs_Fallzahl": 319,
         "Zuwachs_Sterbefall": 0,
@@ -34276,9 +34276,9 @@
         "BelegteBetten": null,
         "Inzidenz": 351.305722188297,
         "Datum_neu": 1660780800000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": "11.08.2022 - 17.08.2022",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 315.9,
         "Fallzahl_aktiv": 4100,
         "Krh_N_belegt": 698,
@@ -34292,11 +34292,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.25,
+        "H_Inzidenz": 4.24,
         "H_Zeitraum": "11.08.2022 - 17.08.2022",
         "H_Datum": "16.08.2022",
         "Datum_Bett": "17.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "19.08.2022",
+        "Fallzahl": 243585,
+        "ObjectId": 896,
+        "Sterbefall": 1753,
+        "Genesungsfall": 237796,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6213,
+        "Zuwachs_Fallzahl": 243,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 307,
+        "BelegteBetten": null,
+        "Inzidenz": 345.917597614857,
+        "Datum_neu": 1660867200000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "12.08.2022 - 18.08.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 320.9,
+        "Fallzahl_aktiv": 4036,
+        "Krh_N_belegt": 698,
+        "Krh_I_belegt": 74,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -64,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.92,
+        "H_Zeitraum": "12.08.2022 - 18.08.2022",
+        "H_Datum": "16.08.2022",
+        "Datum_Bett": "18.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
