### PR TITLE
New data set: 2022-10-05T101404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-04T110403Z.json
+pjson/2022-10-05T101404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-04T110403Z.json pjson/2022-10-05T101404Z.json```:
```
--- pjson/2022-10-04T110403Z.json	2022-10-04 11:04:04.116543450 +0000
+++ pjson/2022-10-05T101404Z.json	2022-10-05 10:14:04.687520890 +0000
@@ -35264,7 +35264,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 387,
+        "F\u00e4lle_Meldedatum": 388,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -35416,7 +35416,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663372800000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -35530,7 +35530,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663632000000,
-        "F\u00e4lle_Meldedatum": 364,
+        "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -35568,9 +35568,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663718400000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35606,7 +35606,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663804800000,
-        "F\u00e4lle_Meldedatum": 288,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -35758,7 +35758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 536,
+        "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -35794,12 +35794,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 381,
         "BelegteBetten": null,
-        "Inzidenz": 356.873450914185,
+        "Inzidenz": null,
         "Datum_neu": 1664236800000,
-        "F\u00e4lle_Meldedatum": 585,
+        "F\u00e4lle_Meldedatum": 587,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 269,
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35812,7 +35812,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.1,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.09.2022"
@@ -35834,9 +35834,9 @@
         "BelegteBetten": null,
         "Inzidenz": 396.92517691009,
         "Datum_neu": 1664323200000,
-        "F\u00e4lle_Meldedatum": 519,
+        "F\u00e4lle_Meldedatum": 520,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 312.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35850,7 +35850,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.44,
+        "H_Inzidenz": 13.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.09.2022"
@@ -35872,9 +35872,9 @@
         "BelegteBetten": null,
         "Inzidenz": 431.588778332555,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 443,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 350,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35888,7 +35888,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.76,
+        "H_Inzidenz": 14.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.09.2022"
@@ -35899,34 +35899,34 @@
         "Datum": "30.09.2022",
         "Fallzahl": 254771,
         "ObjectId": 938,
-        "Sterbefall": 1778,
-        "Genesungsfall": 248377,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6465,
-        "Zuwachs_Fallzahl": 433,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 252,
         "BelegteBetten": null,
         "Inzidenz": 461.2,
         "Datum_neu": 1664496000000,
-        "F\u00e4lle_Meldedatum": 411,
+        "F\u00e4lle_Meldedatum": 469,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 401.9,
-        "Fallzahl_aktiv": 4616,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 181,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.19,
+        "H_Inzidenz": 14.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.09.2022"
@@ -35938,7 +35938,7 @@
         "Fallzahl": 254811,
         "ObjectId": 939,
         "Sterbefall": null,
-        "Genesungsfall": 248473,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -35948,7 +35948,7 @@
         "BelegteBetten": null,
         "Inzidenz": 484.751607457164,
         "Datum_neu": 1664582400000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 412.5,
@@ -35964,7 +35964,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.86,
+        "H_Inzidenz": 14.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.09.2022"
@@ -35976,7 +35976,7 @@
         "Fallzahl": 254828,
         "ObjectId": 940,
         "Sterbefall": null,
-        "Genesungsfall": 248527,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -35986,9 +35986,9 @@
         "BelegteBetten": null,
         "Inzidenz": 466.25237975502,
         "Datum_neu": 1664668800000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 98,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 387,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36002,7 +36002,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.89,
+        "H_Inzidenz": 13.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.10.2022"
@@ -36014,7 +36014,7 @@
         "Fallzahl": 254889,
         "ObjectId": 941,
         "Sterbefall": null,
-        "Genesungsfall": 248898,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -36024,7 +36024,7 @@
         "BelegteBetten": null,
         "Inzidenz": 458.17019289486,
         "Datum_neu": 1664755200000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 375.8,
@@ -36040,7 +36040,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.42,
+        "H_Inzidenz": 13.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.10.2022"
@@ -36053,7 +36053,7 @@
         "ObjectId": 942,
         "Sterbefall": 1779,
         "Genesungsfall": 249260,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6476,
         "Zuwachs_Fallzahl": 160,
         "Zuwachs_Sterbefall": 1,
@@ -36062,13 +36062,13 @@
         "BelegteBetten": null,
         "Inzidenz": 372.858220482058,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 42,
-        "Zeitraum": "27.09.2022 - 03.10.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 564,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 279.5,
         "Fallzahl_aktiv": 3892,
-        "Krh_N_belegt": 634,
-        "Krh_I_belegt": 33,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -203,
         "Krh_I": null,
@@ -36078,11 +36078,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.04,
-        "H_Zeitraum": "27.09.2022 - 03.10.2022",
-        "H_Datum": "27.09.2022",
+        "H_Inzidenz": 10.17,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.10.2022",
+        "Fallzahl": 255818,
+        "ObjectId": 943,
+        "Sterbefall": 1779,
+        "Genesungsfall": 249592,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6507,
+        "Zuwachs_Fallzahl": 887,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 31,
+        "Zuwachs_Genesung": 332,
+        "BelegteBetten": null,
+        "Inzidenz": 420.094112575883,
+        "Datum_neu": 1664928000000,
+        "F\u00e4lle_Meldedatum": 75,
+        "Zeitraum": "28.09.2022 - 04.10.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 308.5,
+        "Fallzahl_aktiv": 4447,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 555,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.27,
+        "H_Zeitraum": "28.09.2022 - 04.10.2022",
+        "H_Datum": "04.10.2022",
+        "Datum_Bett": "04.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
