### PR TITLE
New data set: 2022-09-21T101004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-20T100203Z.json
+pjson/2022-09-21T101004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-20T100203Z.json pjson/2022-09-21T101004Z.json```:
```
--- pjson/2022-09-20T100203Z.json	2022-09-20 10:02:04.283002908 +0000
+++ pjson/2022-09-21T101004Z.json	2022-09-21 10:10:04.587759724 +0000
@@ -34386,7 +34386,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 100,
+        "Zuwachs_Genesung": 95,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661040000000,
@@ -34652,7 +34652,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 82,
+        "Zuwachs_Genesung": 81,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661644800000,
@@ -34728,7 +34728,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 415,
+        "Zuwachs_Genesung": 414,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661817600000,
@@ -34766,7 +34766,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 293,
+        "Zuwachs_Genesung": 291,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661904000000,
@@ -34842,7 +34842,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 245,
+        "Zuwachs_Genesung": 244,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662076800000,
@@ -34956,7 +34956,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 386,
+        "Zuwachs_Genesung": 385,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662336000000,
@@ -34994,7 +34994,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 311,
+        "Zuwachs_Genesung": 309,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662422400000,
@@ -35032,7 +35032,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 286,
+        "Zuwachs_Genesung": 284,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662508800000,
@@ -35070,7 +35070,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 279,
+        "Zuwachs_Genesung": 286,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662595200000,
@@ -35108,7 +35108,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 263,
+        "Zuwachs_Genesung": 259,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662681600000,
@@ -35184,11 +35184,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 43,
+        "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662854400000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -35224,9 +35224,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 348,
         "BelegteBetten": null,
-        "Inzidenz": 264.556916555911,
+        "Inzidenz": null,
         "Datum_neu": 1662940800000,
-        "F\u00e4lle_Meldedatum": 356,
+        "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -35260,11 +35260,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 314,
+        "Zuwachs_Genesung": 318,
         "BelegteBetten": null,
         "Inzidenz": 269.406228672007,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 382,
+        "F\u00e4lle_Meldedatum": 383,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 213.8,
@@ -35280,7 +35280,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.15,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.09.2022"
@@ -35318,7 +35318,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.76,
+        "H_Inzidenz": 4.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.09.2022"
@@ -35336,11 +35336,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 240,
+        "Zuwachs_Genesung": 249,
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1663200000000,
-        "F\u00e4lle_Meldedatum": 340,
+        "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 251.5,
@@ -35356,7 +35356,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": 4.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.09.2022"
@@ -35374,11 +35374,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 0,
+        "Zuwachs_Genesung": 246,
         "BelegteBetten": null,
         "Inzidenz": 309.63755882036,
         "Datum_neu": 1663286400000,
-        "F\u00e4lle_Meldedatum": 249,
+        "F\u00e4lle_Meldedatum": 253,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 269.7,
@@ -35394,7 +35394,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": 4.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.09.2022"
@@ -35412,11 +35412,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 0,
+        "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
         "Inzidenz": 312.870433564424,
         "Datum_neu": 1663372800000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 272.1,
@@ -35432,7 +35432,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.12,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.09.2022"
@@ -35450,11 +35450,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 0,
+        "Zuwachs_Genesung": 47,
         "BelegteBetten": null,
         "Inzidenz": 308.200725600776,
         "Datum_neu": 1663459200000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 255.3,
@@ -35470,7 +35470,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.04,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.09.2022"
@@ -35481,34 +35481,34 @@
         "Datum": "19.09.2022",
         "Fallzahl": 250341,
         "ObjectId": 927,
-        "Sterbefall": 1773,
-        "Genesungsfall": 245608,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6370,
-        "Zuwachs_Fallzahl": 385,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
         "Inzidenz": 305.506663314056,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 339,
+        "F\u00e4lle_Meldedatum": 376,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 247,
-        "Fallzahl_aktiv": 2960,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 53,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.97,
+        "H_Inzidenz": 4.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.09.2022"
@@ -35519,38 +35519,76 @@
         "Datum": "20.09.2022",
         "Fallzahl": 250767,
         "ObjectId": 928,
-        "Sterbefall": 1773,
-        "Genesungsfall": 245898,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6380,
-        "Zuwachs_Fallzahl": 426,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 290,
         "BelegteBetten": null,
         "Inzidenz": 310.5355795826,
         "Datum_neu": 1663632000000,
-        "F\u00e4lle_Meldedatum": 62,
-        "Zeitraum": "13.09.2022 - 19.09.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 334,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 249.7,
-        "Fallzahl_aktiv": 3096,
-        "Krh_N_belegt": 441,
-        "Krh_I_belegt": 39,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 136,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.32,
-        "H_Zeitraum": "13.09.2022 - 19.09.2022",
-        "H_Datum": "13.09.2022",
+        "H_Inzidenz": 3.39,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.09.2022",
+        "Fallzahl": 251138,
+        "ObjectId": 929,
+        "Sterbefall": 1773,
+        "Genesungsfall": 246165,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6384,
+        "Zuwachs_Fallzahl": 371,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 267,
+        "BelegteBetten": null,
+        "Inzidenz": 311.253996192392,
+        "Datum_neu": 1663718400000,
+        "F\u00e4lle_Meldedatum": 44,
+        "Zeitraum": "14.09.2022 - 20.09.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 260.3,
+        "Fallzahl_aktiv": 3200,
+        "Krh_N_belegt": 493,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 104,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.07,
+        "H_Zeitraum": "14.09.2022 - 20.09.2022",
+        "H_Datum": "20.09.2022",
+        "Datum_Bett": "20.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
