### PR TITLE
New data set: 2022-08-31T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-30T100904Z.json
+pjson/2022-08-31T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-30T100904Z.json pjson/2022-08-31T101303Z.json```:
```
--- pjson/2022-08-30T100904Z.json	2022-08-30 10:09:04.694157637 +0000
+++ pjson/2022-08-31T101303Z.json	2022-08-31 10:13:03.523207352 +0000
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2137,
+        "F\u00e4lle_Meldedatum": 2136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2199,
+        "F\u00e4lle_Meldedatum": 2198,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -28804,7 +28804,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648339200000,
-        "F\u00e4lle_Meldedatum": 426,
+        "F\u00e4lle_Meldedatum": 425,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29146,7 +29146,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649116800000,
-        "F\u00e4lle_Meldedatum": 1439,
+        "F\u00e4lle_Meldedatum": 1438,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -29222,7 +29222,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
-        "F\u00e4lle_Meldedatum": 1065,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -29260,7 +29260,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649376000000,
-        "F\u00e4lle_Meldedatum": 887,
+        "F\u00e4lle_Meldedatum": 886,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -29450,7 +29450,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649808000000,
-        "F\u00e4lle_Meldedatum": 747,
+        "F\u00e4lle_Meldedatum": 748,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -30438,7 +30438,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1652054400000,
-        "F\u00e4lle_Meldedatum": 509,
+        "F\u00e4lle_Meldedatum": 508,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -30932,7 +30932,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653177600000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -31996,7 +31996,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655596800000,
-        "F\u00e4lle_Meldedatum": 168,
+        "F\u00e4lle_Meldedatum": 169,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -33212,7 +33212,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658361600000,
-        "F\u00e4lle_Meldedatum": 561,
+        "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -33288,7 +33288,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658534400000,
-        "F\u00e4lle_Meldedatum": 246,
+        "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -34044,7 +34044,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 430,
+        "Zuwachs_Genesung": 431,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660262400000,
@@ -34424,11 +34424,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 438,
+        "Zuwachs_Genesung": 437,
         "BelegteBetten": null,
-        "Inzidenz": 311.792808649736,
+        "Inzidenz": null,
         "Datum_neu": 1661126400000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -34464,12 +34464,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 450,
         "BelegteBetten": null,
-        "Inzidenz": 303.710621789576,
+        "Inzidenz": null,
         "Datum_neu": 1661212800000,
         "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 240,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34482,7 +34482,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.98,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.08.2022"
@@ -34504,7 +34504,7 @@
         "BelegteBetten": null,
         "Inzidenz": 287.007435611911,
         "Datum_neu": 1661299200000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 245.2,
@@ -34520,7 +34520,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.66,
+        "H_Inzidenz": 4.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.08.2022"
@@ -34542,7 +34542,7 @@
         "BelegteBetten": null,
         "Inzidenz": 284.492977477639,
         "Datum_neu": 1661385600000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 252.4,
@@ -34558,7 +34558,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.04,
+        "H_Inzidenz": 4.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.08.2022"
@@ -34580,7 +34580,7 @@
         "BelegteBetten": null,
         "Inzidenz": 283.415352562951,
         "Datum_neu": 1661472000000,
-        "F\u00e4lle_Meldedatum": 246,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 250.6,
@@ -34596,7 +34596,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.5,
+        "H_Inzidenz": 3.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.08.2022"
@@ -34605,7 +34605,7 @@
     {
       "attributes": {
         "Datum": "27.08.2022",
-        "Fallzahl": 245534,
+        "Fallzahl": 245540,
         "ObjectId": 904,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -34616,9 +34616,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 103,
         "BelegteBetten": null,
-        "Inzidenz": 289.162685441287,
+        "Inzidenz": 290.240310355975,
         "Datum_neu": 1661558400000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 257.3,
@@ -34634,7 +34634,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.28,
+        "H_Inzidenz": 3.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.08.2022"
@@ -34656,7 +34656,7 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1661644800000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 241.6,
@@ -34672,7 +34672,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.18,
+        "H_Inzidenz": 3.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.08.2022"
@@ -34683,36 +34683,36 @@
         "Datum": "29.08.2022",
         "Fallzahl": 245533,
         "ObjectId": 906,
-        "Sterbefall": 1756,
-        "Genesungsfall": 240522,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6254,
-        "Zuwachs_Fallzahl": 335,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 8,
-        "Zuwachs_Genesung": 242,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 440,
         "BelegteBetten": null,
         "Inzidenz": 279.643665361543,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 325,
-        "Zeitraum": "22.08.2022 - 28.08.2022",
+        "F\u00e4lle_Meldedatum": 353,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 235,
-        "Fallzahl_aktiv": 3255,
-        "Krh_N_belegt": 642,
-        "Krh_I_belegt": 69,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 92,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.08,
-        "H_Zeitraum": "22.08.2022 - 28.08.2022",
-        "H_Datum": "23.08.2022",
+        "H_Inzidenz": 3.5,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.08.2022"
       }
     },
@@ -34722,37 +34722,75 @@
         "Fallzahl": 245951,
         "ObjectId": 907,
         "Sterbefall": 1756,
-        "Genesungsfall": 241132,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 241128,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6263,
         "Zuwachs_Fallzahl": 418,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 9,
-        "Zuwachs_Genesung": 610,
+        "Zuwachs_Genesung": 414,
         "BelegteBetten": null,
         "Inzidenz": 274.794353245447,
         "Datum_neu": 1661817600000,
-        "F\u00e4lle_Meldedatum": 60,
-        "Zeitraum": "23.08.2022 - 29.08.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 303,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 219,
-        "Fallzahl_aktiv": 3063,
-        "Krh_N_belegt": 642,
-        "Krh_I_belegt": 69,
+        "Fallzahl_aktiv": 3067,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -192,
+        "Fallzahl_aktiv_Zuwachs": 4,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.05,
-        "H_Zeitraum": "23.08.2022 - 29.08.2022",
-        "H_Datum": "23.08.2022",
+        "H_Inzidenz": 3.03,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.08.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "31.08.2022",
+        "Fallzahl": 246254,
+        "ObjectId": 908,
+        "Sterbefall": 1757,
+        "Genesungsfall": 241420,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6267,
+        "Zuwachs_Fallzahl": 303,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 292,
+        "BelegteBetten": null,
+        "Inzidenz": 281.080498581127,
+        "Datum_neu": 1661904000000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": "24.08.2022 - 30.08.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 245,
+        "Fallzahl_aktiv": 3077,
+        "Krh_N_belegt": 491,
+        "Krh_I_belegt": 58,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 10,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.49,
+        "H_Zeitraum": "24.08.2022 - 30.08.2022",
+        "H_Datum": "30.08.2022",
+        "Datum_Bett": "30.08.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
