### PR TITLE
New data set: 2022-10-18T101103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-17T110604Z.json
+pjson/2022-10-18T101103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-17T110604Z.json pjson/2022-10-18T101103Z.json```:
```
--- pjson/2022-10-17T110604Z.json	2022-10-17 11:06:04.398867210 +0000
+++ pjson/2022-10-18T101103Z.json	2022-10-18 10:11:04.333229608 +0000
@@ -31846,7 +31846,7 @@
         "Datum_neu": 1655251200000,
         "F\u00e4lle_Meldedatum": 368,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31884,7 +31884,7 @@
         "Datum_neu": 1655337600000,
         "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -31960,7 +31960,7 @@
         "Datum_neu": 1655510400000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32036,7 +32036,7 @@
         "Datum_neu": 1655683200000,
         "F\u00e4lle_Meldedatum": 699,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32074,7 +32074,7 @@
         "Datum_neu": 1655769600000,
         "F\u00e4lle_Meldedatum": 588,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32150,7 +32150,7 @@
         "Datum_neu": 1655942400000,
         "F\u00e4lle_Meldedatum": 508,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32188,7 +32188,7 @@
         "Datum_neu": 1656028800000,
         "F\u00e4lle_Meldedatum": 493,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32226,7 +32226,7 @@
         "Datum_neu": 1656115200000,
         "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32264,7 +32264,7 @@
         "Datum_neu": 1656201600000,
         "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32302,7 +32302,7 @@
         "Datum_neu": 1656288000000,
         "F\u00e4lle_Meldedatum": 742,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32340,7 +32340,7 @@
         "Datum_neu": 1656374400000,
         "F\u00e4lle_Meldedatum": 788,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32378,7 +32378,7 @@
         "Datum_neu": 1656460800000,
         "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32416,7 +32416,7 @@
         "Datum_neu": 1656547200000,
         "F\u00e4lle_Meldedatum": 490,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32454,7 +32454,7 @@
         "Datum_neu": 1656633600000,
         "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32492,7 +32492,7 @@
         "Datum_neu": 1656720000000,
         "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32530,7 +32530,7 @@
         "Datum_neu": 1656806400000,
         "F\u00e4lle_Meldedatum": 117,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32568,7 +32568,7 @@
         "Datum_neu": 1656892800000,
         "F\u00e4lle_Meldedatum": 621,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32606,7 +32606,7 @@
         "Datum_neu": 1656979200000,
         "F\u00e4lle_Meldedatum": 718,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32644,7 +32644,7 @@
         "Datum_neu": 1657065600000,
         "F\u00e4lle_Meldedatum": 563,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32682,7 +32682,7 @@
         "Datum_neu": 1657152000000,
         "F\u00e4lle_Meldedatum": 462,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32720,7 +32720,7 @@
         "Datum_neu": 1657238400000,
         "F\u00e4lle_Meldedatum": 395,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32758,7 +32758,7 @@
         "Datum_neu": 1657324800000,
         "F\u00e4lle_Meldedatum": 242,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32796,7 +32796,7 @@
         "Datum_neu": 1657411200000,
         "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32834,7 +32834,7 @@
         "Datum_neu": 1657497600000,
         "F\u00e4lle_Meldedatum": 786,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32872,7 +32872,7 @@
         "Datum_neu": 1657584000000,
         "F\u00e4lle_Meldedatum": 723,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 31,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32910,7 +32910,7 @@
         "Datum_neu": 1657670400000,
         "F\u00e4lle_Meldedatum": 567,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -32986,7 +32986,7 @@
         "Datum_neu": 1657843200000,
         "F\u00e4lle_Meldedatum": 1123,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33024,7 +33024,7 @@
         "Datum_neu": 1657929600000,
         "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33062,7 +33062,7 @@
         "Datum_neu": 1658016000000,
         "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33100,7 +33100,7 @@
         "Datum_neu": 1658102400000,
         "F\u00e4lle_Meldedatum": 805,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33176,7 +33176,7 @@
         "Datum_neu": 1658275200000,
         "F\u00e4lle_Meldedatum": 691,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33214,7 +33214,7 @@
         "Datum_neu": 1658361600000,
         "F\u00e4lle_Meldedatum": 562,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33252,7 +33252,7 @@
         "Datum_neu": 1658448000000,
         "F\u00e4lle_Meldedatum": 571,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33290,7 +33290,7 @@
         "Datum_neu": 1658534400000,
         "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33328,7 +33328,7 @@
         "Datum_neu": 1658620800000,
         "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33366,7 +33366,7 @@
         "Datum_neu": 1658707200000,
         "F\u00e4lle_Meldedatum": 762,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33404,7 +33404,7 @@
         "Datum_neu": 1658793600000,
         "F\u00e4lle_Meldedatum": 675,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33442,7 +33442,7 @@
         "Datum_neu": 1658880000000,
         "F\u00e4lle_Meldedatum": 522,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33480,7 +33480,7 @@
         "Datum_neu": 1658966400000,
         "F\u00e4lle_Meldedatum": 374,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33518,7 +33518,7 @@
         "Datum_neu": 1659052800000,
         "F\u00e4lle_Meldedatum": 430,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33556,7 +33556,7 @@
         "Datum_neu": 1659139200000,
         "F\u00e4lle_Meldedatum": 119,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33594,7 +33594,7 @@
         "Datum_neu": 1659225600000,
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33632,7 +33632,7 @@
         "Datum_neu": 1659312000000,
         "F\u00e4lle_Meldedatum": 573,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33670,7 +33670,7 @@
         "Datum_neu": 1659398400000,
         "F\u00e4lle_Meldedatum": 554,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33708,7 +33708,7 @@
         "Datum_neu": 1659484800000,
         "F\u00e4lle_Meldedatum": 357,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33746,7 +33746,7 @@
         "Datum_neu": 1659571200000,
         "F\u00e4lle_Meldedatum": 335,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33784,7 +33784,7 @@
         "Datum_neu": 1659657600000,
         "F\u00e4lle_Meldedatum": 310,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33822,7 +33822,7 @@
         "Datum_neu": 1659744000000,
         "F\u00e4lle_Meldedatum": 181,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33860,7 +33860,7 @@
         "Datum_neu": 1659830400000,
         "F\u00e4lle_Meldedatum": 86,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33898,7 +33898,7 @@
         "Datum_neu": 1659916800000,
         "F\u00e4lle_Meldedatum": 463,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33936,7 +33936,7 @@
         "Datum_neu": 1660003200000,
         "F\u00e4lle_Meldedatum": 459,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -33974,7 +33974,7 @@
         "Datum_neu": 1660089600000,
         "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34050,7 +34050,7 @@
         "Datum_neu": 1660262400000,
         "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34088,7 +34088,7 @@
         "Datum_neu": 1660348800000,
         "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34126,7 +34126,7 @@
         "Datum_neu": 1660435200000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34164,7 +34164,7 @@
         "Datum_neu": 1660521600000,
         "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34202,7 +34202,7 @@
         "Datum_neu": 1660608000000,
         "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34240,7 +34240,7 @@
         "Datum_neu": 1660694400000,
         "F\u00e4lle_Meldedatum": 274,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34316,7 +34316,7 @@
         "Datum_neu": 1660867200000,
         "F\u00e4lle_Meldedatum": 239,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34354,7 +34354,7 @@
         "Datum_neu": 1660953600000,
         "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34392,7 +34392,7 @@
         "Datum_neu": 1661040000000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34430,7 +34430,7 @@
         "Datum_neu": 1661126400000,
         "F\u00e4lle_Meldedatum": 391,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34506,7 +34506,7 @@
         "Datum_neu": 1661299200000,
         "F\u00e4lle_Meldedatum": 261,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34544,7 +34544,7 @@
         "Datum_neu": 1661385600000,
         "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34582,7 +34582,7 @@
         "Datum_neu": 1661472000000,
         "F\u00e4lle_Meldedatum": 252,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34620,7 +34620,7 @@
         "Datum_neu": 1661558400000,
         "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34658,7 +34658,7 @@
         "Datum_neu": 1661644800000,
         "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34696,7 +34696,7 @@
         "Datum_neu": 1661731200000,
         "F\u00e4lle_Meldedatum": 353,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34734,7 +34734,7 @@
         "Datum_neu": 1661817600000,
         "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34772,7 +34772,7 @@
         "Datum_neu": 1661904000000,
         "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34810,7 +34810,7 @@
         "Datum_neu": 1661990400000,
         "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34848,7 +34848,7 @@
         "Datum_neu": 1662076800000,
         "F\u00e4lle_Meldedatum": 236,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34886,7 +34886,7 @@
         "Datum_neu": 1662163200000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34924,7 +34924,7 @@
         "Datum_neu": 1662249600000,
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34962,7 +34962,7 @@
         "Datum_neu": 1662336000000,
         "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35000,7 +35000,7 @@
         "Datum_neu": 1662422400000,
         "F\u00e4lle_Meldedatum": 299,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35038,7 +35038,7 @@
         "Datum_neu": 1662508800000,
         "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35076,7 +35076,7 @@
         "Datum_neu": 1662595200000,
         "F\u00e4lle_Meldedatum": 249,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35114,7 +35114,7 @@
         "Datum_neu": 1662681600000,
         "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35152,7 +35152,7 @@
         "Datum_neu": 1662768000000,
         "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35190,7 +35190,7 @@
         "Datum_neu": 1662854400000,
         "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35228,7 +35228,7 @@
         "Datum_neu": 1662940800000,
         "F\u00e4lle_Meldedatum": 358,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35266,7 +35266,7 @@
         "Datum_neu": 1663027200000,
         "F\u00e4lle_Meldedatum": 389,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35304,7 +35304,7 @@
         "Datum_neu": 1663113600000,
         "F\u00e4lle_Meldedatum": 284,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35342,7 +35342,7 @@
         "Datum_neu": 1663200000000,
         "F\u00e4lle_Meldedatum": 332,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35380,7 +35380,7 @@
         "Datum_neu": 1663286400000,
         "F\u00e4lle_Meldedatum": 254,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35418,7 +35418,7 @@
         "Datum_neu": 1663372800000,
         "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35494,7 +35494,7 @@
         "Datum_neu": 1663545600000,
         "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35532,7 +35532,7 @@
         "Datum_neu": 1663632000000,
         "F\u00e4lle_Meldedatum": 366,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35570,7 +35570,7 @@
         "Datum_neu": 1663718400000,
         "F\u00e4lle_Meldedatum": 328,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35646,7 +35646,7 @@
         "Datum_neu": 1663891200000,
         "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35684,7 +35684,7 @@
         "Datum_neu": 1663977600000,
         "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35722,7 +35722,7 @@
         "Datum_neu": 1664064000000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35760,7 +35760,7 @@
         "Datum_neu": 1664150400000,
         "F\u00e4lle_Meldedatum": 539,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35798,7 +35798,7 @@
         "Datum_neu": 1664236800000,
         "F\u00e4lle_Meldedatum": 588,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35836,7 +35836,7 @@
         "Datum_neu": 1664323200000,
         "F\u00e4lle_Meldedatum": 523,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35874,7 +35874,7 @@
         "Datum_neu": 1664409600000,
         "F\u00e4lle_Meldedatum": 448,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35912,7 +35912,7 @@
         "Datum_neu": 1664496000000,
         "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35950,7 +35950,7 @@
         "Datum_neu": 1664582400000,
         "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35988,7 +35988,7 @@
         "Datum_neu": 1664668800000,
         "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36026,7 +36026,7 @@
         "Datum_neu": 1664755200000,
         "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36062,9 +36062,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 860,
