### PR TITLE
New data set: 2022-09-07T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-06T152004Z.json
+pjson/2022-09-07T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-06T152004Z.json pjson/2022-09-07T100103Z.json```:
```
--- pjson/2022-09-06T152004Z.json	2022-09-06 15:20:05.296539478 +0000
+++ pjson/2022-09-07T100103Z.json	2022-09-07 10:01:03.878922226 +0000
@@ -32834,7 +32834,7 @@
         "Datum_neu": 1657497600000,
         "F\u00e4lle_Meldedatum": 786,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32948,7 +32948,7 @@
         "Datum_neu": 1657756800000,
         "F\u00e4lle_Meldedatum": 267,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33784,7 +33784,7 @@
         "Datum_neu": 1659657600000,
         "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34694,7 +34694,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -34730,12 +34730,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 415,
         "BelegteBetten": null,
-        "Inzidenz": 274.794353245447,
+        "Inzidenz": null,
         "Datum_neu": 1661817600000,
-        "F\u00e4lle_Meldedatum": 314,
+        "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 219,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34748,7 +34748,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.08.2022"
@@ -34770,7 +34770,7 @@
         "BelegteBetten": null,
         "Inzidenz": 281.080498581127,
         "Datum_neu": 1661904000000,
-        "F\u00e4lle_Meldedatum": 221,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 245,
@@ -34786,7 +34786,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.52,
+        "H_Inzidenz": 3.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.08.2022"
@@ -34808,7 +34808,7 @@
         "BelegteBetten": null,
         "Inzidenz": 274.614749092999,
         "Datum_neu": 1661990400000,
-        "F\u00e4lle_Meldedatum": 251,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 247.7,
@@ -34824,7 +34824,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.67,
+        "H_Inzidenz": 3.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.08.2022"
@@ -34862,7 +34862,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.6,
+        "H_Inzidenz": 3.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.09.2022"
@@ -34884,9 +34884,9 @@
         "BelegteBetten": null,
         "Inzidenz": 224.505190560006,
         "Datum_neu": 1662163200000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 230.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34900,7 +34900,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.48,
+        "H_Inzidenz": 3.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.09.2022"
@@ -34922,7 +34922,7 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1662249600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 215,
@@ -34938,7 +34938,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.28,
+        "H_Inzidenz": 3.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.09.2022"
@@ -34949,26 +34949,26 @@
         "Datum": "05.09.2022",
         "Fallzahl": 247086,
         "ObjectId": 913,
-        "Sterbefall": 1757,
-        "Genesungsfall": 242473,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6287,
-        "Zuwachs_Fallzahl": 374,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 386,
         "BelegteBetten": null,
         "Inzidenz": 267.789791299975,
         "Datum_neu": 1662336000000,
-        "F\u00e4lle_Meldedatum": 335,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 207.8,
-        "Fallzahl_aktiv": 2856,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -34976,7 +34976,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.2,
+        "H_Inzidenz": 3.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.09.2022"
@@ -34989,7 +34989,7 @@
         "ObjectId": 914,
         "Sterbefall": 1757,
         "Genesungsfall": 242784,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6300,
         "Zuwachs_Fallzahl": 388,
         "Zuwachs_Sterbefall": 0,
@@ -34998,13 +34998,13 @@
         "BelegteBetten": null,
         "Inzidenz": 271.741082653831,
         "Datum_neu": 1662422400000,
-        "F\u00e4lle_Meldedatum": 16,
-        "Zeitraum": "30.08.2022 - 05.09.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 284,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 210,
         "Fallzahl_aktiv": 2933,
-        "Krh_N_belegt": 491,
-        "Krh_I_belegt": 58,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 77,
         "Krh_I": null,
@@ -35014,11 +35014,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.32,
-        "H_Zeitraum": "30.08.2022 - 05.09.2022",
-        "H_Datum": "06.09.2022",
+        "H_Inzidenz": 3.03,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.09.2022",
+        "Fallzahl": 247776,
+        "ObjectId": 915,
+        "Sterbefall": 1757,
+        "Genesungsfall": 243070,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6320,
+        "Zuwachs_Fallzahl": 302,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 286,
+        "BelegteBetten": null,
+        "Inzidenz": 267.969395452423,
+        "Datum_neu": 1662508800000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": "31.08.2022 - 06.09.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 218.3,
+        "Fallzahl_aktiv": 2949,
+        "Krh_N_belegt": 473,
+        "Krh_I_belegt": 45,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 16,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.54,
+        "H_Zeitraum": "31.08.2022 - 06.09.2022",
+        "H_Datum": "07.09.2022",
+        "Datum_Bett": "06.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
