### PR TITLE
New data set: 2022-10-21T100004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-19T095603Z.json
+pjson/2022-10-21T100004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-20T095204Z.json pjson/2022-10-21T100004Z.json```:
```
--- pjson/2022-10-20T095204Z.json	2022-10-20 09:52:04.747572557 +0000
+++ pjson/2022-10-21T100004Z.json	2022-10-21 10:00:04.429232877 +0000
@@ -35948,7 +35948,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664582400000,
-        "F\u00e4lle_Meldedatum": 131,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -36062,7 +36062,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 861,
+        "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -36290,7 +36290,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 866,
+        "F\u00e4lle_Meldedatum": 867,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -36364,9 +36364,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 521,
         "BelegteBetten": null,
-        "Inzidenz": 726.139588347283,
+        "Inzidenz": null,
         "Datum_neu": 1665532800000,
-        "F\u00e4lle_Meldedatum": 618,
+        "F\u00e4lle_Meldedatum": 619,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -36404,13 +36404,13 @@
         "BelegteBetten": null,
         "Inzidenz": 691.116778619922,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 547,
+        "F\u00e4lle_Meldedatum": 548,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 615.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1190,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36420,7 +36420,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 24.93,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.10.2022"
@@ -36458,7 +36458,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.87,
+        "H_Inzidenz": 24.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.10.2022"
@@ -36480,7 +36480,7 @@
         "BelegteBetten": null,
         "Inzidenz": 641,
         "Datum_neu": 1665792000000,
-        "F\u00e4lle_Meldedatum": 255,
+        "F\u00e4lle_Meldedatum": 256,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 515.5,
@@ -36496,7 +36496,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23,
+        "H_Inzidenz": 23.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.10.2022"
@@ -36534,7 +36534,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.8,
+        "H_Inzidenz": 23.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.10.2022"
@@ -36556,9 +36556,9 @@
         "BelegteBetten": null,
         "Inzidenz": 605.445597902224,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 655,
+        "F\u00e4lle_Meldedatum": 662,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 447.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1190,
@@ -36572,7 +36572,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.2,
+        "H_Inzidenz": 24.21,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.10.2022"
@@ -36594,7 +36594,7 @@
         "BelegteBetten": null,
         "Inzidenz": 588.203599267215,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 707,
+        "F\u00e4lle_Meldedatum": 711,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 493,
@@ -36610,7 +36610,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.41,
+        "H_Inzidenz": 23.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.10.2022"
@@ -36621,26 +36621,26 @@
         "Datum": "19.10.2022",
         "Fallzahl": 263852,
         "ObjectId": 957,
-        "Sterbefall": 1787,
-        "Genesungsfall": 255121,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6772,
-        "Zuwachs_Fallzahl": 890,
-        "Zuwachs_Sterbefall": 8,
-        "Zuwachs_Krankenhauseinweisung": 28,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 911,
         "BelegteBetten": null,
         "Inzidenz": 605.80480620712,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 418,
-        "Zeitraum": "12.10.2022 - 18.10.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 444,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 428.4,
-        "Fallzahl_aktiv": 6944,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
         "Krh_I_belegt": 103,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -29,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36648,20 +36648,20 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 20.6,
-        "H_Zeitraum": "12.10.2022 - 18.10.2022",
-        "H_Datum": "18.10.2022",
+        "H_Inzidenz": 22.68,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "18.10.2022"
       }
     },
     {
       "attributes": {
-        "Datum": "20.10.2023",
+        "Datum": "20.10.2022",
         "Fallzahl": 264343,
         "ObjectId": 958,
         "Sterbefall": 1787,
         "Genesungsfall": 255745,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6785,
         "Zuwachs_Fallzahl": 491,
         "Zuwachs_Sterbefall": 0,
@@ -36669,10 +36669,10 @@
         "Zuwachs_Genesung": 624,
         "BelegteBetten": null,
         "Inzidenz": 581.019433169295,
-        "Datum_neu": 1697760000000,
-        "F\u00e4lle_Meldedatum": 53,
-        "Zeitraum": "13.10.2022 - 19.10.2022",
-        "Hosp_Meldedatum": 1,
+        "Datum_neu": 1666224000000,
+        "F\u00e4lle_Meldedatum": 376,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 511.4,
         "Fallzahl_aktiv": 6811,
         "Krh_N_belegt": 1283,
@@ -36686,10 +36686,48 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 17.39,
-        "H_Zeitraum": "13.10.2022 - 19.10.2022",
-        "H_Datum": "18.10.2022",
-        "Datum_Bett": "19.10.2023"
+        "H_Inzidenz": 20.43,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.10.2022",
+        "Fallzahl": 264763,
+        "ObjectId": 959,
+        "Sterbefall": 1787,
+        "Genesungsfall": 256407,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6807,
+        "Zuwachs_Fallzahl": 420,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 22,
+        "Zuwachs_Genesung": 662,
+        "BelegteBetten": null,
+        "Inzidenz": 557.13208089371,
+        "Datum_neu": 1666310400000,
+        "F\u00e4lle_Meldedatum": 56,
+        "Zeitraum": "14.10.2022 - 20.10.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 506.5,
+        "Fallzahl_aktiv": 6569,
+        "Krh_N_belegt": 1283,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -242,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 17.46,
+        "H_Zeitraum": "14.10.2022 - 20.10.2022",
+        "H_Datum": "20.10.2022",
+        "Datum_Bett": "20.10.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
