### PR TITLE
New data set: 2022-08-22T100503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-19T095504Z.json
+pjson/2022-08-22T100503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-19T095504Z.json pjson/2022-08-22T100503Z.json```:
```
--- pjson/2022-08-19T095504Z.json	2022-08-19 09:55:04.973347016 +0000
+++ pjson/2022-08-22T100503Z.json	2022-08-22 10:05:04.135042089 +0000
@@ -32908,7 +32908,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657670400000,
-        "F\u00e4lle_Meldedatum": 566,
+        "F\u00e4lle_Meldedatum": 567,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -32946,7 +32946,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657756800000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 267,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -32984,7 +32984,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1657843200000,
-        "F\u00e4lle_Meldedatum": 1124,
+        "F\u00e4lle_Meldedatum": 1123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -33098,7 +33098,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658102400000,
-        "F\u00e4lle_Meldedatum": 804,
+        "F\u00e4lle_Meldedatum": 805,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33136,7 +33136,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658188800000,
-        "F\u00e4lle_Meldedatum": 855,
+        "F\u00e4lle_Meldedatum": 854,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -33174,7 +33174,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658275200000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 690,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -33212,7 +33212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 562,
+        "F\u00e4lle_Meldedatum": 561,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -33364,7 +33364,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658707200000,
-        "F\u00e4lle_Meldedatum": 761,
+        "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -33440,7 +33440,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658880000000,
-        "F\u00e4lle_Meldedatum": 523,
+        "F\u00e4lle_Meldedatum": 522,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -33898,7 +33898,7 @@
         "Datum_neu": 1659916800000,
         "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33934,9 +33934,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 457,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33972,9 +33972,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660089600000,
-        "F\u00e4lle_Meldedatum": 411,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34008,7 +34008,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 393,
         "BelegteBetten": null,
-        "Inzidenz": 396.745572757642,
+        "Inzidenz": null,
         "Datum_neu": 1660176000000,
         "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
@@ -34046,12 +34046,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 415,
         "BelegteBetten": null,
-        "Inzidenz": 392.614677251338,
+        "Inzidenz": null,
         "Datum_neu": 1660262400000,
         "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 355.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34064,7 +34064,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.78,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.08.2022"
@@ -34084,12 +34084,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 128,
         "BelegteBetten": null,
-        "Inzidenz": 401.235676568842,
+        "Inzidenz": null,
         "Datum_neu": 1660348800000,
         "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 342.5,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34102,7 +34102,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.08.2022"
@@ -34122,12 +34122,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 83,
         "BelegteBetten": null,
-        "Inzidenz": 380.401594884874,
+        "Inzidenz": null,
         "Datum_neu": 1660435200000,
         "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 309.9,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34140,7 +34140,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.51,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.08.2022"
@@ -34162,7 +34162,7 @@
         "BelegteBetten": null,
         "Inzidenz": 374.654262006538,
         "Datum_neu": 1660521600000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 294.5,
@@ -34178,7 +34178,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 4.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.08.2022"
@@ -34202,7 +34202,7 @@
         "Datum_neu": 1660608000000,
         "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 302.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34216,7 +34216,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.51,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.08.2022"
@@ -34238,9 +34238,9 @@
         "BelegteBetten": null,
         "Inzidenz": 375.013470311434,
         "Datum_neu": 1660694400000,
-        "F\u00e4lle_Meldedatum": 273,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 317.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34250,11 +34250,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.34,
+        "H_Inzidenz": 4.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.08.2022"
@@ -34265,26 +34265,26 @@
         "Datum": "18.08.2022",
         "Fallzahl": 243342,
         "ObjectId": 895,
-        "Sterbefall": 1753,
-        "Genesungsfall": 237489,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6201,
-        "Zuwachs_Fallzahl": 319,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
         "Inzidenz": 351.305722188297,
         "Datum_neu": 1660780800000,
-        "F\u00e4lle_Meldedatum": 255,
-        "Zeitraum": "11.08.2022 - 17.08.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 275,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 315.9,
-        "Fallzahl_aktiv": 4100,
-        "Krh_N_belegt": 698,
-        "Krh_I_belegt": 74,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -13,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34292,9 +34292,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.24,
-        "H_Zeitraum": "11.08.2022 - 17.08.2022",
-        "H_Datum": "16.08.2022",
+        "H_Inzidenz": 4.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.08.2022"
       }
     },
@@ -34305,7 +34305,7 @@
         "ObjectId": 896,
         "Sterbefall": 1753,
         "Genesungsfall": 237796,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6213,
         "Zuwachs_Fallzahl": 243,
         "Zuwachs_Sterbefall": 0,
@@ -34314,15 +34314,129 @@
         "BelegteBetten": null,
         "Inzidenz": 345.917597614857,
         "Datum_neu": 1660867200000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "12.08.2022 - 18.08.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 225,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 320.9,
         "Fallzahl_aktiv": 4036,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -64,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.22,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.08.2022",
+        "Fallzahl": 243888,
+        "ObjectId": 897,
+        "Sterbefall": null,
+        "Genesungsfall": 238000,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 204,
+        "BelegteBetten": null,
+        "Inzidenz": 326.161140845576,
+        "Datum_neu": 1660953600000,
+        "F\u00e4lle_Meldedatum": 68,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 291.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.45,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.08.2022",
+        "Fallzahl": 243915,
+        "ObjectId": 898,
+        "Sterbefall": null,
+        "Genesungsfall": 238101,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 101,
+        "BelegteBetten": null,
+        "Inzidenz": 321.132224577032,
+        "Datum_neu": 1661040000000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 274.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.16,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "20.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.08.2022",
+        "Fallzahl": 243929,
+        "ObjectId": 899,
+        "Sterbefall": 1754,
+        "Genesungsfall": 238539,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6231,
+        "Zuwachs_Fallzahl": 344,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 438,
+        "BelegteBetten": null,
+        "Inzidenz": 311.792808649736,
+        "Datum_neu": 1661126400000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "15.08.2022 - 21.08.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 260.3,
+        "Fallzahl_aktiv": 3636,
         "Krh_N_belegt": 698,
         "Krh_I_belegt": 74,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -64,
+        "Fallzahl_aktiv_Zuwachs": -95,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34330,10 +34444,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
-        "H_Zeitraum": "12.08.2022 - 18.08.2022",
+        "H_Inzidenz": 2.88,
+        "H_Zeitraum": "15.08.2022 - 21.08.2022",
         "H_Datum": "16.08.2022",
-        "Datum_Bett": "18.08.2022"
+        "Datum_Bett": "21.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
