### PR TITLE
New data set: 2022-10-14T100804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-13T101303Z.json
+pjson/2022-10-14T100804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-13T101303Z.json pjson/2022-10-14T100804Z.json```:
```
--- pjson/2022-10-13T101303Z.json	2022-10-13 10:13:03.993738867 +0000
+++ pjson/2022-10-14T100804Z.json	2022-10-14 10:08:04.652761943 +0000
@@ -35758,7 +35758,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664150400000,
-        "F\u00e4lle_Meldedatum": 538,
+        "F\u00e4lle_Meldedatum": 539,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -35872,7 +35872,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -35910,7 +35910,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664496000000,
-        "F\u00e4lle_Meldedatum": 479,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -35988,7 +35988,7 @@
         "Datum_neu": 1664668800000,
         "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36064,7 +36064,7 @@
         "Datum_neu": 1664841600000,
         "F\u00e4lle_Meldedatum": 860,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36102,7 +36102,7 @@
         "Datum_neu": 1664928000000,
         "F\u00e4lle_Meldedatum": 921,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36136,15 +36136,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 287,
         "BelegteBetten": null,
-        "Inzidenz": 515.8,
+        "Inzidenz": null,
         "Datum_neu": 1665014400000,
         "F\u00e4lle_Meldedatum": 636,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 309.4,
+        "Hosp_Meldedatum": 18,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 876,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36154,7 +36154,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.79,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.10.2022"
@@ -36176,7 +36176,7 @@
         "BelegteBetten": null,
         "Inzidenz": 569.345163260175,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 665,
+        "F\u00e4lle_Meldedatum": 668,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 485.3,
@@ -36192,7 +36192,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.6,
+        "H_Inzidenz": 18.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.10.2022"
@@ -36230,7 +36230,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 17.02,
+        "H_Inzidenz": 19.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.10.2022"
@@ -36252,7 +36252,7 @@
         "BelegteBetten": null,
         "Inzidenz": 472.358920938252,
         "Datum_neu": 1665273600000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 442.2,
@@ -36268,7 +36268,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.7,
+        "H_Inzidenz": 19.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.10.2022"
@@ -36290,7 +36290,7 @@
         "BelegteBetten": null,
         "Inzidenz": 534.7,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 855,
+        "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": 419.9,
@@ -36306,7 +36306,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.4,
+        "H_Inzidenz": 19.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.10.2022"
@@ -36328,9 +36328,9 @@
         "BelegteBetten": null,
         "Inzidenz": 687.165487266066,
         "Datum_neu": 1665446400000,
-        "F\u00e4lle_Meldedatum": 781,
+        "F\u00e4lle_Meldedatum": 800,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 561.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36344,7 +36344,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 18.01,
+        "H_Inzidenz": 23.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.10.2022"
@@ -36355,34 +36355,34 @@
         "Datum": "12.10.2022",
         "Fallzahl": 260269,
         "ObjectId": 950,
-        "Sterbefall": 1779,
-        "Genesungsfall": 252030,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6668,
-        "Zuwachs_Fallzahl": 1069,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 55,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 521,
         "BelegteBetten": null,
         "Inzidenz": 726.139588347283,
         "Datum_neu": 1665532800000,
-        "F\u00e4lle_Meldedatum": 534,
+        "F\u00e4lle_Meldedatum": 581,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 604.7,
-        "Fallzahl_aktiv": 6460,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
         "Krh_I_belegt": 86,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 548,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14,
+        "H_Inzidenz": 20.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.10.2022"
@@ -36395,7 +36395,7 @@
         "ObjectId": 951,
         "Sterbefall": 1779,
         "Genesungsfall": 252473,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6683,
         "Zuwachs_Fallzahl": 718,
         "Zuwachs_Sterbefall": 0,
@@ -36404,9 +36404,9 @@
         "BelegteBetten": null,
         "Inzidenz": 691.116778619922,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 67,
-        "Zeitraum": "06.10.2022 - 12.10.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 271,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 615.5,
         "Fallzahl_aktiv": 6735,
         "Krh_N_belegt": 1190,
@@ -36420,11 +36420,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14,
-        "H_Zeitraum": "06.10.2022 - 12.10.2022",
-        "H_Datum": "13.10.2022",
+        "H_Inzidenz": 17.81,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.10.2022",
+        "Fallzahl": 261267,
+        "ObjectId": 952,
+        "Sterbefall": 1779,
+        "Genesungsfall": 252939,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6710,
+        "Zuwachs_Fallzahl": 280,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 27,
+        "Zuwachs_Genesung": 466,
+        "BelegteBetten": null,
+        "Inzidenz": 639.211178562448,
+        "Datum_neu": 1665705600000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "07.10.2022 - 13.10.2022",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 616.7,
+        "Fallzahl_aktiv": 6549,
+        "Krh_N_belegt": 1190,
+        "Krh_I_belegt": 86,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -186,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 14,
+        "H_Zeitraum": "07.10.2022 - 13.10.2022",
+        "H_Datum": "14.10.2022",
+        "Datum_Bett": "13.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
