### PR TITLE
New data set: 2022-09-30T094604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-29T100403Z.json
+pjson/2022-09-30T094604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-29T100403Z.json pjson/2022-09-30T094604Z.json```:
```
--- pjson/2022-09-29T100403Z.json	2022-09-29 10:04:04.346463252 +0000
+++ pjson/2022-09-30T094604Z.json	2022-09-30 09:46:04.418190330 +0000
@@ -33896,7 +33896,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659916800000,
-        "F\u00e4lle_Meldedatum": 464,
+        "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -33934,7 +33934,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 458,
+        "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -34392,7 +34392,7 @@
         "Datum_neu": 1661040000000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34430,7 +34430,7 @@
         "Datum_neu": 1661126400000,
         "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34848,7 +34848,7 @@
         "Datum_neu": 1662076800000,
         "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35228,7 +35228,7 @@
         "Datum_neu": 1662940800000,
         "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35264,9 +35264,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35342,7 +35342,7 @@
         "Datum_neu": 1663200000000,
         "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35606,10 +35606,10 @@
         "BelegteBetten": null,
         "Inzidenz": 320.952620424584,
         "Datum_neu": 1663804800000,
-        "F\u00e4lle_Meldedatum": 286,
+        "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 277,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35622,7 +35622,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.09.2022"
@@ -35660,7 +35660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.28,
+        "H_Inzidenz": 9.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.09.2022"
@@ -35698,7 +35698,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.02,
+        "H_Inzidenz": 10.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.09.2022"
@@ -35720,7 +35720,7 @@
         "BelegteBetten": null,
         "Inzidenz": 328.136786522504,
         "Datum_neu": 1664064000000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 270.6,
@@ -35736,7 +35736,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.64,
+        "H_Inzidenz": 10.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.09.2022"
@@ -35758,7 +35758,7 @@
         "BelegteBetten": null,
         "Inzidenz": 324.0058910162,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 534,
+        "F\u00e4lle_Meldedatum": 535,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 260.9,
@@ -35774,7 +35774,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.69,
+        "H_Inzidenz": 11.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.09.2022"
@@ -35796,9 +35796,9 @@
         "BelegteBetten": null,
         "Inzidenz": 356.873450914185,
         "Datum_neu": 1664236800000,
-        "F\u00e4lle_Meldedatum": 579,
+        "F\u00e4lle_Meldedatum": 582,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 269,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35812,7 +35812,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.64,
+        "H_Inzidenz": 11.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.09.2022"
@@ -35823,34 +35823,34 @@
         "Datum": "28.09.2022",
         "Fallzahl": 253420,
         "ObjectId": 936,
-        "Sterbefall": 1778,
-        "Genesungsfall": 247795,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6440,
-        "Zuwachs_Fallzahl": 619,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 289,
         "BelegteBetten": null,
         "Inzidenz": 396.92517691009,
         "Datum_neu": 1664323200000,
-        "F\u00e4lle_Meldedatum": 477,
+        "F\u00e4lle_Meldedatum": 513,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 312.1,
-        "Fallzahl_aktiv": 3847,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 330,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.79,
+        "H_Inzidenz": 11.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.09.2022"
@@ -35863,7 +35863,7 @@
         "ObjectId": 937,
         "Sterbefall": 1778,
         "Genesungsfall": 248125,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6446,
         "Zuwachs_Fallzahl": 487,
         "Zuwachs_Sterbefall": 0,
@@ -35872,9 +35872,9 @@
         "BelegteBetten": null,
         "Inzidenz": 431.588778332555,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": "22.09.2022 - 28.09.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 350,
         "Fallzahl_aktiv": 4004,
         "Krh_N_belegt": 634,
@@ -35888,11 +35888,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.34,
+        "H_Inzidenz": 11.38,
         "H_Zeitraum": "22.09.2022 - 28.09.2022",
-        "H_Datum": "29.09.2022",
+        "H_Datum": "27.09.2022",
         "Datum_Bett": "28.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.09.2022",
+        "Fallzahl": 254340,
+        "ObjectId": 938,
+        "Sterbefall": 1778,
+        "Genesungsfall": 248377,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6465,
+        "Zuwachs_Fallzahl": 433,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 252,
+        "BelegteBetten": null,
+        "Inzidenz": 461.223463486476,
+        "Datum_neu": 1664496000000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "23.09.2022 - 29.09.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 401.9,
+        "Fallzahl_aktiv": 4185,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 33,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 181,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.82,
+        "H_Zeitraum": "23.09.2022 - 29.09.2022",
+        "H_Datum": "27.09.2022",
+        "Datum_Bett": "29.09.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
