### PR TITLE
New data set: 2022-09-06T152004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-05T100504Z.json
+pjson/2022-09-06T152004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-05T100504Z.json pjson/2022-09-06T152004Z.json```:
```
--- pjson/2022-09-05T100504Z.json	2022-09-05 10:05:04.889830528 +0000
+++ pjson/2022-09-06T152004Z.json	2022-09-06 15:20:05.296539478 +0000
@@ -34692,12 +34692,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 440,
         "BelegteBetten": null,
-        "Inzidenz": 279.643665361543,
+        "Inzidenz": null,
         "Datum_neu": 1661731200000,
         "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 235,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34710,7 +34710,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.08.2022"
@@ -34732,7 +34732,7 @@
         "BelegteBetten": null,
         "Inzidenz": 274.794353245447,
         "Datum_neu": 1661817600000,
-        "F\u00e4lle_Meldedatum": 315,
+        "F\u00e4lle_Meldedatum": 314,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 219,
@@ -34748,7 +34748,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.45,
+        "H_Inzidenz": 3.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.08.2022"
@@ -34770,7 +34770,7 @@
         "BelegteBetten": null,
         "Inzidenz": 281.080498581127,
         "Datum_neu": 1661904000000,
-        "F\u00e4lle_Meldedatum": 223,
+        "F\u00e4lle_Meldedatum": 221,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 245,
@@ -34786,7 +34786,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.23,
+        "H_Inzidenz": 3.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.08.2022"
@@ -34808,9 +34808,9 @@
         "BelegteBetten": null,
         "Inzidenz": 274.614749092999,
         "Datum_neu": 1661990400000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 251,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 247.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34824,7 +34824,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.28,
+        "H_Inzidenz": 3.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.08.2022"
@@ -34835,26 +34835,26 @@
         "Datum": "02.09.2022",
         "Fallzahl": 246712,
         "ObjectId": 910,
-        "Sterbefall": 1757,
-        "Genesungsfall": 241941,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6275,
-        "Zuwachs_Fallzahl": 209,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 245,
         "BelegteBetten": null,
         "Inzidenz": 267.969395452423,
         "Datum_neu": 1662076800000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 241,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 233.7,
-        "Fallzahl_aktiv": 3014,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -36,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34862,7 +34862,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
+        "H_Inzidenz": 3.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.09.2022"
@@ -34874,7 +34874,7 @@
         "Fallzahl": 247042,
         "ObjectId": 911,
         "Sterbefall": null,
-        "Genesungsfall": 242047,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -34884,9 +34884,9 @@
         "BelegteBetten": null,
         "Inzidenz": 224.505190560006,
         "Datum_neu": 1662163200000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 230.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34900,7 +34900,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
+        "H_Inzidenz": 3.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.09.2022"
@@ -34912,7 +34912,7 @@
         "Fallzahl": 247066,
         "ObjectId": 912,
         "Sterbefall": null,
-        "Genesungsfall": 242087,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -34922,9 +34922,9 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1662249600000,
-        "F\u00e4lle_Meldedatum": 30,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 215,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34938,7 +34938,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
+        "H_Inzidenz": 3.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.09.2022"
@@ -34951,7 +34951,7 @@
         "ObjectId": 913,
         "Sterbefall": 1757,
         "Genesungsfall": 242473,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6287,
         "Zuwachs_Fallzahl": 374,
         "Zuwachs_Sterbefall": 0,
@@ -34960,13 +34960,13 @@
         "BelegteBetten": null,
         "Inzidenz": 267.789791299975,
         "Datum_neu": 1662336000000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "29.08.2022 - 04.09.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 335,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 207.8,
         "Fallzahl_aktiv": 2856,
-        "Krh_N_belegt": 491,
-        "Krh_I_belegt": 58,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -12,
         "Krh_I": null,
@@ -34976,11 +34976,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.86,
-        "H_Zeitraum": "29.08.2022 - 04.09.2022",
-        "H_Datum": "02.09.2022",
+        "H_Inzidenz": 3.2,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "04.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "06.09.2022",
+        "Fallzahl": 247474,
+        "ObjectId": 914,
+        "Sterbefall": 1757,
+        "Genesungsfall": 242784,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6300,
+        "Zuwachs_Fallzahl": 388,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 311,
+        "BelegteBetten": null,
+        "Inzidenz": 271.741082653831,
+        "Datum_neu": 1662422400000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "30.08.2022 - 05.09.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 210,
+        "Fallzahl_aktiv": 2933,
+        "Krh_N_belegt": 491,
+        "Krh_I_belegt": 58,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 77,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.32,
+        "H_Zeitraum": "30.08.2022 - 05.09.2022",
+        "H_Datum": "06.09.2022",
+        "Datum_Bett": "05.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