+        "F\u00e4lle_Meldedatum": 861,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 36,
+        "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36102,7 +36102,7 @@
         "Datum_neu": 1664928000000,
         "F\u00e4lle_Meldedatum": 921,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36140,7 +36140,7 @@
         "Datum_neu": 1665014400000,
         "F\u00e4lle_Meldedatum": 637,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36176,9 +36176,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 668,
+        "F\u00e4lle_Meldedatum": 669,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36214,9 +36214,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665187200000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 237,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36252,9 +36252,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665273600000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36290,13 +36290,13 @@
         "BelegteBetten": null,
         "Inzidenz": 534.7,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 863,
+        "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
-        "Inzidenz_RKI": 419.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 876,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36306,7 +36306,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.10.2022"
@@ -36328,9 +36328,9 @@
         "BelegteBetten": null,
         "Inzidenz": 687.165487266066,
         "Datum_neu": 1665446400000,
-        "F\u00e4lle_Meldedatum": 807,
+        "F\u00e4lle_Meldedatum": 808,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 561.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 876,
@@ -36344,7 +36344,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 25.43,
+        "H_Inzidenz": 26.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.10.2022"
@@ -36366,9 +36366,9 @@
         "BelegteBetten": null,
         "Inzidenz": 726.139588347283,
         "Datum_neu": 1665532800000,
