### PR TITLE
New data set: 2022-09-05T100504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-02T100203Z.json
+pjson/2022-09-05T100504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-02T100203Z.json pjson/2022-09-05T100504Z.json```:
```
--- pjson/2022-09-02T100203Z.json	2022-09-02 10:02:04.249668497 +0000
+++ pjson/2022-09-05T100504Z.json	2022-09-05 10:05:04.889830528 +0000
@@ -34088,7 +34088,7 @@
         "Datum_neu": 1660348800000,
         "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34468,7 +34468,7 @@
         "Datum_neu": 1661212800000,
         "F\u00e4lle_Meldedatum": 312,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34578,12 +34578,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 366,
         "BelegteBetten": null,
-        "Inzidenz": 283.415352562951,
+        "Inzidenz": null,
         "Datum_neu": 1661472000000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 250.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34596,7 +34596,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.99,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.08.2022"
@@ -34605,7 +34605,7 @@
     {
       "attributes": {
         "Datum": "27.08.2022",
-        "Fallzahl": 245546,
+        "Fallzahl": 245548,
         "ObjectId": 904,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -34616,12 +34616,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 102,
         "BelegteBetten": null,
-        "Inzidenz": 290.958726965768,
+        "Inzidenz": null,
         "Datum_neu": 1661558400000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 257.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34634,7 +34634,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.08.2022"
@@ -34654,12 +34654,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 82,
         "BelegteBetten": null,
-        "Inzidenz": 282.696935953159,
+        "Inzidenz": null,
         "Datum_neu": 1661644800000,
         "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 241.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34672,7 +34672,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.97,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.08.2022"
@@ -34732,7 +34732,7 @@
         "BelegteBetten": null,
         "Inzidenz": 274.794353245447,
         "Datum_neu": 1661817600000,
-        "F\u00e4lle_Meldedatum": 316,
+        "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 219,
@@ -34770,7 +34770,7 @@
         "BelegteBetten": null,
         "Inzidenz": 281.080498581127,
         "Datum_neu": 1661904000000,
-        "F\u00e4lle_Meldedatum": 218,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 245,
@@ -34797,26 +34797,26 @@
         "Datum": "01.09.2022",
         "Fallzahl": 246503,
         "ObjectId": 909,
-        "Sterbefall": 1757,
-        "Genesungsfall": 241696,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6268,
-        "Zuwachs_Fallzahl": 250,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 278,
         "BelegteBetten": null,
         "Inzidenz": 274.614749092999,
         "Datum_neu": 1661990400000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 247.7,
-        "Fallzahl_aktiv": 3050,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -28,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34837,7 +34837,7 @@
         "ObjectId": 910,
         "Sterbefall": 1757,
         "Genesungsfall": 241941,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6275,
         "Zuwachs_Fallzahl": 209,
         "Zuwachs_Sterbefall": 0,
@@ -34846,13 +34846,13 @@
         "BelegteBetten": null,
         "Inzidenz": 267.969395452423,
         "Datum_neu": 1662076800000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "26.08.2022 - 01.09.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 235,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 233.7,
         "Fallzahl_aktiv": 3014,
-        "Krh_N_belegt": 491,
-        "Krh_I_belegt": 58,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -36,
         "Krh_I": null,
@@ -34863,10 +34863,124 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 2.86,
-        "H_Zeitraum": "26.08.2022 - 01.09.2022",
-        "H_Datum": "30.08.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.09.2022",
+        "Fallzahl": 247042,
+        "ObjectId": 911,
+        "Sterbefall": null,
+        "Genesungsfall": 242047,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 106,
+        "BelegteBetten": null,
+        "Inzidenz": 224.505190560006,
+        "Datum_neu": 1662163200000,
+        "F\u00e4lle_Meldedatum": 81,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 230.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.86,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.09.2022",
+        "Fallzahl": 247066,
+        "ObjectId": 912,
+        "Sterbefall": null,
+        "Genesungsfall": 242087,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 40,
+        "BelegteBetten": null,
+        "Inzidenz": 211.034879126405,
+        "Datum_neu": 1662249600000,
+        "F\u00e4lle_Meldedatum": 30,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 215,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.86,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "03.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.09.2022",
+        "Fallzahl": 247086,
+        "ObjectId": 913,
+        "Sterbefall": 1757,
+        "Genesungsfall": 242473,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6287,
+        "Zuwachs_Fallzahl": 374,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 386,
+        "BelegteBetten": null,
+        "Inzidenz": 267.789791299975,
+        "Datum_neu": 1662336000000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "29.08.2022 - 04.09.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 207.8,
+        "Fallzahl_aktiv": 2856,
+        "Krh_N_belegt": 491,
+        "Krh_I_belegt": 58,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.86,
+        "H_Zeitraum": "29.08.2022 - 04.09.2022",
+        "H_Datum": "02.09.2022",
+        "Datum_Bett": "04.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
