### PR TITLE
New data set: 2022-10-19T095603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-18T101103Z.json
+pjson/2022-10-19T095603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-18T101103Z.json pjson/2022-10-19T095603Z.json```:
```
--- pjson/2022-10-18T101103Z.json	2022-10-18 10:11:04.333229608 +0000
+++ pjson/2022-10-19T095603Z.json	2022-10-19 09:56:03.874656766 +0000
@@ -34732,7 +34732,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661817600000,
-        "F\u00e4lle_Meldedatum": 315,
+        "F\u00e4lle_Meldedatum": 314,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -35378,7 +35378,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663286400000,
-        "F\u00e4lle_Meldedatum": 254,
+        "F\u00e4lle_Meldedatum": 253,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -35466,7 +35466,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -35542,7 +35542,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -35656,7 +35656,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -35694,7 +35694,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36074,7 +36074,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36150,7 +36150,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36188,7 +36188,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36226,7 +36226,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36288,7 +36288,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 521,
         "BelegteBetten": null,
-        "Inzidenz": 534.7,
+        "Inzidenz": null,
         "Datum_neu": 1665360000000,
         "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
@@ -36326,15 +36326,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 577,
         "BelegteBetten": null,
-        "Inzidenz": 687.165487266066,
+        "Inzidenz": null,
         "Datum_neu": 1665446400000,
-        "F\u00e4lle_Meldedatum": 808,
+        "F\u00e4lle_Meldedatum": 809,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
-        "Inzidenz_RKI": 561.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 876,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36344,7 +36344,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 26.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.10.2022"
@@ -36366,7 +36366,7 @@
         "BelegteBetten": null,
         "Inzidenz": 726.139588347283,
         "Datum_neu": 1665532800000,
-        "F\u00e4lle_Meldedatum": 615,
+        "F\u00e4lle_Meldedatum": 618,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": 604.7,
@@ -36404,7 +36404,7 @@
         "BelegteBetten": null,
         "Inzidenz": 691.116778619922,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 615.5,
@@ -36442,7 +36442,7 @@
         "BelegteBetten": null,
         "Inzidenz": 639.211178562448,
         "Datum_neu": 1665705600000,
-        "F\u00e4lle_Meldedatum": 514,
+        "F\u00e4lle_Meldedatum": 525,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 616.7,
@@ -36480,7 +36480,7 @@
         "BelegteBetten": null,
         "Inzidenz": 641,
         "Datum_neu": 1665792000000,
-        "F\u00e4lle_Meldedatum": 204,
+        "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 515.5,
@@ -36518,9 +36518,9 @@
         "BelegteBetten": null,
         "Inzidenz": 622,
         "Datum_neu": 1665878400000,
-        "F\u00e4lle_Meldedatum": 82,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 473.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
@@ -36556,9 +36556,9 @@
         "BelegteBetten": null,
         "Inzidenz": 605.445597902224,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 510,
-        "Zeitraum": "10.10.2022 - 16.10.2022",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 636,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 447.3,
         "Fallzahl_aktiv": 7013,
         "Krh_N_belegt": 1190,
@@ -36573,8 +36573,8 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 17.73,
-        "H_Zeitraum": "10.10.2022 - 16.10.2022",
-        "H_Datum": "11.10.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.10.2022"
       }
     },
@@ -36585,7 +36585,7 @@
         "ObjectId": 956,
         "Sterbefall": 1779,
         "Genesungsfall": 254210,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6744,
         "Zuwachs_Fallzahl": 810,
         "Zuwachs_Sterbefall": 0,
@@ -36594,9 +36594,9 @@
         "BelegteBetten": null,
         "Inzidenz": 588.203599267215,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 675,
         "Zeitraum": "11.10.2022 - 17.10.2022",
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 493,
         "Fallzahl_aktiv": 6973,
         "Krh_N_belegt": 1190,
@@ -36615,6 +36615,44 @@
         "H_Datum": "11.10.2022",
         "Datum_Bett": "17.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "19.10.2022",
+        "Fallzahl": 263852,
+        "ObjectId": 957,
+        "Sterbefall": 1787,
+        "Genesungsfall": 255121,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6772,
+        "Zuwachs_Fallzahl": 890,
+        "Zuwachs_Sterbefall": 8,
+        "Zuwachs_Krankenhauseinweisung": 28,
+        "Zuwachs_Genesung": 911,
+        "BelegteBetten": null,
+        "Inzidenz": 605.80480620712,
+        "Datum_neu": 1666137600000,
+        "F\u00e4lle_Meldedatum": 44,
+        "Zeitraum": "12.10.2022 - 18.10.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 428.4,
+        "Fallzahl_aktiv": 6944,
+        "Krh_N_belegt": 1283,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -29,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.9,
+        "H_Zeitraum": "12.10.2022 - 18.10.2022",
+        "H_Datum": "18.10.2022",
+        "Datum_Bett": "18.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
