### PR TITLE
New data set: 2022-08-30T100904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-29T100204Z.json
+pjson/2022-08-30T100904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-29T100204Z.json pjson/2022-08-30T100904Z.json```:
```
--- pjson/2022-08-29T100204Z.json	2022-08-29 10:02:04.173733160 +0000
+++ pjson/2022-08-30T100904Z.json	2022-08-30 10:09:04.694157637 +0000
@@ -30932,7 +30932,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653177600000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -34164,7 +34164,7 @@
         "Datum_neu": 1660521600000,
         "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34431,7 +34431,7 @@
         "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 260.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34444,7 +34444,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.23,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.08.2022"
@@ -34482,7 +34482,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 4.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.08.2022"
@@ -34520,7 +34520,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.29,
+        "H_Inzidenz": 4.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.08.2022"
@@ -34558,7 +34558,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 4.04,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.08.2022"
@@ -34569,26 +34569,26 @@
         "Datum": "26.08.2022",
         "Fallzahl": 245198,
         "ObjectId": 903,
-        "Sterbefall": 1755,
-        "Genesungsfall": 240094,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6246,
-        "Zuwachs_Fallzahl": 253,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 366,
         "BelegteBetten": null,
         "Inzidenz": 283.415352562951,
         "Datum_neu": 1661472000000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 250.6,
-        "Fallzahl_aktiv": 3349,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -113,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34596,7 +34596,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.88,
+        "H_Inzidenz": 3.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.08.2022"
@@ -34605,10 +34605,10 @@
     {
       "attributes": {
         "Datum": "27.08.2022",
-        "Fallzahl": 245508,
+        "Fallzahl": 245534,
         "ObjectId": 904,
         "Sterbefall": null,
-        "Genesungsfall": 240197,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -34616,9 +34616,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 103,
         "BelegteBetten": null,
-        "Inzidenz": 287.725852221703,
+        "Inzidenz": 289.162685441287,
         "Datum_neu": 1661558400000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 257.3,
@@ -34634,7 +34634,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
+        "H_Inzidenz": 3.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.08.2022"
@@ -34646,7 +34646,7 @@
         "Fallzahl": 245528,
         "ObjectId": 905,
         "Sterbefall": null,
-        "Genesungsfall": 240280,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -34656,9 +34656,9 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1661644800000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 241.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34672,7 +34672,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.32,
+        "H_Inzidenz": 3.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.08.2022"
@@ -34685,7 +34685,7 @@
         "ObjectId": 906,
         "Sterbefall": 1756,
         "Genesungsfall": 240522,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6254,
         "Zuwachs_Fallzahl": 335,
         "Zuwachs_Sterbefall": 1,
@@ -34694,9 +34694,9 @@
         "BelegteBetten": null,
         "Inzidenz": 279.643665361543,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": "22.08.2022 - 28.08.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 235,
         "Fallzahl_aktiv": 3255,
         "Krh_N_belegt": 642,
@@ -34710,11 +34710,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
+        "H_Inzidenz": 3.08,
         "H_Zeitraum": "22.08.2022 - 28.08.2022",
         "H_Datum": "23.08.2022",
         "Datum_Bett": "28.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.08.2022",
+        "Fallzahl": 245951,
+        "ObjectId": 907,
+        "Sterbefall": 1756,
+        "Genesungsfall": 241132,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6263,
+        "Zuwachs_Fallzahl": 418,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 610,
+        "BelegteBetten": null,
+        "Inzidenz": 274.794353245447,
+        "Datum_neu": 1661817600000,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": "23.08.2022 - 29.08.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 219,
+        "Fallzahl_aktiv": 3063,
+        "Krh_N_belegt": 642,
+        "Krh_I_belegt": 69,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -192,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.05,
+        "H_Zeitraum": "23.08.2022 - 29.08.2022",
+        "H_Datum": "23.08.2022",
+        "Datum_Bett": "29.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
