### PR TITLE
New data set: 2022-09-20T100203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-19T100703Z.json
+pjson/2022-09-20T100203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-19T100703Z.json pjson/2022-09-20T100203Z.json```:
```
--- pjson/2022-09-19T100703Z.json	2022-09-19 10:07:04.271723525 +0000
+++ pjson/2022-09-20T100203Z.json	2022-09-20 10:02:04.283002908 +0000
@@ -35074,7 +35074,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662595200000,
-        "F\u00e4lle_Meldedatum": 247,
+        "F\u00e4lle_Meldedatum": 248,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -35188,7 +35188,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662854400000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -35226,10 +35226,10 @@
         "BelegteBetten": null,
         "Inzidenz": 264.556916555911,
         "Datum_neu": 1662940800000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 210.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35242,7 +35242,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.29,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.09.2022"
@@ -35280,7 +35280,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.05,
+        "H_Inzidenz": 5.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.09.2022"
@@ -35318,7 +35318,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.66,
+        "H_Inzidenz": 4.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.09.2022"
@@ -35340,7 +35340,7 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1663200000000,
-        "F\u00e4lle_Meldedatum": 335,
+        "F\u00e4lle_Meldedatum": 340,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 251.5,
@@ -35356,7 +35356,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.49,
+        "H_Inzidenz": 4.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.09.2022"
@@ -35374,11 +35374,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 242,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": 309.63755882036,
         "Datum_neu": 1663286400000,
-        "F\u00e4lle_Meldedatum": 244,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 269.7,
@@ -35394,7 +35394,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.41,
+        "H_Inzidenz": 4.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.09.2022"
@@ -35412,11 +35412,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 113,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": 312.870433564424,
         "Datum_neu": 1663372800000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 272.1,
@@ -35432,7 +35432,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.7,
+        "H_Inzidenz": 4.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.09.2022"
@@ -35450,13 +35450,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 47,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": 308.200725600776,
         "Datum_neu": 1663459200000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 255.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35470,7 +35470,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.55,
+        "H_Inzidenz": 4.04,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.09.2022"
@@ -35483,7 +35483,7 @@
         "ObjectId": 927,
         "Sterbefall": 1773,
         "Genesungsfall": 245608,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6370,
         "Zuwachs_Fallzahl": 385,
         "Zuwachs_Sterbefall": 0,
@@ -35492,15 +35492,53 @@
         "BelegteBetten": null,
         "Inzidenz": 305.506663314056,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "12.09.2022 - 18.09.2022",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 339,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 247,
         "Fallzahl_aktiv": 2960,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 53,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.97,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.09.2022",
+        "Fallzahl": 250767,
+        "ObjectId": 928,
+        "Sterbefall": 1773,
+        "Genesungsfall": 245898,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6380,
+        "Zuwachs_Fallzahl": 426,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 290,
+        "BelegteBetten": null,
+        "Inzidenz": 310.5355795826,
+        "Datum_neu": 1663632000000,
+        "F\u00e4lle_Meldedatum": 62,
+        "Zeitraum": "13.09.2022 - 19.09.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 249.7,
+        "Fallzahl_aktiv": 3096,
         "Krh_N_belegt": 441,
         "Krh_I_belegt": 39,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 53,
+        "Fallzahl_aktiv_Zuwachs": 136,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -35508,10 +35546,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.45,
-        "H_Zeitraum": "12.09.2022 - 18.09.2022",
+        "H_Inzidenz": 2.32,
+        "H_Zeitraum": "13.09.2022 - 19.09.2022",
         "H_Datum": "13.09.2022",
-        "Datum_Bett": "18.09.2022"
+        "Datum_Bett": "19.09.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
