### PR TITLE
New data set: 2022-09-12T095804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-09T100404Z.json
+pjson/2022-09-12T095804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-09T100404Z.json pjson/2022-09-12T095804Z.json```:
```
--- pjson/2022-09-09T100404Z.json	2022-09-09 10:04:04.440853268 +0000
+++ pjson/2022-09-12T095804Z.json	2022-09-12 09:58:04.408161078 +0000
@@ -14630,7 +14630,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616112000000,
-        "F\u00e4lle_Meldedatum": 114,
+        "F\u00e4lle_Meldedatum": 113,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -14858,7 +14858,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1616630400000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -15390,7 +15390,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1617840000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -15694,7 +15694,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1618531200000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -17556,7 +17556,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1622764800000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 6,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -17898,7 +17898,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1623542400000,
-        "F\u00e4lle_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 2,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -23408,7 +23408,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636070400000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 541,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -23674,7 +23674,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636675200000,
-        "F\u00e4lle_Meldedatum": 1104,
+        "F\u00e4lle_Meldedatum": 1105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -23902,7 +23902,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637193600000,
-        "F\u00e4lle_Meldedatum": 1104,
+        "F\u00e4lle_Meldedatum": 1105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
@@ -24168,7 +24168,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1637798400000,
-        "F\u00e4lle_Meldedatum": 1474,
+        "F\u00e4lle_Meldedatum": 1473,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 787,
+        "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26030,7 +26030,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642032000000,
-        "F\u00e4lle_Meldedatum": 303,
+        "F\u00e4lle_Meldedatum": 302,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26334,7 +26334,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1642723200000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1006,
+        "F\u00e4lle_Meldedatum": 1005,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26714,7 +26714,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643587200000,
-        "F\u00e4lle_Meldedatum": 1500,
+        "F\u00e4lle_Meldedatum": 1501,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -29184,7 +29184,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1649203200000,
-        "F\u00e4lle_Meldedatum": 1063,
+        "F\u00e4lle_Meldedatum": 1064,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -33782,7 +33782,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659657600000,
-        "F\u00e4lle_Meldedatum": 311,
+        "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -34808,7 +34808,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661990400000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -34824,7 +34824,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.97,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.08.2022"
@@ -34849,7 +34849,7 @@
         "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 233.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34862,7 +34862,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.94,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.09.2022"
@@ -34887,7 +34887,7 @@
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 230.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34900,7 +34900,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.85,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.09.2022"
@@ -34922,10 +34922,10 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1662249600000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 215,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34938,7 +34938,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.65,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.09.2022"
@@ -34960,7 +34960,7 @@
         "BelegteBetten": null,
         "Inzidenz": 267.789791299975,
         "Datum_neu": 1662336000000,
-        "F\u00e4lle_Meldedatum": 348,
+        "F\u00e4lle_Meldedatum": 346,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 207.8,
@@ -34998,7 +34998,7 @@
         "BelegteBetten": null,
         "Inzidenz": 271.741082653831,
         "Datum_neu": 1662422400000,
-        "F\u00e4lle_Meldedatum": 298,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 210,
@@ -35014,7 +35014,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.72,
+        "H_Inzidenz": 3.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.09.2022"
@@ -35036,7 +35036,7 @@
         "BelegteBetten": null,
         "Inzidenz": 267.969395452423,
         "Datum_neu": 1662508800000,
-        "F\u00e4lle_Meldedatum": 261,
+        "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 218.3,
@@ -35052,7 +35052,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.7,
+        "H_Inzidenz": 3.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.09.2022"
@@ -35074,7 +35074,7 @@
         "BelegteBetten": null,
         "Inzidenz": 276.769998922375,
         "Datum_neu": 1662595200000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 250,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 242.3,
@@ -35090,7 +35090,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.88,
+        "H_Inzidenz": 3.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.09.2022"
@@ -35103,7 +35103,7 @@
         "ObjectId": 917,
         "Sterbefall": 1757,
         "Genesungsfall": 243618,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6326,
         "Zuwachs_Fallzahl": 219,
         "Zuwachs_Sterbefall": 0,
@@ -35112,15 +35112,129 @@
         "BelegteBetten": null,
         "Inzidenz": 274.255540788103,
         "Datum_neu": 1662681600000,
-        "F\u00e4lle_Meldedatum": 6,
-        "Zeitraum": "02.09.2022 - 08.09.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 218,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 241.6,
         "Fallzahl_aktiv": 2875,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -50,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.33,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "08.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.09.2022",
+        "Fallzahl": 248557,
+        "ObjectId": 918,
+        "Sterbefall": null,
+        "Genesungsfall": 243703,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 639,
+        "BelegteBetten": null,
+        "Inzidenz": 275.333165702791,
+        "Datum_neu": 1662768000000,
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 238.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.11,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "09.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.09.2022",
+        "Fallzahl": 248583,
+        "ObjectId": 919,
+        "Sterbefall": null,
+        "Genesungsfall": 243746,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 397,
+        "BelegteBetten": null,
+        "Inzidenz": 268.687812062215,
+        "Datum_neu": 1662854400000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 219.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.96,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "10.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.09.2022",
+        "Fallzahl": 248603,
+        "ObjectId": 920,
+        "Sterbefall": 1757,
+        "Genesungsfall": 244094,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6340,
+        "Zuwachs_Fallzahl": 353,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 14,
+        "Zuwachs_Genesung": 476,
+        "BelegteBetten": null,
+        "Inzidenz": 264.556916555911,
+        "Datum_neu": 1662940800000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": "05.09.2022 - 11.09.2022",
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": 210.9,
+        "Fallzahl_aktiv": 2752,
         "Krh_N_belegt": 473,
         "Krh_I_belegt": 45,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -50,
+        "Fallzahl_aktiv_Zuwachs": -123,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -35128,10 +35242,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.06,
-        "H_Zeitraum": "02.09.2022 - 08.09.2022",
+        "H_Inzidenz": 2.56,
+        "H_Zeitraum": "05.09.2022 - 11.09.2022",
         "H_Datum": "06.09.2022",
-        "Datum_Bett": "08.09.2022"
+        "Datum_Bett": "11.09.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
