### PR TITLE
New data set: 2022-09-22T100803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-21T101004Z.json
+pjson/2022-09-22T100803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-21T101004Z.json pjson/2022-09-22T100803Z.json```:
```
--- pjson/2022-09-21T101004Z.json	2022-09-21 10:10:04.587759724 +0000
+++ pjson/2022-09-22T100803Z.json	2022-09-22 10:08:04.267987391 +0000
@@ -33366,7 +33366,7 @@
         "Datum_neu": 1658707200000,
         "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33404,7 +33404,7 @@
         "Datum_neu": 1658793600000,
         "F\u00e4lle_Meldedatum": 675,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34516,7 +34516,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -34630,7 +34630,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -35267,7 +35267,7 @@
         "F\u00e4lle_Meldedatum": 383,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 213.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35305,7 +35305,7 @@
         "F\u00e4lle_Meldedatum": 283,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 245.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35318,7 +35318,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.09.2022"
@@ -35356,7 +35356,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.92,
+        "H_Inzidenz": 5.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.09.2022"
@@ -35394,7 +35394,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.92,
+        "H_Inzidenz": 5.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.09.2022"
@@ -35416,7 +35416,7 @@
         "BelegteBetten": null,
         "Inzidenz": 312.870433564424,
         "Datum_neu": 1663372800000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 272.1,
@@ -35432,7 +35432,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 5.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.09.2022"
@@ -35470,7 +35470,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 5.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.09.2022"
@@ -35492,9 +35492,9 @@
         "BelegteBetten": null,
         "Inzidenz": 305.506663314056,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 376,
+        "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 247,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35508,7 +35508,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": 5.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.09.2022"
@@ -35530,9 +35530,9 @@
         "BelegteBetten": null,
         "Inzidenz": 310.5355795826,
         "Datum_neu": 1663632000000,
-        "F\u00e4lle_Meldedatum": 334,
+        "F\u00e4lle_Meldedatum": 359,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 249.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35546,7 +35546,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.39,
+        "H_Inzidenz": 4.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.09.2022"
@@ -35559,7 +35559,7 @@
         "ObjectId": 929,
         "Sterbefall": 1773,
         "Genesungsfall": 246165,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6384,
         "Zuwachs_Fallzahl": 371,
         "Zuwachs_Sterbefall": 0,
@@ -35568,9 +35568,9 @@
         "BelegteBetten": null,
         "Inzidenz": 311.253996192392,
         "Datum_neu": 1663718400000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": "14.09.2022 - 20.09.2022",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 260.3,
         "Fallzahl_aktiv": 3200,
         "Krh_N_belegt": 493,
@@ -35584,11 +35584,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.07,
+        "H_Inzidenz": 4.72,
         "H_Zeitraum": "14.09.2022 - 20.09.2022",
         "H_Datum": "20.09.2022",
         "Datum_Bett": "20.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.09.2022",
+        "Fallzahl": 251489,
+        "ObjectId": 930,
+        "Sterbefall": 1776,
+        "Genesungsfall": 246407,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6389,
+        "Zuwachs_Fallzahl": 351,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 242,
+        "BelegteBetten": null,
+        "Inzidenz": 320.952620424584,
+        "Datum_neu": 1663804800000,
+        "F\u00e4lle_Meldedatum": 58,
+        "Zeitraum": "15.09.2022 - 21.09.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 277,
+        "Fallzahl_aktiv": 3306,
+        "Krh_N_belegt": 493,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 106,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.01,
+        "H_Zeitraum": "15.09.2022 - 21.09.2022",
+        "H_Datum": "20.09.2022",
+        "Datum_Bett": "21.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
