### PR TITLE
New data set: 2022-08-26T100604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-25T101603Z.json
+pjson/2022-08-26T100604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-25T101603Z.json pjson/2022-08-26T100604Z.json```:
```
--- pjson/2022-08-25T101603Z.json	2022-08-25 10:16:03.531559686 +0000
+++ pjson/2022-08-26T100604Z.json	2022-08-26 10:06:04.322763052 +0000
@@ -34274,12 +34274,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
-        "Inzidenz": 351.305722188297,
+        "Inzidenz": null,
         "Datum_neu": 1660780800000,
         "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 315.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34292,7 +34292,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.08.2022"
@@ -34330,7 +34330,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": 5.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.08.2022"
@@ -34368,7 +34368,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.25,
+        "H_Inzidenz": 5.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.08.2022"
@@ -34406,7 +34406,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.1,
+        "H_Inzidenz": 5.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.08.2022"
@@ -34428,7 +34428,7 @@
         "BelegteBetten": null,
         "Inzidenz": 311.792808649736,
         "Datum_neu": 1661126400000,
-        "F\u00e4lle_Meldedatum": 390,
+        "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 260.3,
@@ -34444,7 +34444,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5,
+        "H_Inzidenz": 5.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.08.2022"
@@ -34482,7 +34482,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.85,
+        "H_Inzidenz": 4.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.08.2022"
@@ -34504,7 +34504,7 @@
         "BelegteBetten": null,
         "Inzidenz": 287.007435611911,
         "Datum_neu": 1661299200000,
-        "F\u00e4lle_Meldedatum": 239,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 245.2,
@@ -34520,7 +34520,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.38,
+        "H_Inzidenz": 3.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.08.2022"
@@ -34531,26 +34531,64 @@
         "Datum": "25.08.2022",
         "Fallzahl": 244939,
         "ObjectId": 902,
-        "Sterbefall": 1755,
-        "Genesungsfall": 239729,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6246,
-        "Zuwachs_Fallzahl": 253,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 317,
         "BelegteBetten": null,
         "Inzidenz": 284.492977477639,
         "Datum_neu": 1661385600000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "18.08.2022 - 24.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 254,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 252.4,
-        "Fallzahl_aktiv": 3455,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.01,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "24.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.08.2022",
+        "Fallzahl": 245198,
+        "ObjectId": 903,
+        "Sterbefall": 1755,
+        "Genesungsfall": 240095,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6247,
+        "Zuwachs_Fallzahl": 259,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 366,
+        "BelegteBetten": null,
+        "Inzidenz": 283.415352562951,
+        "Datum_neu": 1661472000000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "19.08.2022 - 25.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 250.6,
+        "Fallzahl_aktiv": 3348,
         "Krh_N_belegt": 642,
         "Krh_I_belegt": 69,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -64,
+        "Fallzahl_aktiv_Zuwachs": -107,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34558,10 +34596,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
-        "H_Zeitraum": "18.08.2022 - 24.08.2022",
+        "H_Inzidenz": 2.19,
+        "H_Zeitraum": "19.08.2022 - 25.08.2022",
         "H_Datum": "23.08.2022",
-        "Datum_Bett": "24.08.2022"
+        "Datum_Bett": "25.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
