### PR TITLE
New data set: 2022-09-28T100103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-27T095804Z.json
+pjson/2022-09-28T100103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-27T095804Z.json pjson/2022-09-28T100103Z.json```:
```
--- pjson/2022-09-27T095804Z.json	2022-09-27 09:58:05.027143517 +0000
+++ pjson/2022-09-28T100103Z.json	2022-09-28 10:01:04.286812570 +0000
@@ -35492,10 +35492,10 @@
         "BelegteBetten": null,
         "Inzidenz": 305.506663314056,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 380,
+        "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 247,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35508,7 +35508,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.65,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.09.2022"
@@ -35532,7 +35532,7 @@
         "Datum_neu": 1663632000000,
         "F\u00e4lle_Meldedatum": 364,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 249.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35546,7 +35546,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.23,
+        "H_Inzidenz": 6.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.09.2022"
@@ -35584,7 +35584,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.05,
+        "H_Inzidenz": 7.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.09.2022"
@@ -35622,7 +35622,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
+        "H_Inzidenz": 8.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.09.2022"
@@ -35644,7 +35644,7 @@
         "BelegteBetten": null,
         "Inzidenz": 315.0256833938,
         "Datum_neu": 1663891200000,
-        "F\u00e4lle_Meldedatum": 318,
+        "F\u00e4lle_Meldedatum": 323,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 274.8,
@@ -35660,7 +35660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.11,
+        "H_Inzidenz": 8.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.09.2022"
@@ -35682,9 +35682,9 @@
         "BelegteBetten": null,
         "Inzidenz": 325.083515930888,
         "Datum_neu": 1663977600000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 287.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35698,7 +35698,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.41,
+        "H_Inzidenz": 9.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.09.2022"
@@ -35720,7 +35720,7 @@
         "BelegteBetten": null,
         "Inzidenz": 328.136786522504,
         "Datum_neu": 1664064000000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 270.6,
@@ -35736,7 +35736,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.76,
+        "H_Inzidenz": 9.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.09.2022"
@@ -35747,26 +35747,26 @@
         "Datum": "26.09.2022",
         "Fallzahl": 252207,
         "ObjectId": 934,
-        "Sterbefall": 1776,
-        "Genesungsfall": 247125,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6415,
-        "Zuwachs_Fallzahl": 158,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 347,
         "BelegteBetten": null,
         "Inzidenz": 324.0058910162,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 501,
-        "Zeitraum": "19.09.2022 - 25.09.2022",
-        "Hosp_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 528,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 260.9,
-        "Fallzahl_aktiv": 3306,
-        "Krh_N_belegt": 493,
-        "Krh_I_belegt": 48,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -189,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -35774,9 +35774,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.48,
-        "H_Zeitraum": "19.09.2022 - 25.09.2022",
-        "H_Datum": "20.09.2022",
+        "H_Inzidenz": 9.99,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.09.2022"
       }
     },
@@ -35787,7 +35787,7 @@
         "ObjectId": 935,
         "Sterbefall": 1778,
         "Genesungsfall": 247506,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6435,
         "Zuwachs_Fallzahl": 594,
         "Zuwachs_Sterbefall": 2,
@@ -35796,9 +35796,9 @@
         "BelegteBetten": null,
         "Inzidenz": 356.873450914185,
         "Datum_neu": 1664236800000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 544,
         "Zeitraum": "20.09.2022 - 26.09.2022",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 269,
         "Fallzahl_aktiv": 3517,
         "Krh_N_belegt": 493,
@@ -35812,11 +35812,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.41,
+        "H_Inzidenz": 9.4,
         "H_Zeitraum": "20.09.2022 - 26.09.2022",
         "H_Datum": "20.09.2022",
         "Datum_Bett": "26.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.09.2022",
+        "Fallzahl": 253420,
+        "ObjectId": 936,
+        "Sterbefall": 1778,
+        "Genesungsfall": 247795,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6440,
+        "Zuwachs_Fallzahl": 619,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 289,
+        "BelegteBetten": null,
+        "Inzidenz": 396.92517691009,
+        "Datum_neu": 1664323200000,
+        "F\u00e4lle_Meldedatum": 76,
+        "Zeitraum": "21.09.2022 - 27.09.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 312.1,
+        "Fallzahl_aktiv": 3847,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 33,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 330,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.14,
+        "H_Zeitraum": "21.09.2022 - 27.09.2022",
+        "H_Datum": "27.09.2022",
+        "Datum_Bett": "27.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
