### PR TITLE
New data set: 2022-09-15T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-14T100604Z.json
+pjson/2022-09-15T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-14T100604Z.json pjson/2022-09-15T100403Z.json```:
```
--- pjson/2022-09-14T100604Z.json	2022-09-14 10:06:04.912075307 +0000
+++ pjson/2022-09-15T100403Z.json	2022-09-15 10:04:04.268061143 +0000
@@ -32986,7 +32986,7 @@
         "Datum_neu": 1657843200000,
         "F\u00e4lle_Meldedatum": 1123,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33756,7 +33756,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34060,7 +34060,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34136,7 +34136,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34212,7 +34212,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34288,7 +34288,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34402,7 +34402,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34820,7 +34820,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34846,7 +34846,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662076800000,
-        "F\u00e4lle_Meldedatum": 237,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -34858,7 +34858,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34960,7 +34960,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662336000000,
-        "F\u00e4lle_Meldedatum": 346,
+        "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -34998,7 +34998,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662422400000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 298,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -35034,12 +35034,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 286,
         "BelegteBetten": null,
-        "Inzidenz": 267.969395452423,
+        "Inzidenz": null,
         "Datum_neu": 1662508800000,
-        "F\u00e4lle_Meldedatum": 263,
+        "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 218.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35052,7 +35052,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.09.2022"
@@ -35074,7 +35074,7 @@
         "BelegteBetten": null,
         "Inzidenz": 276.769998922375,
         "Datum_neu": 1662595200000,
-        "F\u00e4lle_Meldedatum": 248,
+        "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 242.3,
@@ -35090,7 +35090,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.46,
+        "H_Inzidenz": 4.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.09.2022"
@@ -35112,7 +35112,7 @@
         "BelegteBetten": null,
         "Inzidenz": 274.255540788103,
         "Datum_neu": 1662681600000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 241.6,
@@ -35128,7 +35128,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.44,
+        "H_Inzidenz": 4.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.09.2022"
@@ -35150,7 +35150,7 @@
         "BelegteBetten": null,
         "Inzidenz": 275.333165702791,
         "Datum_neu": 1662768000000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 238.9,
@@ -35166,7 +35166,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.71,
+        "H_Inzidenz": 4.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.09.2022"
@@ -35188,7 +35188,7 @@
         "BelegteBetten": null,
         "Inzidenz": 268.687812062215,
         "Datum_neu": 1662854400000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 219.5,
@@ -35204,7 +35204,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.66,
+        "H_Inzidenz": 4.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.09.2022"
@@ -35226,7 +35226,7 @@
         "BelegteBetten": null,
         "Inzidenz": 264.556916555911,
         "Datum_neu": 1662940800000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 354,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 210.9,
@@ -35238,11 +35238,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.31,
+        "H_Inzidenz": 4.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.09.2022"
@@ -35253,34 +35253,34 @@
         "Datum": "13.09.2022",
         "Fallzahl": 249025,
         "ObjectId": 921,
-        "Sterbefall": 1757,
-        "Genesungsfall": 244408,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6347,
-        "Zuwachs_Fallzahl": 422,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 314,
         "BelegteBetten": null,
         "Inzidenz": 269.406228672007,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 364,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 213.8,
-        "Fallzahl_aktiv": 2860,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 108,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.92,
+        "H_Inzidenz": 4.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.09.2022"
@@ -35293,7 +35293,7 @@
         "ObjectId": 922,
         "Sterbefall": 1758,
         "Genesungsfall": 244634,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6355,
         "Zuwachs_Fallzahl": 335,
         "Zuwachs_Sterbefall": 1,
@@ -35302,13 +35302,13 @@
         "BelegteBetten": null,
         "Inzidenz": 288.264664679047,
         "Datum_neu": 1663113600000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "07.09.2022 - 13.09.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 229,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 245.2,
         "Fallzahl_aktiv": 2968,
-        "Krh_N_belegt": 441,
-        "Krh_I_belegt": 39,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 108,
         "Krh_I": null,
@@ -35318,11 +35318,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.2,
-        "H_Zeitraum": "07.09.2022 - 13.09.2022",
-        "H_Datum": "14.09.2022",
+        "H_Inzidenz": 3.87,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.09.2022",
+        "Fallzahl": 249601,
+        "ObjectId": 923,
+        "Sterbefall": 1767,
+        "Genesungsfall": 244874,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6360,
+        "Zuwachs_Fallzahl": 241,
+        "Zuwachs_Sterbefall": 9,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 240,
+        "BelegteBetten": null,
+        "Inzidenz": 282.696935953159,
+        "Datum_neu": 1663200000000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "08.09.2022 - 14.09.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 251.5,
+        "Fallzahl_aktiv": 2960,
+        "Krh_N_belegt": 441,
+        "Krh_I_belegt": 39,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -8,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.18,
+        "H_Zeitraum": "08.09.2022 - 14.09.2022",
+        "H_Datum": "15.09.2022",
+        "Datum_Bett": "14.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
