### PR TITLE
New data set: 2022-10-10T100403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-07T103904Z.json
+pjson/2022-10-10T100403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-07T103904Z.json pjson/2022-10-10T100403Z.json```:
```
--- pjson/2022-10-07T103904Z.json	2022-10-07 10:39:04.585273582 +0000
+++ pjson/2022-10-10T100403Z.json	2022-10-10 10:04:03.914356377 +0000
@@ -35908,12 +35908,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 252,
         "BelegteBetten": null,
-        "Inzidenz": 461.2,
+        "Inzidenz": null,
         "Datum_neu": 1664496000000,
         "F\u00e4lle_Meldedatum": 481,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 401.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35926,7 +35926,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.09.2022"
@@ -35946,12 +35946,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 96,
         "BelegteBetten": null,
-        "Inzidenz": 484.751607457164,
+        "Inzidenz": null,
         "Datum_neu": 1664582400000,
         "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 412.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -35964,7 +35964,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.08,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.09.2022"
@@ -35984,12 +35984,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 54,
         "BelegteBetten": null,
-        "Inzidenz": 466.25237975502,
+        "Inzidenz": null,
         "Datum_neu": 1664668800000,
         "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 387,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -36002,7 +36002,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.63,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.10.2022"
@@ -36024,7 +36024,7 @@
         "BelegteBetten": null,
         "Inzidenz": 458.17019289486,
         "Datum_neu": 1664755200000,
-        "F\u00e4lle_Meldedatum": 170,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 375.8,
@@ -36040,7 +36040,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.09,
+        "H_Inzidenz": 16.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.10.2022"
@@ -36062,9 +36062,9 @@
         "BelegteBetten": null,
         "Inzidenz": 372.858220482058,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 839,
+        "F\u00e4lle_Meldedatum": 853,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 279.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36078,7 +36078,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.53,
+        "H_Inzidenz": 13.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.10.2022"
@@ -36100,9 +36100,9 @@
         "BelegteBetten": null,
         "Inzidenz": 420.094112575883,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 900,
+        "F\u00e4lle_Meldedatum": 907,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 308.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36116,7 +36116,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.64,
+        "H_Inzidenz": 15.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.10.2022"
@@ -36127,34 +36127,34 @@
         "Datum": "06.10.2022",
         "Fallzahl": 256839,
         "ObjectId": 944,
-        "Sterbefall": 1779,
-        "Genesungsfall": 249879,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6558,
-        "Zuwachs_Fallzahl": 1021,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 51,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 287,
         "BelegteBetten": null,
         "Inzidenz": 515.8,
         "Datum_neu": 1665014400000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 598,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 309.4,
-        "Fallzahl_aktiv": 5181,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 734,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.3,
+        "H_Inzidenz": 15.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.10.2022"
@@ -36167,7 +36167,7 @@
         "ObjectId": 945,
         "Sterbefall": 1779,
         "Genesungsfall": 250200,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6584,
         "Zuwachs_Fallzahl": 746,
         "Zuwachs_Sterbefall": 0,
@@ -36176,9 +36176,9 @@
         "BelegteBetten": null,
         "Inzidenz": 569.345163260175,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 35,
-        "Zeitraum": "30.09.2022 - 06.10.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 355,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 485.3,
         "Fallzahl_aktiv": 5606,
         "Krh_N_belegt": 876,
@@ -36192,11 +36192,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.77,
-        "H_Zeitraum": "30.09.2022 - 06.10.2022",
-        "H_Datum": "04.10.2022",
+        "H_Inzidenz": 13.63,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.10.2022",
+        "Fallzahl": 257621,
+        "ObjectId": 946,
+        "Sterbefall": null,
+        "Genesungsfall": 250343,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 143,
+        "BelegteBetten": null,
+        "Inzidenz": 489.241711268365,
+        "Datum_neu": 1665187200000,
+        "F\u00e4lle_Meldedatum": 73,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 465.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.92,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "07.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.10.2022",
+        "Fallzahl": 257658,
+        "ObjectId": 947,
+        "Sterbefall": null,
+        "Genesungsfall": 250411,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 68,
+        "BelegteBetten": null,
+        "Inzidenz": 472.358920938252,
+        "Datum_neu": 1665273600000,
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 442.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "08.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.10.2022",
+        "Fallzahl": 258104,
+        "ObjectId": 948,
+        "Sterbefall": 1779,
+        "Genesungsfall": 250932,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6594,
+        "Zuwachs_Fallzahl": 519,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 521,
+        "BelegteBetten": null,
+        "Inzidenz": 534.68156183771,
+        "Datum_neu": 1665360000000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "03.10.2022 - 09.10.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 419.9,
+        "Fallzahl_aktiv": 5393,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.39,
+        "H_Zeitraum": "03.10.2022 - 09.10.2022",
+        "H_Datum": "10.10.2022",
+        "Datum_Bett": "09.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
