### PR TITLE
New data set: 2022-09-02T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-01T100504Z.json
+pjson/2022-09-02T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-01T100504Z.json pjson/2022-09-02T100203Z.json```:
```
--- pjson/2022-09-01T100504Z.json	2022-09-01 10:05:04.254895994 +0000
+++ pjson/2022-09-02T100203Z.json	2022-09-02 10:02:04.249668497 +0000
@@ -32034,7 +32034,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655683200000,
-        "F\u00e4lle_Meldedatum": 698,
+        "F\u00e4lle_Meldedatum": 699,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -33782,7 +33782,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659657600000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -34126,7 +34126,7 @@
         "Datum_neu": 1660435200000,
         "F\u00e4lle_Meldedatum": 79,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34200,7 +34200,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660608000000,
-        "F\u00e4lle_Meldedatum": 418,
+        "F\u00e4lle_Meldedatum": 419,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -34310,7 +34310,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 316,
+        "Zuwachs_Genesung": 315,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660867200000,
@@ -34428,7 +34428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661126400000,
-        "F\u00e4lle_Meldedatum": 391,
+        "F\u00e4lle_Meldedatum": 392,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -34504,7 +34504,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661299200000,
-        "F\u00e4lle_Meldedatum": 262,
+        "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -34540,12 +34540,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 317,
         "BelegteBetten": null,
-        "Inzidenz": 284.492977477639,
+        "Inzidenz": null,
         "Datum_neu": 1661385600000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 279,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 252.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34558,7 +34558,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.49,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.08.2022"
@@ -34580,7 +34580,7 @@
         "BelegteBetten": null,
         "Inzidenz": 283.415352562951,
         "Datum_neu": 1661472000000,
-        "F\u00e4lle_Meldedatum": 249,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 250.6,
@@ -34596,7 +34596,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.97,
+        "H_Inzidenz": 3.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.08.2022"
@@ -34605,7 +34605,7 @@
     {
       "attributes": {
         "Datum": "27.08.2022",
-        "Fallzahl": 245540,
+        "Fallzahl": 245546,
         "ObjectId": 904,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -34616,9 +34616,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 102,
         "BelegteBetten": null,
-        "Inzidenz": 290.240310355975,
+        "Inzidenz": 290.958726965768,
         "Datum_neu": 1661558400000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 257.3,
@@ -34634,7 +34634,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.85,
+        "H_Inzidenz": 3.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.08.2022"
@@ -34652,11 +34652,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 83,
+        "Zuwachs_Genesung": 82,
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1661644800000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 241.6,
@@ -34672,7 +34672,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.8,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.08.2022"
@@ -34694,9 +34694,9 @@
         "BelegteBetten": null,
         "Inzidenz": 279.643665361543,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 235,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34710,7 +34710,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 3.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.08.2022"
@@ -34728,7 +34728,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 414,
+        "Zuwachs_Genesung": 415,
         "BelegteBetten": null,
         "Inzidenz": 274.794353245447,
         "Datum_neu": 1661817600000,
@@ -34748,7 +34748,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.23,
+        "H_Inzidenz": 3.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.08.2022"
@@ -34759,34 +34759,34 @@
         "Datum": "31.08.2022",
         "Fallzahl": 246253,
         "ObjectId": 908,
-        "Sterbefall": 1757,
-        "Genesungsfall": 241418,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6267,
-        "Zuwachs_Fallzahl": 302,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 293,
         "BelegteBetten": null,
         "Inzidenz": 281.080498581127,
         "Datum_neu": 1661904000000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 245,
-        "Fallzahl_aktiv": 3078,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 8,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.98,
+        "H_Inzidenz": 3.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.08.2022"
@@ -34799,7 +34799,7 @@
         "ObjectId": 909,
         "Sterbefall": 1757,
         "Genesungsfall": 241696,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6268,
         "Zuwachs_Fallzahl": 250,
         "Zuwachs_Sterbefall": 0,
@@ -34808,15 +34808,53 @@
         "BelegteBetten": null,
         "Inzidenz": 274.614749092999,
         "Datum_neu": 1661990400000,
-        "F\u00e4lle_Meldedatum": 44,
-        "Zeitraum": "25.08.2022 - 31.08.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 227,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 247.7,
         "Fallzahl_aktiv": 3050,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -28,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.28,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "31.08.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.09.2022",
+        "Fallzahl": 246712,
+        "ObjectId": 910,
+        "Sterbefall": 1757,
+        "Genesungsfall": 241941,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6275,
+        "Zuwachs_Fallzahl": 209,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 245,
+        "BelegteBetten": null,
+        "Inzidenz": 267.969395452423,
+        "Datum_neu": 1662076800000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "26.08.2022 - 01.09.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 233.7,
+        "Fallzahl_aktiv": 3014,
         "Krh_N_belegt": 491,
         "Krh_I_belegt": 58,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -28,
+        "Fallzahl_aktiv_Zuwachs": -36,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34824,10 +34862,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.64,
-        "H_Zeitraum": "25.08.2022 - 31.08.2022",
+        "H_Inzidenz": 2.86,
+        "H_Zeitraum": "26.08.2022 - 01.09.2022",
         "H_Datum": "30.08.2022",
-        "Datum_Bett": "31.08.2022"
+        "Datum_Bett": "01.09.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
