### PR TITLE
New data set: 2022-10-12T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-11T102504Z.json
+pjson/2022-10-12T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-11T102504Z.json pjson/2022-10-12T101103Z.json```:
```
--- pjson/2022-10-11T102504Z.json	2022-10-11 10:25:04.655229466 +0000
+++ pjson/2022-10-12T101103Z.json	2022-10-12 10:11:03.903047262 +0000
@@ -35454,7 +35454,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663459200000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -35492,7 +35492,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 381,
+        "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -35948,7 +35948,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664582400000,
-        "F\u00e4lle_Meldedatum": 129,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -35986,9 +35986,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664668800000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36026,7 +36026,7 @@
         "Datum_neu": 1664755200000,
         "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36060,15 +36060,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 362,
         "BelegteBetten": null,
-        "Inzidenz": 372.858220482058,
+        "Inzidenz": null,
         "Datum_neu": 1664841600000,
         "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 34,
-        "Inzidenz_RKI": 279.5,
+        "Hosp_Meldedatum": 32,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 876,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36078,7 +36078,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.55,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.10.2022"
@@ -36100,9 +36100,9 @@
         "BelegteBetten": null,
         "Inzidenz": 420.094112575883,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 912,
+        "F\u00e4lle_Meldedatum": 918,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 308.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36116,7 +36116,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.58,
+        "H_Inzidenz": 16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.10.2022"
@@ -36138,9 +36138,9 @@
         "BelegteBetten": null,
         "Inzidenz": 515.8,
         "Datum_neu": 1665014400000,
-        "F\u00e4lle_Meldedatum": 628,
+        "F\u00e4lle_Meldedatum": 634,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 309.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36154,7 +36154,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.78,
+        "H_Inzidenz": 16.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.10.2022"
@@ -36176,7 +36176,7 @@
         "BelegteBetten": null,
         "Inzidenz": 569.345163260175,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 643,
+        "F\u00e4lle_Meldedatum": 658,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 485.3,
@@ -36192,7 +36192,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.89,
+        "H_Inzidenz": 16.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.10.2022"
@@ -36214,7 +36214,7 @@
         "BelegteBetten": null,
         "Inzidenz": 489.241711268365,
         "Datum_neu": 1665187200000,
-        "F\u00e4lle_Meldedatum": 176,
+        "F\u00e4lle_Meldedatum": 227,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 465.3,
@@ -36230,7 +36230,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.95,
+        "H_Inzidenz": 17.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.10.2022"
@@ -36252,9 +36252,9 @@
         "BelegteBetten": null,
         "Inzidenz": 472.358920938252,
         "Datum_neu": 1665273600000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 442.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36268,7 +36268,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.41,
+        "H_Inzidenz": 16.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.10.2022"
@@ -36279,26 +36279,26 @@
         "Datum": "10.10.2022",
         "Fallzahl": 258104,
         "ObjectId": 948,
-        "Sterbefall": 1779,
-        "Genesungsfall": 250932,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6594,
-        "Zuwachs_Fallzahl": 519,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 521,
         "BelegteBetten": null,
         "Inzidenz": 534.7,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 526,
+        "F\u00e4lle_Meldedatum": 825,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": 419.9,
-        "Fallzahl_aktiv": 5393,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36306,7 +36306,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.74,
+        "H_Inzidenz": 16.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.10.2022"
@@ -36319,7 +36319,7 @@
         "ObjectId": 949,
         "Sterbefall": 1779,
         "Genesungsfall": 251509,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6613,
         "Zuwachs_Fallzahl": 1096,
         "Zuwachs_Sterbefall": 0,
@@ -36328,9 +36328,9 @@
         "BelegteBetten": null,
         "Inzidenz": 687.165487266066,
         "Datum_neu": 1665446400000,
-        "F\u00e4lle_Meldedatum": 87,
-        "Zeitraum": "04.10.2022 - 10.10.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 642,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 561.1,
         "Fallzahl_aktiv": 5912,
         "Krh_N_belegt": 876,
@@ -36344,11 +36344,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.65,
-        "H_Zeitraum": "04.10.2022 - 10.10.2022",
-        "H_Datum": "04.10.2022",
+        "H_Inzidenz": 18.01,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.10.2022",
+        "Fallzahl": 260269,
+        "ObjectId": 950,
+        "Sterbefall": 1779,
+        "Genesungsfall": 252030,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6668,
+        "Zuwachs_Fallzahl": 1069,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 55,
+        "Zuwachs_Genesung": 521,
+        "BelegteBetten": null,
+        "Inzidenz": 726.139588347283,
+        "Datum_neu": 1665532800000,
+        "F\u00e4lle_Meldedatum": 78,
+        "Zeitraum": "05.10.2022 - 11.10.2022",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 604.7,
+        "Fallzahl_aktiv": 6460,
+        "Krh_N_belegt": 1190,
+        "Krh_I_belegt": 86,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 548,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 14,
+        "H_Zeitraum": "05.10.2022 - 11.10.2022",
+        "H_Datum": "12.10.2022",
+        "Datum_Bett": "11.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
