### PR TITLE
New data set: 2022-09-08T101004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-07T100103Z.json
+pjson/2022-09-08T101004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-07T100103Z.json pjson/2022-09-08T101004Z.json```:
```
--- pjson/2022-09-07T100103Z.json	2022-09-07 10:01:03.878922226 +0000
+++ pjson/2022-09-08T101004Z.json	2022-09-08 10:10:04.897710211 +0000
@@ -33214,7 +33214,7 @@
         "Datum_neu": 1658361600000,
         "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34010,7 +34010,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660176000000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -34048,7 +34048,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660262400000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -34086,7 +34086,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660348800000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -34124,7 +34124,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660435200000,
-        "F\u00e4lle_Meldedatum": 79,
+        "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -34238,7 +34238,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660694400000,
-        "F\u00e4lle_Meldedatum": 275,
+        "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -34276,7 +34276,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660780800000,
-        "F\u00e4lle_Meldedatum": 279,
+        "F\u00e4lle_Meldedatum": 280,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -34428,7 +34428,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661126400000,
-        "F\u00e4lle_Meldedatum": 392,
+        "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -34542,7 +34542,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661385600000,
-        "F\u00e4lle_Meldedatum": 279,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -34605,7 +34605,7 @@
     {
       "attributes": {
         "Datum": "27.08.2022",
-        "Fallzahl": 245548,
+        "Fallzahl": 245542,
         "ObjectId": 904,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -34618,7 +34618,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661558400000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -34656,7 +34656,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661644800000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 38,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -34694,7 +34694,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 354,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -34770,10 +34770,10 @@
         "BelegteBetten": null,
         "Inzidenz": 281.080498581127,
         "Datum_neu": 1661904000000,
-        "F\u00e4lle_Meldedatum": 220,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 245,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34786,7 +34786,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.67,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.08.2022"
@@ -34824,7 +34824,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.85,
+        "H_Inzidenz": 3.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.08.2022"
@@ -34846,7 +34846,7 @@
         "BelegteBetten": null,
         "Inzidenz": 267.969395452423,
         "Datum_neu": 1662076800000,
-        "F\u00e4lle_Meldedatum": 241,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 233.7,
@@ -34862,7 +34862,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.82,
+        "H_Inzidenz": 3.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.09.2022"
@@ -34884,7 +34884,7 @@
         "BelegteBetten": null,
         "Inzidenz": 224.505190560006,
         "Datum_neu": 1662163200000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 230.1,
@@ -34900,7 +34900,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.77,
+        "H_Inzidenz": 3.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.09.2022"
@@ -34938,7 +34938,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.57,
+        "H_Inzidenz": 3.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.09.2022"
@@ -34960,7 +34960,7 @@
         "BelegteBetten": null,
         "Inzidenz": 267.789791299975,
         "Datum_neu": 1662336000000,
-        "F\u00e4lle_Meldedatum": 342,
+        "F\u00e4lle_Meldedatum": 349,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 207.8,
@@ -34976,7 +34976,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.55,
+        "H_Inzidenz": 3.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.09.2022"
@@ -34998,9 +34998,9 @@
         "BelegteBetten": null,
         "Inzidenz": 271.741082653831,
         "Datum_neu": 1662422400000,
-        "F\u00e4lle_Meldedatum": 284,
+        "F\u00e4lle_Meldedatum": 298,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 210,
         "Fallzahl_aktiv": 2933,
         "Krh_N_belegt": null,
@@ -35014,7 +35014,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.03,
+        "H_Inzidenz": 3.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.09.2022"
@@ -35027,7 +35027,7 @@
         "ObjectId": 915,
         "Sterbefall": 1757,
         "Genesungsfall": 243070,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6320,
         "Zuwachs_Fallzahl": 302,
         "Zuwachs_Sterbefall": 0,
@@ -35036,9 +35036,9 @@
         "BelegteBetten": null,
         "Inzidenz": 267.969395452423,
         "Datum_neu": 1662508800000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 248,
         "Zeitraum": "31.08.2022 - 06.09.2022",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 218.3,
         "Fallzahl_aktiv": 2949,
         "Krh_N_belegt": 473,
@@ -35052,11 +35052,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.54,
+        "H_Inzidenz": 3.28,
         "H_Zeitraum": "31.08.2022 - 06.09.2022",
         "H_Datum": "07.09.2022",
         "Datum_Bett": "06.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.09.2022",
+        "Fallzahl": 248031,
+        "ObjectId": 916,
+        "Sterbefall": 1757,
+        "Genesungsfall": 243349,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6322,
+        "Zuwachs_Fallzahl": 255,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 279,
+        "BelegteBetten": null,
+        "Inzidenz": 276.769998922375,
+        "Datum_neu": 1662595200000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": "01.09.2022 - 07.09.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 242.3,
+        "Fallzahl_aktiv": 2925,
+        "Krh_N_belegt": 473,
+        "Krh_I_belegt": 45,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -24,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.88,
+        "H_Zeitraum": "01.09.2022 - 07.09.2022",
+        "H_Datum": "07.09.2022",
+        "Datum_Bett": "07.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
