### PR TITLE
New data set: 2022-09-09T100404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-08T101004Z.json
+pjson/2022-09-09T100404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-08T101004Z.json pjson/2022-09-09T100404Z.json```:
```
--- pjson/2022-09-08T101004Z.json	2022-09-08 10:10:04.897710211 +0000
+++ pjson/2022-09-09T100404Z.json	2022-09-09 10:04:04.440853268 +0000
@@ -31882,7 +31882,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655337600000,
-        "F\u00e4lle_Meldedatum": 452,
+        "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -31920,7 +31920,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655424000000,
-        "F\u00e4lle_Meldedatum": 384,
+        "F\u00e4lle_Meldedatum": 383,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -32452,7 +32452,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1656633600000,
-        "F\u00e4lle_Meldedatum": 477,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -33668,7 +33668,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 555,
+        "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -33896,7 +33896,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659916800000,
-        "F\u00e4lle_Meldedatum": 463,
+        "F\u00e4lle_Meldedatum": 464,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -34605,7 +34605,7 @@
     {
       "attributes": {
         "Datum": "27.08.2022",
-        "Fallzahl": 245542,
+        "Fallzahl": 245508,
         "ObjectId": 904,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -34694,9 +34694,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 354,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34768,7 +34768,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 293,
         "BelegteBetten": null,
-        "Inzidenz": 281.080498581127,
+        "Inzidenz": null,
         "Datum_neu": 1661904000000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
@@ -34806,12 +34806,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 278,
         "BelegteBetten": null,
-        "Inzidenz": 274.614749092999,
+        "Inzidenz": null,
         "Datum_neu": 1661990400000,
         "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 247.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34824,7 +34824,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
+        "H_Inzidenz": 3.97,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.08.2022"
@@ -34846,7 +34846,7 @@
         "BelegteBetten": null,
         "Inzidenz": 267.969395452423,
         "Datum_neu": 1662076800000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 233.7,
@@ -34862,7 +34862,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.89,
+        "H_Inzidenz": 3.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.09.2022"
@@ -34900,7 +34900,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.82,
+        "H_Inzidenz": 3.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.09.2022"
@@ -34960,7 +34960,7 @@
         "BelegteBetten": null,
         "Inzidenz": 267.789791299975,
         "Datum_neu": 1662336000000,
-        "F\u00e4lle_Meldedatum": 349,
+        "F\u00e4lle_Meldedatum": 348,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 207.8,
@@ -34976,7 +34976,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.7,
+        "H_Inzidenz": 3.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.09.2022"
@@ -34987,13 +34987,13 @@
         "Datum": "06.09.2022",
         "Fallzahl": 247474,
         "ObjectId": 914,
-        "Sterbefall": 1757,
-        "Genesungsfall": 242784,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6300,
-        "Zuwachs_Fallzahl": 388,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 311,
         "BelegteBetten": null,
         "Inzidenz": 271.741082653831,
@@ -35002,19 +35002,19 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 210,
-        "Fallzahl_aktiv": 2933,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 77,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.38,
+        "H_Inzidenz": 3.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.09.2022"
@@ -35025,36 +35025,36 @@
         "Datum": "07.09.2022",
         "Fallzahl": 247776,
         "ObjectId": 915,
-        "Sterbefall": 1757,
-        "Genesungsfall": 243070,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6320,
-        "Zuwachs_Fallzahl": 302,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 286,
         "BelegteBetten": null,
         "Inzidenz": 267.969395452423,
         "Datum_neu": 1662508800000,
-        "F\u00e4lle_Meldedatum": 248,
-        "Zeitraum": "31.08.2022 - 06.09.2022",
+        "F\u00e4lle_Meldedatum": 261,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 218.3,
-        "Fallzahl_aktiv": 2949,
-        "Krh_N_belegt": 473,
-        "Krh_I_belegt": 45,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 16,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.28,
-        "H_Zeitraum": "31.08.2022 - 06.09.2022",
-        "H_Datum": "07.09.2022",
+        "H_Inzidenz": 3.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.09.2022"
       }
     },
@@ -35063,26 +35063,26 @@
         "Datum": "08.09.2022",
         "Fallzahl": 248031,
         "ObjectId": 916,
-        "Sterbefall": 1757,
-        "Genesungsfall": 243349,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6322,
-        "Zuwachs_Fallzahl": 255,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 279,
         "BelegteBetten": null,
         "Inzidenz": 276.769998922375,
         "Datum_neu": 1662595200000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "01.09.2022 - 07.09.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 227,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 242.3,
-        "Fallzahl_aktiv": 2925,
-        "Krh_N_belegt": 473,
-        "Krh_I_belegt": 45,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -24,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -35091,10 +35091,48 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 2.88,
-        "H_Zeitraum": "01.09.2022 - 07.09.2022",
-        "H_Datum": "07.09.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.09.2022",
+        "Fallzahl": 248250,
+        "ObjectId": 917,
+        "Sterbefall": 1757,
+        "Genesungsfall": 243618,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6326,
+        "Zuwachs_Fallzahl": 219,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 269,
+        "BelegteBetten": null,
+        "Inzidenz": 274.255540788103,
+        "Datum_neu": 1662681600000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "02.09.2022 - 08.09.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 241.6,
+        "Fallzahl_aktiv": 2875,
+        "Krh_N_belegt": 473,
+        "Krh_I_belegt": 45,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -50,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.06,
+        "H_Zeitraum": "02.09.2022 - 08.09.2022",
+        "H_Datum": "06.09.2022",
+        "Datum_Bett": "08.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
