### PR TITLE
New data set: 2022-09-13T095604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-12T095804Z.json
+pjson/2022-09-13T095604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-12T095804Z.json pjson/2022-09-13T095604Z.json```:
```
--- pjson/2022-09-12T095804Z.json	2022-09-12 09:58:04.408161078 +0000
+++ pjson/2022-09-13T095604Z.json	2022-09-13 09:56:04.404137192 +0000
@@ -33478,7 +33478,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 373,
+        "F\u00e4lle_Meldedatum": 374,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -34200,7 +34200,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660608000000,
-        "F\u00e4lle_Meldedatum": 419,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -34240,7 +34240,7 @@
         "Datum_neu": 1660694400000,
         "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34656,7 +34656,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661644800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -34694,9 +34694,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661731200000,
-        "F\u00e4lle_Meldedatum": 354,
+        "F\u00e4lle_Meldedatum": 353,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34922,7 +34922,7 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1662249600000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -34962,8 +34962,8 @@
         "Datum_neu": 1662336000000,
         "F\u00e4lle_Meldedatum": 346,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 207.8,
+        "Hosp_Meldedatum": 12,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -34976,7 +34976,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.09.2022"
@@ -34998,7 +34998,7 @@
         "BelegteBetten": null,
         "Inzidenz": 271.741082653831,
         "Datum_neu": 1662422400000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 210,
@@ -35014,7 +35014,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 4.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.09.2022"
@@ -35052,7 +35052,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
+        "H_Inzidenz": 4.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.09.2022"
@@ -35074,7 +35074,7 @@
         "BelegteBetten": null,
         "Inzidenz": 276.769998922375,
         "Datum_neu": 1662595200000,
-        "F\u00e4lle_Meldedatum": 250,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 242.3,
@@ -35090,7 +35090,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.65,
+        "H_Inzidenz": 4.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.09.2022"
@@ -35101,26 +35101,26 @@
         "Datum": "09.09.2022",
         "Fallzahl": 248250,
         "ObjectId": 917,
-        "Sterbefall": 1757,
-        "Genesungsfall": 243618,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6326,
-        "Zuwachs_Fallzahl": 219,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
-        "Zuwachs_Genesung": 269,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 263,
         "BelegteBetten": null,
         "Inzidenz": 274.255540788103,
         "Datum_neu": 1662681600000,
-        "F\u00e4lle_Meldedatum": 218,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 241.6,
-        "Fallzahl_aktiv": 2875,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -50,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -35128,7 +35128,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.33,
+        "H_Inzidenz": 4.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.09.2022"
@@ -35140,17 +35140,17 @@
         "Fallzahl": 248557,
         "ObjectId": 918,
         "Sterbefall": null,
-        "Genesungsfall": 243703,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 639,
+        "Zuwachs_Genesung": 90,
         "BelegteBetten": null,
         "Inzidenz": 275.333165702791,
         "Datum_neu": 1662768000000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 238.9,
@@ -35166,7 +35166,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.11,
+        "H_Inzidenz": 4.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.09.2022"
@@ -35178,17 +35178,17 @@
         "Fallzahl": 248583,
         "ObjectId": 919,
         "Sterbefall": null,
-        "Genesungsfall": 243746,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 397,
+        "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
         "Inzidenz": 268.687812062215,
         "Datum_neu": 1662854400000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 219.5,
@@ -35204,7 +35204,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.96,
+        "H_Inzidenz": 4.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.09.2022"
@@ -35217,36 +35217,74 @@
         "ObjectId": 920,
         "Sterbefall": 1757,
         "Genesungsfall": 244094,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6340,
         "Zuwachs_Fallzahl": 353,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 14,
-        "Zuwachs_Genesung": 476,
+        "Zuwachs_Genesung": 348,
         "BelegteBetten": null,
         "Inzidenz": 264.556916555911,
         "Datum_neu": 1662940800000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 323,
         "Zeitraum": "05.09.2022 - 11.09.2022",
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 210.9,
         "Fallzahl_aktiv": 2752,
         "Krh_N_belegt": 473,
         "Krh_I_belegt": 45,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -123,
+        "Fallzahl_aktiv_Zuwachs": 5,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.56,
+        "H_Inzidenz": 3.99,
         "H_Zeitraum": "05.09.2022 - 11.09.2022",
         "H_Datum": "06.09.2022",
         "Datum_Bett": "11.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.09.2022",
+        "Fallzahl": 249025,
+        "ObjectId": 921,
+        "Sterbefall": 1757,
+        "Genesungsfall": 244408,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6347,
+        "Zuwachs_Fallzahl": 422,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 314,
+        "BelegteBetten": null,
+        "Inzidenz": 269.406228672007,
+        "Datum_neu": 1663027200000,
+        "F\u00e4lle_Meldedatum": 72,
+        "Zeitraum": "06.09.2022 - 12.09.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 213.8,
+        "Fallzahl_aktiv": 2860,
+        "Krh_N_belegt": 473,
+        "Krh_I_belegt": 45,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 108,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.91,
+        "H_Zeitraum": "06.09.2022 - 12.09.2022",
+        "H_Datum": "06.09.2022",
+        "Datum_Bett": "12.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
