### PR TITLE
New data set: 2022-10-06T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-05T101404Z.json
+pjson/2022-10-06T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-05T101404Z.json pjson/2022-10-06T101303Z.json```:
```
--- pjson/2022-10-05T101404Z.json	2022-10-05 10:14:04.687520890 +0000
+++ pjson/2022-10-06T101303Z.json	2022-10-06 10:13:04.012300847 +0000
@@ -35264,7 +35264,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 388,
+        "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -35494,7 +35494,7 @@
         "Datum_neu": 1663545600000,
         "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35532,7 +35532,7 @@
         "Datum_neu": 1663632000000,
         "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35568,9 +35568,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663718400000,
-        "F\u00e4lle_Meldedatum": 327,
+        "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35608,7 +35608,7 @@
         "Datum_neu": 1663804800000,
         "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35684,7 +35684,7 @@
         "Datum_neu": 1663977600000,
         "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35722,7 +35722,7 @@
         "Datum_neu": 1664064000000,
         "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35760,7 +35760,7 @@
         "Datum_neu": 1664150400000,
         "F\u00e4lle_Meldedatum": 537,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35798,7 +35798,7 @@
         "Datum_neu": 1664236800000,
         "F\u00e4lle_Meldedatum": 587,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35832,12 +35832,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 289,
         "BelegteBetten": null,
-        "Inzidenz": 396.92517691009,
+        "Inzidenz": null,
         "Datum_neu": 1664323200000,
-        "F\u00e4lle_Meldedatum": 520,
+        "F\u00e4lle_Meldedatum": 521,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 312.1,
+        "Hosp_Meldedatum": 11,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35850,7 +35850,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.26,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.09.2022"
@@ -35874,7 +35874,7 @@
         "Datum_neu": 1664409600000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 350,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35910,9 +35910,9 @@
         "BelegteBetten": null,
         "Inzidenz": 461.2,
         "Datum_neu": 1664496000000,
-        "F\u00e4lle_Meldedatum": 469,
+        "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 401.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35948,7 +35948,7 @@
         "BelegteBetten": null,
         "Inzidenz": 484.751607457164,
         "Datum_neu": 1664582400000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 412.5,
@@ -35986,9 +35986,9 @@
         "BelegteBetten": null,
         "Inzidenz": 466.25237975502,
         "Datum_neu": 1664668800000,
-        "F\u00e4lle_Meldedatum": 98,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 387,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36024,9 +36024,9 @@
         "BelegteBetten": null,
         "Inzidenz": 458.17019289486,
         "Datum_neu": 1664755200000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 167,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 375.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36051,26 +36051,26 @@
         "Datum": "04.10.2022",
         "Fallzahl": 254931,
         "ObjectId": 942,
-        "Sterbefall": 1779,
-        "Genesungsfall": 249260,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6476,
-        "Zuwachs_Fallzahl": 160,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 362,
         "BelegteBetten": null,
         "Inzidenz": 372.858220482058,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 564,
+        "F\u00e4lle_Meldedatum": 797,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 279.5,
-        "Fallzahl_aktiv": 3892,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -203,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36091,7 +36091,7 @@
         "ObjectId": 943,
         "Sterbefall": 1779,
         "Genesungsfall": 249592,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6507,
         "Zuwachs_Fallzahl": 887,
         "Zuwachs_Sterbefall": 0,
@@ -36100,15 +36100,53 @@
         "BelegteBetten": null,
         "Inzidenz": 420.094112575883,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 75,
-        "Zeitraum": "28.09.2022 - 04.10.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 729,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 308.5,
         "Fallzahl_aktiv": 4447,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 555,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.72,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "04.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.10.2022",
+        "Fallzahl": 256839,
+        "ObjectId": 944,
+        "Sterbefall": 1779,
+        "Genesungsfall": 249879,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6558,
+        "Zuwachs_Fallzahl": 1021,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 51,
+        "Zuwachs_Genesung": 287,
+        "BelegteBetten": null,
+        "Inzidenz": 515.823125830669,
+        "Datum_neu": 1665014400000,
+        "F\u00e4lle_Meldedatum": 40,
+        "Zeitraum": "29.09.2022 - 05.10.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 309.4,
+        "Fallzahl_aktiv": 5181,
         "Krh_N_belegt": 876,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 555,
+        "Fallzahl_aktiv_Zuwachs": 734,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
@@ -36116,10 +36154,10 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.27,
-        "H_Zeitraum": "28.09.2022 - 04.10.2022",
+        "H_Inzidenz": 7.72,
+        "H_Zeitraum": "29.09.2022 - 05.10.2022",
         "H_Datum": "04.10.2022",
-        "Datum_Bett": "04.10.2022"
+        "Datum_Bett": "05.10.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
