### PR TITLE
New data set: 2022-10-24T101403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-19T095603Z.json
+pjson/2022-10-24T101403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-21T100004Z.json pjson/2022-10-24T101403Z.json```:
```
--- pjson/2022-10-21T100004Z.json	2022-10-21 10:00:04.429232877 +0000
+++ pjson/2022-10-24T101403Z.json	2022-10-24 10:14:04.274161291 +0000
@@ -36064,7 +36064,7 @@
         "Datum_neu": 1664841600000,
         "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 33,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36138,7 +36138,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665014400000,
-        "F\u00e4lle_Meldedatum": 637,
+        "F\u00e4lle_Meldedatum": 638,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -36302,7 +36302,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36402,7 +36402,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 443,
         "BelegteBetten": null,
-        "Inzidenz": 691.116778619922,
+        "Inzidenz": null,
         "Datum_neu": 1665619200000,
         "F\u00e4lle_Meldedatum": 548,
         "Zeitraum": null,
@@ -36440,25 +36440,25 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 466,
         "BelegteBetten": null,
-        "Inzidenz": 639.211178562448,
+        "Inzidenz": null,
         "Datum_neu": 1665705600000,
         "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 616.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1190,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 24.73,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.10.2022"
@@ -36478,15 +36478,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 641,
+        "Inzidenz": null,
         "Datum_neu": 1665792000000,
         "F\u00e4lle_Meldedatum": 256,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 515.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1190,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36496,7 +36496,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.94,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.10.2022"
@@ -36516,15 +36516,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 622,
+        "Inzidenz": null,
         "Datum_neu": 1665878400000,
         "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 473.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1190,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36534,7 +36534,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.89,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.10.2022"
@@ -36556,7 +36556,7 @@
         "BelegteBetten": null,
         "Inzidenz": 605.445597902224,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 662,
+        "F\u00e4lle_Meldedatum": 665,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 447.3,
@@ -36572,7 +36572,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 24.21,
+        "H_Inzidenz": 24.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.10.2022"
@@ -36594,7 +36594,7 @@
         "BelegteBetten": null,
         "Inzidenz": 588.203599267215,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 711,
+        "F\u00e4lle_Meldedatum": 719,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 493,
@@ -36610,7 +36610,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.72,
+        "H_Inzidenz": 24.41,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.10.2022"
@@ -36632,9 +36632,9 @@
         "BelegteBetten": null,
         "Inzidenz": 605.80480620712,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 444,
+        "F\u00e4lle_Meldedatum": 450,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 428.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
@@ -36648,7 +36648,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.68,
+        "H_Inzidenz": 23.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.10.2022"
@@ -36659,26 +36659,26 @@
         "Datum": "20.10.2022",
         "Fallzahl": 264343,
         "ObjectId": 958,
-        "Sterbefall": 1787,
-        "Genesungsfall": 255745,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6785,
-        "Zuwachs_Fallzahl": 491,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 13,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 624,
         "BelegteBetten": null,
         "Inzidenz": 581.019433169295,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 376,
+        "F\u00e4lle_Meldedatum": 408,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 511.4,
-        "Fallzahl_aktiv": 6811,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
         "Krh_I_belegt": 103,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -133,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36686,7 +36686,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 20.43,
+        "H_Inzidenz": 21.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.10.2022"
@@ -36698,8 +36698,8 @@
         "Fallzahl": 264763,
         "ObjectId": 959,
         "Sterbefall": 1787,
-        "Genesungsfall": 256407,
-        "Anzeige_Indikator": "x",
+        "Genesungsfall": 256406,
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6807,
         "Zuwachs_Fallzahl": 420,
         "Zuwachs_Sterbefall": 0,
@@ -36708,11 +36708,11 @@
         "BelegteBetten": null,
         "Inzidenz": 557.13208089371,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 56,
-        "Zeitraum": "14.10.2022 - 20.10.2022",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 381,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 506.5,
-        "Fallzahl_aktiv": 6569,
+        "Fallzahl_aktiv": 6570,
         "Krh_N_belegt": 1283,
         "Krh_I_belegt": 103,
         "Krh_I_frei": null,
@@ -36724,11 +36724,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 17.46,
-        "H_Zeitraum": "14.10.2022 - 20.10.2022",
-        "H_Datum": "20.10.2022",
+        "H_Inzidenz": 19.74,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.10.2022",
+        "Fallzahl": 264820,
+        "ObjectId": 960,
+        "Sterbefall": null,
+        "Genesungsfall": 256653,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 247,
+        "BelegteBetten": null,
+        "Inzidenz": 472.5385250907,
+        "Datum_neu": 1666396800000,
+        "F\u00e4lle_Meldedatum": 150,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 469.1,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1283,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 17.24,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "21.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.10.2022",
+        "Fallzahl": 264878,
+        "ObjectId": 961,
+        "Sterbefall": null,
+        "Genesungsfall": 256805,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 152,
+        "BelegteBetten": null,
+        "Inzidenz": 436.797298753547,
+        "Datum_neu": 1666483200000,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 423,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1283,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 16.23,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.10.2022",
+        "Fallzahl": 265371,
+        "ObjectId": 962,
+        "Sterbefall": 1789,
+        "Genesungsfall": 257634,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6818,
+        "Zuwachs_Fallzahl": 493,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 829,
+        "BelegteBetten": null,
+        "Inzidenz": 506.842918208269,
+        "Datum_neu": 1666569600000,
+        "F\u00e4lle_Meldedatum": 34,
+        "Zeitraum": "17.10.2022 - 23.10.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 506.5,
+        "Fallzahl_aktiv": 5948,
+        "Krh_N_belegt": 1283,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -338,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 14.79,
+        "H_Zeitraum": "17.10.2022 - 24.10.2022",
+        "H_Datum": "18.10.2022",
+        "Datum_Bett": "23.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
