### PR TITLE
New data set: 2022-09-01T100504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-08-31T101303Z.json
+pjson/2022-09-01T100504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-08-31T101303Z.json pjson/2022-09-01T100504Z.json```:
```
--- pjson/2022-08-31T101303Z.json	2022-08-31 10:13:03.523207352 +0000
+++ pjson/2022-09-01T100504Z.json	2022-09-01 10:05:04.254895994 +0000
@@ -22572,7 +22572,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1634169600000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -23028,7 +23028,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635206400000,
-        "F\u00e4lle_Meldedatum": 470,
+        "F\u00e4lle_Meldedatum": 471,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -23100,7 +23100,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 102,
+        "Zuwachs_Genesung": 101,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635379200000,
@@ -23142,7 +23142,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1635465600000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -23556,7 +23556,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 447,
+        "Zuwachs_Genesung": 448,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636416000000,
@@ -23670,7 +23670,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 212,
+        "Zuwachs_Genesung": 213,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1254,
+        "F\u00e4lle_Meldedatum": 1253,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -25152,7 +25152,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1240,
+        "Zuwachs_Genesung": 1239,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
@@ -26790,7 +26790,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643760000000,
-        "F\u00e4lle_Meldedatum": 1349,
+        "F\u00e4lle_Meldedatum": 1346,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27284,7 +27284,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644883200000,
-        "F\u00e4lle_Meldedatum": 1249,
+        "F\u00e4lle_Meldedatum": 1251,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -27318,7 +27318,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1345,
+        "Zuwachs_Genesung": 1342,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
@@ -27812,7 +27812,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1237,
+        "Zuwachs_Genesung": 1239,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646092800000,
@@ -29180,7 +29180,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 2148,
+        "Zuwachs_Genesung": 2147,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
@@ -29218,7 +29218,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 2193,
+        "Zuwachs_Genesung": 2192,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649289600000,
@@ -29332,7 +29332,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 432,
+        "Zuwachs_Genesung": 431,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649548800000,
@@ -31460,7 +31460,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 77,
+        "Zuwachs_Genesung": 75,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1654387200000,
@@ -33480,7 +33480,7 @@
         "Datum_neu": 1658966400000,
         "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33632,7 +33632,7 @@
         "Datum_neu": 1659312000000,
         "F\u00e4lle_Meldedatum": 573,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 29,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33670,7 +33670,7 @@
         "Datum_neu": 1659398400000,
         "F\u00e4lle_Meldedatum": 555,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34006,7 +34006,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 394,
+        "Zuwachs_Genesung": 395,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660176000000,
@@ -34158,7 +34158,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 546,
+        "Zuwachs_Genesung": 545,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660521600000,
@@ -34196,7 +34196,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 550,
+        "Zuwachs_Genesung": 549,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660608000000,
@@ -34430,7 +34430,7 @@
         "Datum_neu": 1661126400000,
         "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34502,12 +34502,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 420,
         "BelegteBetten": null,
-        "Inzidenz": 287.007435611911,
+        "Inzidenz": null,
         "Datum_neu": 1661299200000,
         "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 245.2,
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34520,7 +34520,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.88,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.08.2022"
@@ -34544,7 +34544,7 @@
         "Datum_neu": 1661385600000,
         "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 252.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34558,7 +34558,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.26,
+        "H_Inzidenz": 4.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.08.2022"
@@ -34596,7 +34596,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.08.2022"
@@ -34614,11 +34614,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 103,
+        "Zuwachs_Genesung": 102,
         "BelegteBetten": null,
         "Inzidenz": 290.240310355975,
         "Datum_neu": 1661558400000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 257.3,
@@ -34634,7 +34634,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.6,
+        "H_Inzidenz": 3.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.08.2022"
@@ -34656,7 +34656,7 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1661644800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 241.6,
@@ -34672,7 +34672,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 3.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.08.2022"
@@ -34694,7 +34694,7 @@
         "BelegteBetten": null,
         "Inzidenz": 279.643665361543,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 353,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 235,
@@ -34710,7 +34710,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.5,
+        "H_Inzidenz": 3.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.08.2022"
@@ -34721,34 +34721,34 @@
         "Datum": "30.08.2022",
         "Fallzahl": 245951,
         "ObjectId": 907,
-        "Sterbefall": 1756,
-        "Genesungsfall": 241128,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6263,
-        "Zuwachs_Fallzahl": 418,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 414,
         "BelegteBetten": null,
         "Inzidenz": 274.794353245447,
         "Datum_neu": 1661817600000,
-        "F\u00e4lle_Meldedatum": 303,
+        "F\u00e4lle_Meldedatum": 316,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 219,
-        "Fallzahl_aktiv": 3067,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 4,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.03,
+        "H_Inzidenz": 3.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.08.2022"
@@ -34757,39 +34757,77 @@
     {
       "attributes": {
         "Datum": "31.08.2022",
-        "Fallzahl": 246254,
+        "Fallzahl": 246253,
         "ObjectId": 908,
         "Sterbefall": 1757,
-        "Genesungsfall": 241420,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 241418,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6267,
-        "Zuwachs_Fallzahl": 303,
+        "Zuwachs_Fallzahl": 302,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 4,
-        "Zuwachs_Genesung": 292,
+        "Zuwachs_Genesung": 293,
         "BelegteBetten": null,
         "Inzidenz": 281.080498581127,
         "Datum_neu": 1661904000000,
-        "F\u00e4lle_Meldedatum": 20,
-        "Zeitraum": "24.08.2022 - 30.08.2022",
+        "F\u00e4lle_Meldedatum": 209,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 245,
-        "Fallzahl_aktiv": 3077,
+        "Fallzahl_aktiv": 3078,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 8,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.98,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.09.2022",
+        "Fallzahl": 246503,
+        "ObjectId": 909,
+        "Sterbefall": 1757,
+        "Genesungsfall": 241696,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6268,
+        "Zuwachs_Fallzahl": 250,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 278,
+        "BelegteBetten": null,
+        "Inzidenz": 274.614749092999,
+        "Datum_neu": 1661990400000,
+        "F\u00e4lle_Meldedatum": 44,
+        "Zeitraum": "25.08.2022 - 31.08.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 247.7,
+        "Fallzahl_aktiv": 3050,
         "Krh_N_belegt": 491,
         "Krh_I_belegt": 58,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 10,
+        "Fallzahl_aktiv_Zuwachs": -28,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.49,
-        "H_Zeitraum": "24.08.2022 - 30.08.2022",
+        "H_Inzidenz": 2.64,
+        "H_Zeitraum": "25.08.2022 - 31.08.2022",
         "H_Datum": "30.08.2022",
-        "Datum_Bett": "30.08.2022"
+        "Datum_Bett": "31.08.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
