### PR TITLE
New data set: 2022-10-04T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-09-30T094604Z.json
+pjson/2022-10-04T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-09-30T094604Z.json pjson/2022-10-04T110403Z.json```:
```
--- pjson/2022-09-30T094604Z.json	2022-09-30 09:46:04.418190330 +0000
+++ pjson/2022-10-04T110403Z.json	2022-10-04 11:04:04.116543450 +0000
@@ -34924,7 +34924,7 @@
         "Datum_neu": 1662249600000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34962,7 +34962,7 @@
         "Datum_neu": 1662336000000,
         "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35038,7 +35038,7 @@
         "Datum_neu": 1662508800000,
         "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35266,7 +35266,7 @@
         "Datum_neu": 1663027200000,
         "F\u00e4lle_Meldedatum": 387,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35304,7 +35304,7 @@
         "Datum_neu": 1663113600000,
         "F\u00e4lle_Meldedatum": 283,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35342,7 +35342,7 @@
         "Datum_neu": 1663200000000,
         "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35380,7 +35380,7 @@
         "Datum_neu": 1663286400000,
         "F\u00e4lle_Meldedatum": 254,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35390,7 +35390,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -35418,7 +35418,7 @@
         "Datum_neu": 1663372800000,
         "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35456,7 +35456,7 @@
         "Datum_neu": 1663459200000,
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35494,7 +35494,7 @@
         "Datum_neu": 1663545600000,
         "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35532,7 +35532,7 @@
         "Datum_neu": 1663632000000,
         "F\u00e4lle_Meldedatum": 364,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35604,7 +35604,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 242,
         "BelegteBetten": null,
-        "Inzidenz": 320.952620424584,
+        "Inzidenz": null,
         "Datum_neu": 1663804800000,
         "F\u00e4lle_Meldedatum": 288,
         "Zeitraum": null,
@@ -35642,12 +35642,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 224,
         "BelegteBetten": null,
-        "Inzidenz": 315.0256833938,
+        "Inzidenz": null,
         "Datum_neu": 1663891200000,
-        "F\u00e4lle_Meldedatum": 323,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 274.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35660,7 +35660,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.52,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.09.2022"
@@ -35680,12 +35680,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 98,
         "BelegteBetten": null,
-        "Inzidenz": 325.083515930888,
+        "Inzidenz": null,
         "Datum_neu": 1663977600000,
         "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 287.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35698,7 +35698,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.29,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.09.2022"
@@ -35718,12 +35718,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
-        "Inzidenz": 328.136786522504,
+        "Inzidenz": null,
         "Datum_neu": 1664064000000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 270.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35736,7 +35736,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.96,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.09.2022"
@@ -35756,12 +35756,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 347,
         "BelegteBetten": null,
-        "Inzidenz": 324.0058910162,
+        "Inzidenz": null,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 535,
+        "F\u00e4lle_Meldedatum": 536,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 260.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35774,7 +35774,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.03,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.09.2022"
@@ -35796,7 +35796,7 @@
         "BelegteBetten": null,
         "Inzidenz": 356.873450914185,
         "Datum_neu": 1664236800000,
-        "F\u00e4lle_Meldedatum": 582,
+        "F\u00e4lle_Meldedatum": 585,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 269,
@@ -35812,7 +35812,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.53,
+        "H_Inzidenz": 12.1,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.09.2022"
@@ -35834,7 +35834,7 @@
         "BelegteBetten": null,
         "Inzidenz": 396.92517691009,
         "Datum_neu": 1664323200000,
-        "F\u00e4lle_Meldedatum": 513,
+        "F\u00e4lle_Meldedatum": 519,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 312.1,
@@ -35850,7 +35850,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.58,
+        "H_Inzidenz": 12.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.09.2022"
@@ -35861,62 +35861,62 @@
         "Datum": "29.09.2022",
         "Fallzahl": 253907,
         "ObjectId": 937,
-        "Sterbefall": 1778,
-        "Genesungsfall": 248125,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6446,
-        "Zuwachs_Fallzahl": 487,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 330,
         "BelegteBetten": null,
         "Inzidenz": 431.588778332555,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 410,
-        "Zeitraum": "22.09.2022 - 28.09.2022",
-        "Hosp_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 443,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 350,
-        "Fallzahl_aktiv": 4004,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 33,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 157,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.38,
-        "H_Zeitraum": "22.09.2022 - 28.09.2022",
-        "H_Datum": "27.09.2022",
+        "H_Inzidenz": 12.76,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.09.2022"
       }
     },
     {
       "attributes": {
         "Datum": "30.09.2022",
-        "Fallzahl": 254340,
+        "Fallzahl": 254771,
         "ObjectId": 938,
         "Sterbefall": 1778,
         "Genesungsfall": 248377,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6465,
         "Zuwachs_Fallzahl": 433,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 19,
         "Zuwachs_Genesung": 252,
         "BelegteBetten": null,
-        "Inzidenz": 461.223463486476,
+        "Inzidenz": 461.2,
         "Datum_neu": 1664496000000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "23.09.2022 - 29.09.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 411,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 401.9,
-        "Fallzahl_aktiv": 4185,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 33,
+        "Fallzahl_aktiv": 4616,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 181,
         "Krh_I": null,
@@ -35926,11 +35926,163 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.82,
-        "H_Zeitraum": "23.09.2022 - 29.09.2022",
-        "H_Datum": "27.09.2022",
+        "H_Inzidenz": 12.19,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.09.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.10.2022",
+        "Fallzahl": 254811,
+        "ObjectId": 939,
+        "Sterbefall": null,
+        "Genesungsfall": 248473,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 96,
+        "BelegteBetten": null,
+        "Inzidenz": 484.751607457164,
+        "Datum_neu": 1664582400000,
+        "F\u00e4lle_Meldedatum": 40,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 412.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.86,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "30.09.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.10.2022",
+        "Fallzahl": 254828,
+        "ObjectId": 940,
+        "Sterbefall": null,
+        "Genesungsfall": 248527,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 54,
+        "BelegteBetten": null,
+        "Inzidenz": 466.25237975502,
+        "Datum_neu": 1664668800000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 387,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.89,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "01.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.10.2022",
+        "Fallzahl": 254889,
+        "ObjectId": 941,
+        "Sterbefall": null,
+        "Genesungsfall": 248898,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 371,
+        "BelegteBetten": null,
+        "Inzidenz": 458.17019289486,
+        "Datum_neu": 1664755200000,
+        "F\u00e4lle_Meldedatum": 61,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 375.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.42,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "02.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.10.2022",
+        "Fallzahl": 254931,
+        "ObjectId": 942,
+        "Sterbefall": 1779,
+        "Genesungsfall": 249260,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6476,
+        "Zuwachs_Fallzahl": 160,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 362,
+        "BelegteBetten": null,
+        "Inzidenz": 372.858220482058,
+        "Datum_neu": 1664841600000,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": "27.09.2022 - 03.10.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 279.5,
+        "Fallzahl_aktiv": 3892,
+        "Krh_N_belegt": 634,
+        "Krh_I_belegt": 33,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -203,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.04,
+        "H_Zeitraum": "27.09.2022 - 03.10.2022",
+        "H_Datum": "27.09.2022",
+        "Datum_Bett": "03.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
