### PR TITLE
New data set: 2022-09-29T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-28T100103Z.json
+pjson/2022-09-29T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-28T100103Z.json pjson/2022-09-29T100403Z.json```:
```
--- pjson/2022-09-28T100103Z.json	2022-09-28 10:01:04.286812570 +0000
+++ pjson/2022-09-29T100403Z.json	2022-09-29 10:04:04.346463252 +0000
@@ -34012,7 +34012,7 @@
         "Datum_neu": 1660176000000,
         "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34164,7 +34164,7 @@
         "Datum_neu": 1660521600000,
         "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35452,7 +35452,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 47,
         "BelegteBetten": null,
-        "Inzidenz": 308.200725600776,
+        "Inzidenz": null,
         "Datum_neu": 1663459200000,
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
@@ -35490,7 +35490,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
-        "Inzidenz": 305.506663314056,
+        "Inzidenz": null,
         "Datum_neu": 1663545600000,
         "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
@@ -35528,12 +35528,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 290,
         "BelegteBetten": null,
-        "Inzidenz": 310.5355795826,
+        "Inzidenz": null,
         "Datum_neu": 1663632000000,
         "F\u00e4lle_Meldedatum": 364,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 249.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35546,7 +35546,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.33,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.09.2022"
@@ -35566,12 +35566,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 267,
         "BelegteBetten": null,
-        "Inzidenz": 311.253996192392,
+        "Inzidenz": null,
         "Datum_neu": 1663718400000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 260.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35584,7 +35584,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.3,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.09.2022"
@@ -35622,7 +35622,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.01,
+        "H_Inzidenz": 8.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.09.2022"
@@ -35660,7 +35660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.85,
+        "H_Inzidenz": 9.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.09.2022"
@@ -35682,7 +35682,7 @@
         "BelegteBetten": null,
         "Inzidenz": 325.083515930888,
         "Datum_neu": 1663977600000,
-        "F\u00e4lle_Meldedatum": 144,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 287.9,
@@ -35698,7 +35698,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.45,
+        "H_Inzidenz": 10.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.09.2022"
@@ -35736,7 +35736,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.99,
+        "H_Inzidenz": 10.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.09.2022"
@@ -35758,9 +35758,9 @@
         "BelegteBetten": null,
         "Inzidenz": 324.0058910162,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 534,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 260.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35774,7 +35774,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.99,
+        "H_Inzidenz": 10.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.09.2022"
@@ -35785,36 +35785,36 @@
         "Datum": "27.09.2022",
         "Fallzahl": 252801,
         "ObjectId": 935,
-        "Sterbefall": 1778,
-        "Genesungsfall": 247506,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6435,
-        "Zuwachs_Fallzahl": 594,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 381,
         "BelegteBetten": null,
         "Inzidenz": 356.873450914185,
         "Datum_neu": 1664236800000,
-        "F\u00e4lle_Meldedatum": 544,
-        "Zeitraum": "20.09.2022 - 26.09.2022",
+        "F\u00e4lle_Meldedatum": 579,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 269,
-        "Fallzahl_aktiv": 3517,
-        "Krh_N_belegt": 493,
-        "Krh_I_belegt": 48,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 211,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.4,
-        "H_Zeitraum": "20.09.2022 - 26.09.2022",
-        "H_Datum": "20.09.2022",
+        "H_Inzidenz": 10.64,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.09.2022"
       }
     },
@@ -35825,7 +35825,7 @@
         "ObjectId": 936,
         "Sterbefall": 1778,
         "Genesungsfall": 247795,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6440,
         "Zuwachs_Fallzahl": 619,
         "Zuwachs_Sterbefall": 0,
@@ -35834,13 +35834,13 @@
         "BelegteBetten": null,
         "Inzidenz": 396.92517691009,
         "Datum_neu": 1664323200000,
-        "F\u00e4lle_Meldedatum": 76,
-        "Zeitraum": "21.09.2022 - 27.09.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 477,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 312.1,
         "Fallzahl_aktiv": 3847,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 33,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 330,
         "Krh_I": null,
@@ -35850,11 +35850,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.14,
-        "H_Zeitraum": "21.09.2022 - 27.09.2022",
-        "H_Datum": "27.09.2022",
+        "H_Inzidenz": 9.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.09.2022",
+        "Fallzahl": 253907,
+        "ObjectId": 937,
+        "Sterbefall": 1778,
+        "Genesungsfall": 248125,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6446,
+        "Zuwachs_Fallzahl": 487,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 330,
+        "BelegteBetten": null,
+        "Inzidenz": 431.588778332555,
+        "Datum_neu": 1664409600000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "22.09.2022 - 28.09.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 350,
+        "Fallzahl_aktiv": 4004,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 33,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 157,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.34,
+        "H_Zeitraum": "22.09.2022 - 28.09.2022",
+        "H_Datum": "29.09.2022",
+        "Datum_Bett": "28.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
