### PR TITLE
New data set: 2022-09-26T100604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-23T101103Z.json
+pjson/2022-09-26T100604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-23T101103Z.json pjson/2022-09-26T100604Z.json```:
```
--- pjson/2022-09-23T101103Z.json	2022-09-23 10:11:04.258924241 +0000
+++ pjson/2022-09-26T100604Z.json	2022-09-26 10:06:04.786122754 +0000
@@ -35338,12 +35338,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 249,
         "BelegteBetten": null,
-        "Inzidenz": 282.696935953159,
+        "Inzidenz": null,
         "Datum_neu": 1663200000000,
         "F\u00e4lle_Meldedatum": 341,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 251.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35356,7 +35356,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.91,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.09.2022"
@@ -35376,12 +35376,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 246,
         "BelegteBetten": null,
-        "Inzidenz": 309.63755882036,
+        "Inzidenz": null,
         "Datum_neu": 1663286400000,
         "F\u00e4lle_Meldedatum": 254,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 269.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35394,7 +35394,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.54,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.09.2022"
@@ -35414,12 +35414,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
-        "Inzidenz": 312.870433564424,
+        "Inzidenz": null,
         "Datum_neu": 1663372800000,
         "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 272.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35432,7 +35432,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.57,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.09.2022"
@@ -35492,7 +35492,7 @@
         "BelegteBetten": null,
         "Inzidenz": 305.506663314056,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 379,
+        "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 247,
@@ -35508,7 +35508,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.91,
+        "H_Inzidenz": 6.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.09.2022"
@@ -35546,7 +35546,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.76,
+        "H_Inzidenz": 5.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.09.2022"
@@ -35557,34 +35557,34 @@
         "Datum": "21.09.2022",
         "Fallzahl": 251138,
         "ObjectId": 929,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1773,
+        "Genesungsfall": 246165,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 6384,
+        "Zuwachs_Fallzahl": 371,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
         "Zuwachs_Genesung": 267,
         "BelegteBetten": null,
         "Inzidenz": 311.253996192392,
         "Datum_neu": 1663718400000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 260.3,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 3200,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 104,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.31,
+        "H_Inzidenz": 6.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.09.2022"
@@ -35595,34 +35595,34 @@
         "Datum": "22.09.2022",
         "Fallzahl": 251489,
         "ObjectId": 930,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1776,
+        "Genesungsfall": 246407,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 6389,
+        "Zuwachs_Fallzahl": 351,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 5,
         "Zuwachs_Genesung": 242,
         "BelegteBetten": null,
         "Inzidenz": 320.952620424584,
         "Datum_neu": 1663804800000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 284,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 277,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 3306,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 106,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.53,
+        "H_Inzidenz": 6.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.09.2022"
@@ -35631,26 +35631,26 @@
     {
       "attributes": {
         "Datum": "23.09.2022",
-        "Fallzahl": 251749,
+        "Fallzahl": 252049,
         "ObjectId": 931,
         "Sterbefall": 1776,
         "Genesungsfall": 246631,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6398,
         "Zuwachs_Fallzahl": 260,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 9,
         "Zuwachs_Genesung": 224,
         "BelegteBetten": null,
-        "Inzidenz": 309.63755882036,
+        "Inzidenz": 315.0256833938,
         "Datum_neu": 1663891200000,
-        "F\u00e4lle_Meldedatum": 40,
-        "Zeitraum": "16.09.2022 - 22.09.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 310,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 274.8,
-        "Fallzahl_aktiv": 3342,
-        "Krh_N_belegt": 493,
-        "Krh_I_belegt": 48,
+        "Fallzahl_aktiv": 3642,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 36,
         "Krh_I": null,
@@ -35660,11 +35660,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
-        "H_Zeitraum": "16.09.2022 - 22.09.2022",
-        "H_Datum": "20.09.2022",
+        "H_Inzidenz": 6.68,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.09.2022",
+        "Fallzahl": 252162,
+        "ObjectId": 932,
+        "Sterbefall": null,
+        "Genesungsfall": 246729,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 98,
+        "BelegteBetten": null,
+        "Inzidenz": 325.083515930888,
+        "Datum_neu": 1663977600000,
+        "F\u00e4lle_Meldedatum": 113,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 287.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.13,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "23.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.09.2022",
+        "Fallzahl": 252193,
+        "ObjectId": 933,
+        "Sterbefall": null,
+        "Genesungsfall": 246778,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 49,
+        "BelegteBetten": null,
+        "Inzidenz": 328.136786522504,
+        "Datum_neu": 1664064000000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 270.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.89,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "24.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.09.2022",
+        "Fallzahl": 252207,
+        "ObjectId": 934,
+        "Sterbefall": 1776,
+        "Genesungsfall": 247125,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6415,
+        "Zuwachs_Fallzahl": 158,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 347,
+        "BelegteBetten": null,
+        "Inzidenz": 324.0058910162,
+        "Datum_neu": 1664150400000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "19.09.2022 - 25.09.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 260.9,
+        "Fallzahl_aktiv": 3306,
+        "Krh_N_belegt": 493,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -189,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.52,
+        "H_Zeitraum": "19.09.2022 - 25.09.2022",
+        "H_Datum": "20.09.2022",
+        "Datum_Bett": "25.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