-        "F\u00e4lle_Meldedatum": 613,
+        "F\u00e4lle_Meldedatum": 615,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 604.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
@@ -36382,7 +36382,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.61,
+        "H_Inzidenz": 24.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.10.2022"
@@ -36393,34 +36393,34 @@
         "Datum": "13.10.2022",
         "Fallzahl": 260987,
         "ObjectId": 951,
-        "Sterbefall": 1779,
-        "Genesungsfall": 252473,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6683,
-        "Zuwachs_Fallzahl": 718,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 443,
         "BelegteBetten": null,
         "Inzidenz": 691.116778619922,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 526,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 615.5,
-        "Fallzahl_aktiv": 6735,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
         "Krh_I_belegt": 86,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 275,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 20.21,
+        "H_Inzidenz": 22.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.10.2022"
@@ -36431,26 +36431,26 @@
         "Datum": "14.10.2022",
         "Fallzahl": 261267,
         "ObjectId": 952,
-        "Sterbefall": 1779,
-        "Genesungsfall": 252939,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6710,
-        "Zuwachs_Fallzahl": 280,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 27,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 466,
         "BelegteBetten": null,
         "Inzidenz": 639.211178562448,
         "Datum_neu": 1665705600000,
-        "F\u00e4lle_Meldedatum": 378,
+        "F\u00e4lle_Meldedatum": 514,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 616.7,
-        "Fallzahl_aktiv": 6549,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
         "Krh_I_belegt": 86,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -186,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36458,7 +36458,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 18.08,
