### PR TITLE
New data set: 2022-09-19T100703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-16T100204Z.json
+pjson/2022-09-19T100703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-16T100204Z.json pjson/2022-09-19T100703Z.json```:
```
--- pjson/2022-09-16T100204Z.json	2022-09-16 10:02:04.484726935 +0000
+++ pjson/2022-09-19T100703Z.json	2022-09-19 10:07:04.271723525 +0000
@@ -35036,7 +35036,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662508800000,
-        "F\u00e4lle_Meldedatum": 262,
+        "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -35072,7 +35072,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 279,
         "BelegteBetten": null,
-        "Inzidenz": 276.769998922375,
+        "Inzidenz": null,
         "Datum_neu": 1662595200000,
         "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
@@ -35110,12 +35110,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 263,
         "BelegteBetten": null,
-        "Inzidenz": 274.255540788103,
+        "Inzidenz": null,
         "Datum_neu": 1662681600000,
         "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 241.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35128,7 +35128,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.61,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.09.2022"
@@ -35148,12 +35148,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 90,
         "BelegteBetten": null,
-        "Inzidenz": 275.333165702791,
+        "Inzidenz": null,
         "Datum_neu": 1662768000000,
         "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 238.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35166,7 +35166,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.93,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.09.2022"
@@ -35186,12 +35186,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 268.687812062215,
+        "Inzidenz": null,
         "Datum_neu": 1662854400000,
         "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 219.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35204,7 +35204,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.91,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.09.2022"
@@ -35242,7 +35242,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 5.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.09.2022"
@@ -35264,7 +35264,7 @@
         "BelegteBetten": null,
         "Inzidenz": 269.406228672007,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 380,
+        "F\u00e4lle_Meldedatum": 382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 213.8,
@@ -35280,7 +35280,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.91,
+        "H_Inzidenz": 5.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.09.2022"
@@ -35302,7 +35302,7 @@
         "BelegteBetten": null,
         "Inzidenz": 288.264664679047,
         "Datum_neu": 1663113600000,
-        "F\u00e4lle_Meldedatum": 278,
+        "F\u00e4lle_Meldedatum": 283,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 245.2,
@@ -35318,7 +35318,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.44,
+        "H_Inzidenz": 4.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.09.2022"
@@ -35329,26 +35329,26 @@
         "Datum": "15.09.2022",
         "Fallzahl": 249601,
         "ObjectId": 923,
-        "Sterbefall": 1767,
-        "Genesungsfall": 244874,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6360,
-        "Zuwachs_Fallzahl": 241,
-        "Zuwachs_Sterbefall": 9,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 240,
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1663200000000,
-        "F\u00e4lle_Meldedatum": 319,
-        "Zeitraum": "08.09.2022 - 14.09.2022",
+        "F\u00e4lle_Meldedatum": 335,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 251.5,
-        "Fallzahl_aktiv": 2960,
-        "Krh_N_belegt": 441,
-        "Krh_I_belegt": 39,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -8,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -35356,9 +35356,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.07,
-        "H_Zeitraum": "08.09.2022 - 14.09.2022",
-        "H_Datum": "13.09.2022",
+        "H_Inzidenz": 4.49,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "14.09.2022"
       }
     },
@@ -35367,26 +35367,140 @@
         "Datum": "16.09.2022",
         "Fallzahl": 249956,
         "ObjectId": 924,
-        "Sterbefall": 1773,
-        "Genesungsfall": 245116,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6362,
-        "Zuwachs_Fallzahl": 355,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 242,
         "BelegteBetten": null,
-        "Inzidenz": 305.506663314056,
+        "Inzidenz": 309.63755882036,
         "Datum_neu": 1663286400000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "09.09.2022 - 15.09.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 244,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 269.7,
-        "Fallzahl_aktiv": 3067,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "15.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.09.2022",
+        "Fallzahl": 250288,
+        "ObjectId": 925,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 113,
+        "BelegteBetten": null,
+        "Inzidenz": 312.870433564424,
+        "Datum_neu": 1663372800000,
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 272.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "16.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.09.2022",
+        "Fallzahl": 250319,
+        "ObjectId": 926,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 47,
+        "BelegteBetten": null,
+        "Inzidenz": 308.200725600776,
+        "Datum_neu": 1663459200000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 255.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.55,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "17.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.09.2022",
+        "Fallzahl": 250341,
+        "ObjectId": 927,
+        "Sterbefall": 1773,
+        "Genesungsfall": 245608,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6370,
+        "Zuwachs_Fallzahl": 385,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 332,
+        "BelegteBetten": null,
+        "Inzidenz": 305.506663314056,
+        "Datum_neu": 1663545600000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "12.09.2022 - 18.09.2022",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 247,
+        "Fallzahl_aktiv": 2960,
         "Krh_N_belegt": 441,
         "Krh_I_belegt": 39,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 107,
+        "Fallzahl_aktiv_Zuwachs": 53,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -35394,10 +35508,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.75,
-        "H_Zeitraum": "09.09.2022 - 15.09.2022",
+        "H_Inzidenz": 3.45,
+        "H_Zeitraum": "12.09.2022 - 18.09.2022",
         "H_Datum": "13.09.2022",
-        "Datum_Bett": "15.09.2022"
+        "Datum_Bett": "18.09.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
