### PR TITLE
New data set: 2022-10-20T095204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-19T095603Z.json
+pjson/2022-10-20T095204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-19T095603Z.json pjson/2022-10-20T095204Z.json```:
```
--- pjson/2022-10-19T095603Z.json	2022-10-19 09:56:03.874656766 +0000
+++ pjson/2022-10-20T095204Z.json	2022-10-20 09:52:04.747572557 +0000
@@ -36290,7 +36290,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 864,
+        "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -36369,10 +36369,10 @@
         "F\u00e4lle_Meldedatum": 618,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
-        "Inzidenz_RKI": 604.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1190,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36382,7 +36382,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 24.59,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.10.2022"
@@ -36404,7 +36404,7 @@
         "BelegteBetten": null,
         "Inzidenz": 691.116778619922,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 547,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 615.5,
@@ -36420,7 +36420,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.56,
+        "H_Inzidenz": 24.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.10.2022"
@@ -36442,7 +36442,7 @@
         "BelegteBetten": null,
         "Inzidenz": 639.211178562448,
         "Datum_neu": 1665705600000,
-        "F\u00e4lle_Meldedatum": 525,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 616.7,
@@ -36458,7 +36458,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 20.83,
+        "H_Inzidenz": 23.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.10.2022"
@@ -36480,7 +36480,7 @@
         "BelegteBetten": null,
         "Inzidenz": 641,
         "Datum_neu": 1665792000000,
-        "F\u00e4lle_Meldedatum": 247,
+        "F\u00e4lle_Meldedatum": 255,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 515.5,
@@ -36496,7 +36496,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 18.95,
+        "H_Inzidenz": 23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.10.2022"
@@ -36534,7 +36534,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 18.35,
+        "H_Inzidenz": 22.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.10.2022"
@@ -36545,34 +36545,34 @@
         "Datum": "17.10.2022",
         "Fallzahl": 262152,
         "ObjectId": 955,
-        "Sterbefall": 1779,
-        "Genesungsfall": 253360,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6729,
-        "Zuwachs_Fallzahl": 885,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 421,
         "BelegteBetten": null,
         "Inzidenz": 605.445597902224,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 636,
+        "F\u00e4lle_Meldedatum": 655,
         "Zeitraum": null,
         "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": 447.3,
-        "Fallzahl_aktiv": 7013,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
         "Krh_I_belegt": 86,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 464,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 17.73,
+        "H_Inzidenz": 23.2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.10.2022"
@@ -36583,26 +36583,26 @@
         "Datum": "18.10.2022",
         "Fallzahl": 262962,
         "ObjectId": 956,
-        "Sterbefall": 1779,
-        "Genesungsfall": 254210,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6744,
-        "Zuwachs_Fallzahl": 810,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 850,
         "BelegteBetten": null,
         "Inzidenz": 588.203599267215,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 675,
-        "Zeitraum": "11.10.2022 - 17.10.2022",
-        "Hosp_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 707,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 493,
-        "Fallzahl_aktiv": 6973,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
         "Krh_I_belegt": 86,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -40,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36610,9 +36610,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.9,
-        "H_Zeitraum": "11.10.2022 - 17.10.2022",
-        "H_Datum": "11.10.2022",
+        "H_Inzidenz": 22.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.10.2022"
       }
     },
@@ -36623,7 +36623,7 @@
         "ObjectId": 957,
         "Sterbefall": 1787,
         "Genesungsfall": 255121,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6772,
         "Zuwachs_Fallzahl": 890,
         "Zuwachs_Sterbefall": 8,
@@ -36632,9 +36632,9 @@
         "BelegteBetten": null,
         "Inzidenz": 605.80480620712,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 418,
         "Zeitraum": "12.10.2022 - 18.10.2022",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 428.4,
         "Fallzahl_aktiv": 6944,
         "Krh_N_belegt": 1283,
@@ -36648,11 +36648,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.9,
+        "H_Inzidenz": 20.6,
         "H_Zeitraum": "12.10.2022 - 18.10.2022",
         "H_Datum": "18.10.2022",
         "Datum_Bett": "18.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.10.2023",
+        "Fallzahl": 264343,
+        "ObjectId": 958,
+        "Sterbefall": 1787,
+        "Genesungsfall": 255745,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6785,
+        "Zuwachs_Fallzahl": 491,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 624,
+        "BelegteBetten": null,
+        "Inzidenz": 581.019433169295,
+        "Datum_neu": 1697760000000,
+        "F\u00e4lle_Meldedatum": 53,
+        "Zeitraum": "13.10.2022 - 19.10.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 511.4,
+        "Fallzahl_aktiv": 6811,
+        "Krh_N_belegt": 1283,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -133,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 17.39,
+        "H_Zeitraum": "13.10.2022 - 19.10.2022",
+        "H_Datum": "18.10.2022",
+        "Datum_Bett": "19.10.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
