### PR TITLE
New data set: 2022-10-13T101303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-12T101103Z.json
+pjson/2022-10-13T101303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-12T101103Z.json pjson/2022-10-13T101303Z.json```:
```
--- pjson/2022-10-12T101103Z.json	2022-10-12 10:11:03.903047262 +0000
+++ pjson/2022-10-13T101303Z.json	2022-10-13 10:13:03.993738867 +0000
@@ -35834,7 +35834,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664323200000,
-        "F\u00e4lle_Meldedatum": 522,
+        "F\u00e4lle_Meldedatum": 523,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -35872,7 +35872,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 451,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -36024,7 +36024,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664755200000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -36062,7 +36062,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 859,
+        "F\u00e4lle_Meldedatum": 860,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -36098,15 +36098,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
-        "Inzidenz": 420.094112575883,
+        "Inzidenz": null,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 918,
+        "F\u00e4lle_Meldedatum": 921,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 308.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 876,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36116,7 +36116,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.10.2022"
@@ -36138,7 +36138,7 @@
         "BelegteBetten": null,
         "Inzidenz": 515.8,
         "Datum_neu": 1665014400000,
-        "F\u00e4lle_Meldedatum": 634,
+        "F\u00e4lle_Meldedatum": 636,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 309.4,
@@ -36176,7 +36176,7 @@
         "BelegteBetten": null,
         "Inzidenz": 569.345163260175,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 658,
+        "F\u00e4lle_Meldedatum": 665,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 485.3,
@@ -36214,7 +36214,7 @@
         "BelegteBetten": null,
         "Inzidenz": 489.241711268365,
         "Datum_neu": 1665187200000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 465.3,
@@ -36252,7 +36252,7 @@
         "BelegteBetten": null,
         "Inzidenz": 472.358920938252,
         "Datum_neu": 1665273600000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 442.2,
@@ -36290,9 +36290,9 @@
         "BelegteBetten": null,
         "Inzidenz": 534.7,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 825,
+        "F\u00e4lle_Meldedatum": 855,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": 419.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36317,28 +36317,28 @@
         "Datum": "11.10.2022",
         "Fallzahl": 259200,
         "ObjectId": 949,
-        "Sterbefall": 1779,
-        "Genesungsfall": 251509,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6613,
-        "Zuwachs_Fallzahl": 1096,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 577,
         "BelegteBetten": null,
         "Inzidenz": 687.165487266066,
         "Datum_neu": 1665446400000,
-        "F\u00e4lle_Meldedatum": 642,
+        "F\u00e4lle_Meldedatum": 781,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 561.1,
-        "Fallzahl_aktiv": 5912,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 519,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -36357,7 +36357,7 @@
         "ObjectId": 950,
         "Sterbefall": 1779,
         "Genesungsfall": 252030,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6668,
         "Zuwachs_Fallzahl": 1069,
         "Zuwachs_Sterbefall": 0,
@@ -36366,9 +36366,9 @@
         "BelegteBetten": null,
         "Inzidenz": 726.139588347283,
         "Datum_neu": 1665532800000,
-        "F\u00e4lle_Meldedatum": 78,
-        "Zeitraum": "05.10.2022 - 11.10.2022",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 534,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 604.7,
         "Fallzahl_aktiv": 6460,
         "Krh_N_belegt": 1190,
@@ -36383,10 +36383,48 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 14,
-        "H_Zeitraum": "05.10.2022 - 11.10.2022",
-        "H_Datum": "12.10.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.10.2022",
+        "Fallzahl": 260987,
+        "ObjectId": 951,
+        "Sterbefall": 1779,
+        "Genesungsfall": 252473,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6683,
+        "Zuwachs_Fallzahl": 718,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 443,
+        "BelegteBetten": null,
+        "Inzidenz": 691.116778619922,
+        "Datum_neu": 1665619200000,
+        "F\u00e4lle_Meldedatum": 67,
+        "Zeitraum": "06.10.2022 - 12.10.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 615.5,
+        "Fallzahl_aktiv": 6735,
+        "Krh_N_belegt": 1190,
+        "Krh_I_belegt": 86,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 275,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 14,
+        "H_Zeitraum": "06.10.2022 - 12.10.2022",
+        "H_Datum": "13.10.2022",
+        "Datum_Bett": "12.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
