### PR TITLE
New data set: 2022-10-11T102504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-10T100403Z.json
+pjson/2022-10-11T102504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-10T100403Z.json pjson/2022-10-11T102504Z.json```:
```
--- pjson/2022-10-10T100403Z.json	2022-10-10 10:04:03.914356377 +0000
+++ pjson/2022-10-11T102504Z.json	2022-10-11 10:25:04.655229466 +0000
@@ -35872,7 +35872,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 449,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -35910,7 +35910,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664496000000,
-        "F\u00e4lle_Meldedatum": 481,
+        "F\u00e4lle_Meldedatum": 479,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -35948,7 +35948,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664582400000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -35986,7 +35986,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664668800000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -36022,12 +36022,12 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 371,
         "BelegteBetten": null,
-        "Inzidenz": 458.17019289486,
+        "Inzidenz": null,
         "Datum_neu": 1664755200000,
         "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 375.8,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -36040,7 +36040,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.25,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.10.2022"
@@ -36062,13 +36062,13 @@
         "BelegteBetten": null,
         "Inzidenz": 372.858220482058,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 853,
+        "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
         "Hosp_Meldedatum": 34,
         "Inzidenz_RKI": 279.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36078,7 +36078,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.88,
+        "H_Inzidenz": 15.55,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.10.2022"
@@ -36100,13 +36100,13 @@
         "BelegteBetten": null,
         "Inzidenz": 420.094112575883,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 907,
+        "F\u00e4lle_Meldedatum": 912,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 308.5,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36116,7 +36116,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.26,
+        "H_Inzidenz": 15.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.10.2022"
@@ -36138,7 +36138,7 @@
         "BelegteBetten": null,
         "Inzidenz": 515.8,
         "Datum_neu": 1665014400000,
-        "F\u00e4lle_Meldedatum": 598,
+        "F\u00e4lle_Meldedatum": 628,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 309.4,
@@ -36154,7 +36154,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.19,
+        "H_Inzidenz": 15.78,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.10.2022"
@@ -36165,34 +36165,34 @@
         "Datum": "07.10.2022",
         "Fallzahl": 257585,
         "ObjectId": 945,
-        "Sterbefall": 1779,
-        "Genesungsfall": 250200,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6584,
-        "Zuwachs_Fallzahl": 746,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 321,
         "BelegteBetten": null,
         "Inzidenz": 569.345163260175,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 355,
+        "F\u00e4lle_Meldedatum": 643,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 485.3,
-        "Fallzahl_aktiv": 5606,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 425,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.63,
+        "H_Inzidenz": 14.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.10.2022"
@@ -36204,7 +36204,7 @@
         "Fallzahl": 257621,
         "ObjectId": 946,
         "Sterbefall": null,
-        "Genesungsfall": 250343,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -36214,9 +36214,9 @@
         "BelegteBetten": null,
         "Inzidenz": 489.241711268365,
         "Datum_neu": 1665187200000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 465.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36230,7 +36230,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.92,
+        "H_Inzidenz": 13.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.10.2022"
@@ -36242,7 +36242,7 @@
         "Fallzahl": 257658,
         "ObjectId": 947,
         "Sterbefall": null,
-        "Genesungsfall": 250411,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -36252,9 +36252,9 @@
         "BelegteBetten": null,
         "Inzidenz": 472.358920938252,
         "Datum_neu": 1665273600000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 442.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36268,7 +36268,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.23,
+        "H_Inzidenz": 13.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.10.2022"
@@ -36281,18 +36281,18 @@
         "ObjectId": 948,
         "Sterbefall": 1779,
         "Genesungsfall": 250932,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6594,
         "Zuwachs_Fallzahl": 519,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 10,
         "Zuwachs_Genesung": 521,
         "BelegteBetten": null,
-        "Inzidenz": 534.68156183771,
+        "Inzidenz": 534.7,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "03.10.2022 - 09.10.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 526,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 419.9,
         "Fallzahl_aktiv": 5393,
         "Krh_N_belegt": 876,
@@ -36306,11 +36306,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.39,
-        "H_Zeitraum": "03.10.2022 - 09.10.2022",
-        "H_Datum": "10.10.2022",
+        "H_Inzidenz": 12.74,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.10.2022",
+        "Fallzahl": 259200,
+        "ObjectId": 949,
+        "Sterbefall": 1779,
+        "Genesungsfall": 251509,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6613,
+        "Zuwachs_Fallzahl": 1096,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 577,
+        "BelegteBetten": null,
+        "Inzidenz": 687.165487266066,
+        "Datum_neu": 1665446400000,
+        "F\u00e4lle_Meldedatum": 87,
+        "Zeitraum": "04.10.2022 - 10.10.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 561.1,
+        "Fallzahl_aktiv": 5912,
+        "Krh_N_belegt": 876,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 519,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.65,
+        "H_Zeitraum": "04.10.2022 - 10.10.2022",
+        "H_Datum": "04.10.2022",
+        "Datum_Bett": "10.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
