### PR TITLE
New data set: 2022-09-16T100204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-15T100403Z.json
+pjson/2022-09-16T100204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-15T100403Z.json pjson/2022-09-16T100204Z.json```:
```
--- pjson/2022-09-15T100403Z.json	2022-09-15 10:04:04.268061143 +0000
+++ pjson/2022-09-16T100204Z.json	2022-09-16 10:02:04.484726935 +0000
@@ -31806,7 +31806,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1655164800000,
-        "F\u00e4lle_Meldedatum": 529,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -33832,7 +33832,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -33946,7 +33946,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34326,7 +34326,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34440,7 +34440,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34782,7 +34782,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34858,7 +34858,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -35077,7 +35077,7 @@
         "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 242.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35090,7 +35090,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.09.2022"
@@ -35128,7 +35128,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.56,
+        "H_Inzidenz": 4.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.09.2022"
@@ -35166,7 +35166,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.88,
+        "H_Inzidenz": 4.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.09.2022"
@@ -35188,7 +35188,7 @@
         "BelegteBetten": null,
         "Inzidenz": 268.687812062215,
         "Datum_neu": 1662854400000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 219.5,
@@ -35204,7 +35204,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.86,
+        "H_Inzidenz": 4.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.09.2022"
@@ -35226,7 +35226,7 @@
         "BelegteBetten": null,
         "Inzidenz": 264.556916555911,
         "Datum_neu": 1662940800000,
-        "F\u00e4lle_Meldedatum": 354,
+        "F\u00e4lle_Meldedatum": 355,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 210.9,
@@ -35242,7 +35242,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.51,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.09.2022"
@@ -35264,7 +35264,7 @@
         "BelegteBetten": null,
         "Inzidenz": 269.406228672007,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 373,
+        "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 213.8,
@@ -35280,7 +35280,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": 4.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.09.2022"
@@ -35291,34 +35291,34 @@
         "Datum": "14.09.2022",
         "Fallzahl": 249360,
         "ObjectId": 922,
-        "Sterbefall": 1758,
-        "Genesungsfall": 244634,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6355,
-        "Zuwachs_Fallzahl": 335,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 226,
         "BelegteBetten": null,
         "Inzidenz": 288.264664679047,
         "Datum_neu": 1663113600000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 245.2,
-        "Fallzahl_aktiv": 2968,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 108,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.87,
+        "H_Inzidenz": 4.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.09.2022"
@@ -35331,7 +35331,7 @@
         "ObjectId": 923,
         "Sterbefall": 1767,
         "Genesungsfall": 244874,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6360,
         "Zuwachs_Fallzahl": 241,
         "Zuwachs_Sterbefall": 9,
@@ -35340,9 +35340,9 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1663200000000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 319,
         "Zeitraum": "08.09.2022 - 14.09.2022",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 251.5,
         "Fallzahl_aktiv": 2960,
         "Krh_N_belegt": 441,
@@ -35356,11 +35356,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.18,
+        "H_Inzidenz": 4.07,
         "H_Zeitraum": "08.09.2022 - 14.09.2022",
-        "H_Datum": "15.09.2022",
+        "H_Datum": "13.09.2022",
         "Datum_Bett": "14.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.09.2022",
+        "Fallzahl": 249956,
+        "ObjectId": 924,
+        "Sterbefall": 1773,
+        "Genesungsfall": 245116,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6362,
+        "Zuwachs_Fallzahl": 355,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 242,
+        "BelegteBetten": null,
+        "Inzidenz": 305.506663314056,
+        "Datum_neu": 1663286400000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "09.09.2022 - 15.09.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 269.7,
+        "Fallzahl_aktiv": 3067,
+        "Krh_N_belegt": 441,
+        "Krh_I_belegt": 39,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 107,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.75,
+        "H_Zeitraum": "09.09.2022 - 15.09.2022",
+        "H_Datum": "13.09.2022",
+        "Datum_Bett": "15.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
