### PR TITLE
New data set: 2022-10-07T103904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-06T101303Z.json
+pjson/2022-10-07T103904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-06T101303Z.json pjson/2022-10-07T103904Z.json```:
```
--- pjson/2022-10-06T101303Z.json	2022-10-06 10:13:04.012300847 +0000
+++ pjson/2022-10-07T103904Z.json	2022-10-07 10:39:04.585273582 +0000
@@ -35532,7 +35532,7 @@
         "Datum_neu": 1663632000000,
         "F\u00e4lle_Meldedatum": 365,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35570,7 +35570,7 @@
         "Datum_neu": 1663718400000,
         "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35684,7 +35684,7 @@
         "Datum_neu": 1663977600000,
         "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35720,9 +35720,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664064000000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35758,7 +35758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 537,
+        "F\u00e4lle_Meldedatum": 538,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -35796,9 +35796,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664236800000,
-        "F\u00e4lle_Meldedatum": 587,
+        "F\u00e4lle_Meldedatum": 588,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35834,7 +35834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664323200000,
-        "F\u00e4lle_Meldedatum": 521,
+        "F\u00e4lle_Meldedatum": 522,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -35870,12 +35870,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 330,
         "BelegteBetten": null,
-        "Inzidenz": 431.588778332555,
+        "Inzidenz": null,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 350,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35888,7 +35888,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.15,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.09.2022"
@@ -35912,7 +35912,7 @@
         "Datum_neu": 1664496000000,
         "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 401.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35926,7 +35926,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.57,
+        "H_Inzidenz": 15.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.09.2022"
@@ -35948,9 +35948,9 @@
         "BelegteBetten": null,
         "Inzidenz": 484.751607457164,
         "Datum_neu": 1664582400000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 412.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35964,7 +35964,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.07,
+        "H_Inzidenz": 16.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.09.2022"
@@ -35986,7 +35986,7 @@
         "BelegteBetten": null,
         "Inzidenz": 466.25237975502,
         "Datum_neu": 1664668800000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 387,
@@ -36002,7 +36002,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.33,
+        "H_Inzidenz": 15.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.10.2022"
@@ -36024,9 +36024,9 @@
         "BelegteBetten": null,
         "Inzidenz": 458.17019289486,
         "Datum_neu": 1664755200000,
-        "F\u00e4lle_Meldedatum": 167,
+        "F\u00e4lle_Meldedatum": 170,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 375.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36040,7 +36040,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.18,
+        "H_Inzidenz": 15.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.10.2022"
@@ -36062,9 +36062,9 @@
         "BelegteBetten": null,
         "Inzidenz": 372.858220482058,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 797,
+        "F\u00e4lle_Meldedatum": 839,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": 279.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36078,7 +36078,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.17,
+        "H_Inzidenz": 13.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.10.2022"
@@ -36089,34 +36089,34 @@
         "Datum": "05.10.2022",
         "Fallzahl": 255818,
         "ObjectId": 943,
-        "Sterbefall": 1779,
-        "Genesungsfall": 249592,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6507,
-        "Zuwachs_Fallzahl": 887,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 31,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
         "Inzidenz": 420.094112575883,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 729,
+        "F\u00e4lle_Meldedatum": 900,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 308.5,
-        "Fallzahl_aktiv": 4447,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 555,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
+        "H_Inzidenz": 14.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.10.2022"
@@ -36129,18 +36129,18 @@
         "ObjectId": 944,
         "Sterbefall": 1779,
         "Genesungsfall": 249879,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6558,
         "Zuwachs_Fallzahl": 1021,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 51,
         "Zuwachs_Genesung": 287,
         "BelegteBetten": null,
-        "Inzidenz": 515.823125830669,
+        "Inzidenz": 515.8,
         "Datum_neu": 1665014400000,
-        "F\u00e4lle_Meldedatum": 40,
-        "Zeitraum": "29.09.2022 - 05.10.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 527,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 309.4,
         "Fallzahl_aktiv": 5181,
         "Krh_N_belegt": 876,
@@ -36154,11 +36154,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
-        "H_Zeitraum": "29.09.2022 - 05.10.2022",
-        "H_Datum": "04.10.2022",
+        "H_Inzidenz": 14.3,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.10.2022",
+        "Fallzahl": 257585,
+        "ObjectId": 945,
+        "Sterbefall": 1779,
+        "Genesungsfall": 250200,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6584,
+        "Zuwachs_Fallzahl": 746,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 26,
+        "Zuwachs_Genesung": 321,
+        "BelegteBetten": null,
+        "Inzidenz": 569.345163260175,
+        "Datum_neu": 1665100800000,
+        "F\u00e4lle_Meldedatum": 35,
+        "Zeitraum": "30.09.2022 - 06.10.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 485.3,
+        "Fallzahl_aktiv": 5606,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 425,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.77,
+        "H_Zeitraum": "30.09.2022 - 06.10.2022",
+        "H_Datum": "04.10.2022",
+        "Datum_Bett": "06.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
