### PR TITLE
New data set: 2022-08-29T100204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-26T100604Z.json
+pjson/2022-08-29T100204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-26T100604Z.json pjson/2022-08-29T100204Z.json```:
```
--- pjson/2022-08-26T100604Z.json	2022-08-26 10:06:04.322763052 +0000
+++ pjson/2022-08-29T100204Z.json	2022-08-29 10:02:04.173733160 +0000
@@ -34162,7 +34162,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660521600000,
-        "F\u00e4lle_Meldedatum": 453,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -34312,12 +34312,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 316,
         "BelegteBetten": null,
-        "Inzidenz": 345.917597614857,
+        "Inzidenz": null,
         "Datum_neu": 1660867200000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 320.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34330,7 +34330,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.08.2022"
@@ -34350,12 +34350,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 204,
         "BelegteBetten": null,
-        "Inzidenz": 326.161140845576,
+        "Inzidenz": null,
         "Datum_neu": 1660953600000,
         "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 291.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34368,7 +34368,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.3,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.08.2022"
@@ -34386,14 +34386,14 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 101,
+        "Zuwachs_Genesung": 100,
         "BelegteBetten": null,
-        "Inzidenz": 321.132224577032,
+        "Inzidenz": null,
         "Datum_neu": 1661040000000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 274.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34402,11 +34402,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.15,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.08.2022"
@@ -34428,9 +34428,9 @@
         "BelegteBetten": null,
         "Inzidenz": 311.792808649736,
         "Datum_neu": 1661126400000,
-        "F\u00e4lle_Meldedatum": 391,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 260.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34444,7 +34444,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.05,
+        "H_Inzidenz": 5.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.08.2022"
@@ -34482,7 +34482,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.08.2022"
@@ -34504,9 +34504,9 @@
         "BelegteBetten": null,
         "Inzidenz": 287.007435611911,
         "Datum_neu": 1661299200000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 245.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34520,7 +34520,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 4.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.08.2022"
@@ -34542,7 +34542,7 @@
         "BelegteBetten": null,
         "Inzidenz": 284.492977477639,
         "Datum_neu": 1661385600000,
-        "F\u00e4lle_Meldedatum": 254,
+        "F\u00e4lle_Meldedatum": 276,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 252.4,
@@ -34558,7 +34558,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.01,
+        "H_Inzidenz": 3.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.08.2022"
@@ -34570,36 +34570,150 @@
         "Fallzahl": 245198,
         "ObjectId": 903,
         "Sterbefall": 1755,
-        "Genesungsfall": 240095,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6247,
-        "Zuwachs_Fallzahl": 259,
+        "Genesungsfall": 240094,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 6246,
+        "Zuwachs_Fallzahl": 253,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Krankenhauseinweisung": 2,
         "Zuwachs_Genesung": 366,
         "BelegteBetten": null,
         "Inzidenz": 283.415352562951,
         "Datum_neu": 1661472000000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "19.08.2022 - 25.08.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 238,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 250.6,
-        "Fallzahl_aktiv": 3348,
+        "Fallzahl_aktiv": 3349,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -113,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.88,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.08.2022",
+        "Fallzahl": 245508,
+        "ObjectId": 904,
+        "Sterbefall": null,
+        "Genesungsfall": 240197,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 103,
+        "BelegteBetten": null,
+        "Inzidenz": 287.725852221703,
+        "Datum_neu": 1661558400000,
+        "F\u00e4lle_Meldedatum": 59,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 257.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.49,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.08.2022",
+        "Fallzahl": 245528,
+        "ObjectId": 905,
+        "Sterbefall": null,
+        "Genesungsfall": 240280,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 83,
+        "BelegteBetten": null,
+        "Inzidenz": 282.696935953159,
+        "Datum_neu": 1661644800000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 241.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.32,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "27.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.08.2022",
+        "Fallzahl": 245533,
+        "ObjectId": 906,
+        "Sterbefall": 1756,
+        "Genesungsfall": 240522,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6254,
+        "Zuwachs_Fallzahl": 335,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 242,
+        "BelegteBetten": null,
+        "Inzidenz": 279.643665361543,
+        "Datum_neu": 1661731200000,
+        "F\u00e4lle_Meldedatum": 5,
+        "Zeitraum": "22.08.2022 - 28.08.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 235,
+        "Fallzahl_aktiv": 3255,
         "Krh_N_belegt": 642,
         "Krh_I_belegt": 69,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -107,
+        "Fallzahl_aktiv_Zuwachs": 92,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.19,
-        "H_Zeitraum": "19.08.2022 - 25.08.2022",
+        "H_Inzidenz": 2.05,
+        "H_Zeitraum": "22.08.2022 - 28.08.2022",
         "H_Datum": "23.08.2022",
-        "Datum_Bett": "25.08.2022"
+        "Datum_Bett": "28.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
