### PR TITLE
New data set: 2022-09-27T095804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-26T100604Z.json
+pjson/2022-09-27T095804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-26T100604Z.json pjson/2022-09-27T095804Z.json```:
```
--- pjson/2022-09-26T100604Z.json	2022-09-26 10:06:04.786122754 +0000
+++ pjson/2022-09-27T095804Z.json	2022-09-27 09:58:05.027143517 +0000
@@ -34846,7 +34846,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662076800000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -34998,7 +34998,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662422400000,
-        "F\u00e4lle_Meldedatum": 298,
+        "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -35074,7 +35074,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662595200000,
-        "F\u00e4lle_Meldedatum": 248,
+        "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -35188,7 +35188,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662854400000,
-        "F\u00e4lle_Meldedatum": 48,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -35226,7 +35226,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662940800000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -35264,9 +35264,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 383,
+        "F\u00e4lle_Meldedatum": 386,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35340,7 +35340,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663200000000,
-        "F\u00e4lle_Meldedatum": 341,
+        "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -35380,7 +35380,7 @@
         "Datum_neu": 1663286400000,
         "F\u00e4lle_Meldedatum": 254,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35457,7 +35457,7 @@
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 255.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35470,7 +35470,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.64,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.09.2022"
@@ -35508,7 +35508,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.08,
+        "H_Inzidenz": 6.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.09.2022"
@@ -35530,7 +35530,7 @@
         "BelegteBetten": null,
         "Inzidenz": 310.5355795826,
         "Datum_neu": 1663632000000,
-        "F\u00e4lle_Meldedatum": 362,
+        "F\u00e4lle_Meldedatum": 364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 249.7,
@@ -35546,7 +35546,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.96,
+        "H_Inzidenz": 6.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.09.2022"
@@ -35557,13 +35557,13 @@
         "Datum": "21.09.2022",
         "Fallzahl": 251138,
         "ObjectId": 929,
-        "Sterbefall": 1773,
-        "Genesungsfall": 246165,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6384,
-        "Zuwachs_Fallzahl": 371,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 267,
         "BelegteBetten": null,
         "Inzidenz": 311.253996192392,
@@ -35572,19 +35572,19 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 260.3,
-        "Fallzahl_aktiv": 3200,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 104,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.68,
+        "H_Inzidenz": 7.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.09.2022"
@@ -35595,34 +35595,34 @@
         "Datum": "22.09.2022",
         "Fallzahl": 251489,
         "ObjectId": 930,
-        "Sterbefall": 1776,
-        "Genesungsfall": 246407,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6389,
-        "Zuwachs_Fallzahl": 351,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 242,
         "BelegteBetten": null,
         "Inzidenz": 320.952620424584,
         "Datum_neu": 1663804800000,
-        "F\u00e4lle_Meldedatum": 284,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 277,
-        "Fallzahl_aktiv": 3306,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 106,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
+        "H_Inzidenz": 7.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.09.2022"
@@ -35633,34 +35633,34 @@
         "Datum": "23.09.2022",
         "Fallzahl": 252049,
         "ObjectId": 931,
-        "Sterbefall": 1776,
-        "Genesungsfall": 246631,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6398,
-        "Zuwachs_Fallzahl": 260,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 224,
         "BelegteBetten": null,
         "Inzidenz": 315.0256833938,
         "Datum_neu": 1663891200000,
-        "F\u00e4lle_Meldedatum": 310,
+        "F\u00e4lle_Meldedatum": 318,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 274.8,
-        "Fallzahl_aktiv": 3642,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 36,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.68,
+        "H_Inzidenz": 8.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.09.2022"
@@ -35672,7 +35672,7 @@
         "Fallzahl": 252162,
         "ObjectId": 932,
         "Sterbefall": null,
-        "Genesungsfall": 246729,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -35682,7 +35682,7 @@
         "BelegteBetten": null,
         "Inzidenz": 325.083515930888,
         "Datum_neu": 1663977600000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 287.9,
@@ -35694,11 +35694,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.13,
+        "H_Inzidenz": 8.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.09.2022"
@@ -35710,7 +35710,7 @@
         "Fallzahl": 252193,
         "ObjectId": 933,
         "Sterbefall": null,
-        "Genesungsfall": 246778,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -35720,7 +35720,7 @@
         "BelegteBetten": null,
         "Inzidenz": 328.136786522504,
         "Datum_neu": 1664064000000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 270.6,
@@ -35736,7 +35736,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.89,
+        "H_Inzidenz": 8.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.09.2022"
@@ -35749,7 +35749,7 @@
         "ObjectId": 934,
         "Sterbefall": 1776,
         "Genesungsfall": 247125,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6415,
         "Zuwachs_Fallzahl": 158,
         "Zuwachs_Sterbefall": 0,
@@ -35758,9 +35758,9 @@
         "BelegteBetten": null,
         "Inzidenz": 324.0058910162,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 501,
         "Zeitraum": "19.09.2022 - 25.09.2022",
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 260.9,
         "Fallzahl_aktiv": 3306,
         "Krh_N_belegt": 493,
@@ -35774,11 +35774,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.52,
+        "H_Inzidenz": 8.48,
         "H_Zeitraum": "19.09.2022 - 25.09.2022",
         "H_Datum": "20.09.2022",
         "Datum_Bett": "25.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.09.2022",
+        "Fallzahl": 252801,
+        "ObjectId": 935,
+        "Sterbefall": 1778,
+        "Genesungsfall": 247506,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6435,
+        "Zuwachs_Fallzahl": 594,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 381,
+        "BelegteBetten": null,
+        "Inzidenz": 356.873450914185,
+        "Datum_neu": 1664236800000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "20.09.2022 - 26.09.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 269,
+        "Fallzahl_aktiv": 3517,
+        "Krh_N_belegt": 493,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 211,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.41,
+        "H_Zeitraum": "20.09.2022 - 26.09.2022",
+        "H_Datum": "20.09.2022",
+        "Datum_Bett": "26.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