+        "H_Inzidenz": 20.83,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.10.2022"
@@ -36470,7 +36470,7 @@
         "Fallzahl": 262077,
         "ObjectId": 953,
         "Sterbefall": null,
-        "Genesungsfall": 253068,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -36480,9 +36480,9 @@
         "BelegteBetten": null,
         "Inzidenz": 641,
         "Datum_neu": 1665792000000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 204,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 515.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
@@ -36496,7 +36496,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.06,
+        "H_Inzidenz": 18.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.10.2022"
@@ -36508,7 +36508,7 @@
         "Fallzahl": 262131,
         "ObjectId": 954,
         "Sterbefall": null,
-        "Genesungsfall": 253188,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -36518,7 +36518,7 @@
         "BelegteBetten": null,
         "Inzidenz": 622,
         "Datum_neu": 1665878400000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 473.2,
@@ -36534,7 +36534,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.07,
+        "H_Inzidenz": 18.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.10.2022"
@@ -36547,7 +36547,7 @@
         "ObjectId": 955,
         "Sterbefall": 1779,
         "Genesungsfall": 253360,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6729,
         "Zuwachs_Fallzahl": 885,
         "Zuwachs_Sterbefall": 0,
@@ -36556,9 +36556,9 @@
         "BelegteBetten": null,
         "Inzidenz": 605.445597902224,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 510,
         "Zeitraum": "10.10.2022 - 16.10.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 447.3,
         "Fallzahl_aktiv": 7013,
         "Krh_N_belegt": 1190,
@@ -36572,11 +36572,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.11,
+        "H_Inzidenz": 17.73,
         "H_Zeitraum": "10.10.2022 - 16.10.2022",
         "H_Datum": "11.10.2022",
         "Datum_Bett": "16.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.10.2022",
+        "Fallzahl": 262962,
+        "ObjectId": 956,
+        "Sterbefall": 1779,
+        "Genesungsfall": 254210,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6744,
+        "Zuwachs_Fallzahl": 810,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 850,
+        "BelegteBetten": null,
+        "Inzidenz": 588.203599267215,
+        "Datum_neu": 1666051200000,
+        "F\u00e4lle_Meldedatum": 59,
+        "Zeitraum": "11.10.2022 - 17.10.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 493,
+        "Fallzahl_aktiv": 6973,
+        "Krh_N_belegt": 1190,
+        "Krh_I_belegt": 86,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -40,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.9,
+        "H_Zeitraum": "11.10.2022 - 17.10.2022",
+        "H_Datum": "11.10.2022",
+        "Datum_Bett": "17.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
