### PR TITLE
New data set: 2022-09-23T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-22T100803Z.json
+pjson/2022-09-23T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-22T100803Z.json pjson/2022-09-23T101103Z.json```:
```
--- pjson/2022-09-22T100803Z.json	2022-09-22 10:08:04.267987391 +0000
+++ pjson/2022-09-23T101103Z.json	2022-09-23 10:11:04.258924241 +0000
@@ -35262,7 +35262,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 318,
         "BelegteBetten": null,
-        "Inzidenz": 269.406228672007,
+        "Inzidenz": null,
         "Datum_neu": 1663027200000,
         "F\u00e4lle_Meldedatum": 383,
         "Zeitraum": null,
@@ -35300,7 +35300,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 226,
         "BelegteBetten": null,
-        "Inzidenz": 288.264664679047,
+        "Inzidenz": null,
         "Datum_neu": 1663113600000,
         "F\u00e4lle_Meldedatum": 283,
         "Zeitraum": null,
@@ -35356,7 +35356,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.14,
+        "H_Inzidenz": 5.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.09.2022"
@@ -35378,7 +35378,7 @@
         "BelegteBetten": null,
         "Inzidenz": 309.63755882036,
         "Datum_neu": 1663286400000,
-        "F\u00e4lle_Meldedatum": 253,
+        "F\u00e4lle_Meldedatum": 254,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 269.7,
@@ -35394,7 +35394,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.34,
+        "H_Inzidenz": 5.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.09.2022"
@@ -35416,7 +35416,7 @@
         "BelegteBetten": null,
         "Inzidenz": 312.870433564424,
         "Datum_neu": 1663372800000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 272.1,
@@ -35432,7 +35432,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.24,
+        "H_Inzidenz": 5.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.09.2022"
@@ -35454,7 +35454,7 @@
         "BelegteBetten": null,
         "Inzidenz": 308.200725600776,
         "Datum_neu": 1663459200000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 255.3,
@@ -35470,7 +35470,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
+        "H_Inzidenz": 5.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.09.2022"
@@ -35492,7 +35492,7 @@
         "BelegteBetten": null,
         "Inzidenz": 305.506663314056,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 380,
+        "F\u00e4lle_Meldedatum": 379,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 247,
@@ -35508,7 +35508,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.52,
+        "H_Inzidenz": 5.91,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.09.2022"
@@ -35530,7 +35530,7 @@
         "BelegteBetten": null,
         "Inzidenz": 310.5355795826,
         "Datum_neu": 1663632000000,
-        "F\u00e4lle_Meldedatum": 359,
+        "F\u00e4lle_Meldedatum": 362,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 249.7,
@@ -35546,7 +35546,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.65,
+        "H_Inzidenz": 5.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.09.2022"
@@ -35557,36 +35557,36 @@
         "Datum": "21.09.2022",
         "Fallzahl": 251138,
         "ObjectId": 929,
-        "Sterbefall": 1773,
-        "Genesungsfall": 246165,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6384,
-        "Zuwachs_Fallzahl": 371,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 267,
         "BelegteBetten": null,
         "Inzidenz": 311.253996192392,
         "Datum_neu": 1663718400000,
-        "F\u00e4lle_Meldedatum": 307,
-        "Zeitraum": "14.09.2022 - 20.09.2022",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 322,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 260.3,
-        "Fallzahl_aktiv": 3200,
-        "Krh_N_belegt": 493,
-        "Krh_I_belegt": 48,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 104,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.72,
-        "H_Zeitraum": "14.09.2022 - 20.09.2022",
-        "H_Datum": "20.09.2022",
+        "H_Inzidenz": 6.31,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.09.2022"
       }
     },
@@ -35595,26 +35595,64 @@
         "Datum": "22.09.2022",
         "Fallzahl": 251489,
         "ObjectId": 930,
-        "Sterbefall": 1776,
-        "Genesungsfall": 246407,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6389,
-        "Zuwachs_Fallzahl": 351,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 242,
         "BelegteBetten": null,
         "Inzidenz": 320.952620424584,
         "Datum_neu": 1663804800000,
-        "F\u00e4lle_Meldedatum": 58,
-        "Zeitraum": "15.09.2022 - 21.09.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 257,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 277,
-        "Fallzahl_aktiv": 3306,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.53,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.09.2022",
+        "Fallzahl": 251749,
+        "ObjectId": 931,
+        "Sterbefall": 1776,
+        "Genesungsfall": 246631,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6398,
+        "Zuwachs_Fallzahl": 260,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 224,
+        "BelegteBetten": null,
+        "Inzidenz": 309.63755882036,
+        "Datum_neu": 1663891200000,
+        "F\u00e4lle_Meldedatum": 40,
+        "Zeitraum": "16.09.2022 - 22.09.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 274.8,
+        "Fallzahl_aktiv": 3342,
         "Krh_N_belegt": 493,
         "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 106,
+        "Fallzahl_aktiv_Zuwachs": 36,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -35622,10 +35660,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.01,
-        "H_Zeitraum": "15.09.2022 - 21.09.2022",
+        "H_Inzidenz": 5.79,
+        "H_Zeitraum": "16.09.2022 - 22.09.2022",
         "H_Datum": "20.09.2022",
-        "Datum_Bett": "21.09.2022"
+        "Datum_Bett": "22.09.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
