### PR TITLE
New data set: 2022-10-25T095804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-24T101403Z.json
+pjson/2022-10-25T095804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-24T101403Z.json pjson/2022-10-25T095804Z.json```:
```
--- pjson/2022-10-24T101403Z.json	2022-10-24 10:14:04.274161291 +0000
+++ pjson/2022-10-25T095804Z.json	2022-10-25 09:58:04.947310529 +0000
@@ -35492,7 +35492,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 380,
+        "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -36442,9 +36442,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665705600000,
-        "F\u00e4lle_Meldedatum": 527,
+        "F\u00e4lle_Meldedatum": 528,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36552,17 +36552,17 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 421,
+        "Zuwachs_Genesung": 420,
         "BelegteBetten": null,
-        "Inzidenz": 605.445597902224,
+        "Inzidenz": null,
         "Datum_neu": 1665964800000,
         "F\u00e4lle_Meldedatum": 665,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
-        "Inzidenz_RKI": 447.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1190,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36572,7 +36572,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 24.93,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.10.2022"
@@ -36632,7 +36632,7 @@
         "BelegteBetten": null,
         "Inzidenz": 605.80480620712,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 450,
+        "F\u00e4lle_Meldedatum": 451,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 428.4,
@@ -36670,9 +36670,9 @@
         "BelegteBetten": null,
         "Inzidenz": 581.019433169295,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 408,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 511.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
@@ -36697,26 +36697,26 @@
         "Datum": "21.10.2022",
         "Fallzahl": 264763,
         "ObjectId": 959,
-        "Sterbefall": 1787,
-        "Genesungsfall": 256406,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6807,
-        "Zuwachs_Fallzahl": 420,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 22,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 662,
         "BelegteBetten": null,
         "Inzidenz": 557.13208089371,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 381,
+        "F\u00e4lle_Meldedatum": 405,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 506.5,
-        "Fallzahl_aktiv": 6570,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
         "Krh_I_belegt": 103,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -242,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36736,7 +36736,7 @@
         "Fallzahl": 264820,
         "ObjectId": 960,
         "Sterbefall": null,
-        "Genesungsfall": 256653,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -36746,7 +36746,7 @@
         "BelegteBetten": null,
         "Inzidenz": 472.5385250907,
         "Datum_neu": 1666396800000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 180,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 469.1,
@@ -36774,7 +36774,7 @@
         "Fallzahl": 264878,
         "ObjectId": 961,
         "Sterbefall": null,
-        "Genesungsfall": 256805,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -36784,7 +36784,7 @@
         "BelegteBetten": null,
         "Inzidenz": 436.797298753547,
         "Datum_neu": 1666483200000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 423,
@@ -36813,7 +36813,7 @@
         "ObjectId": 962,
         "Sterbefall": 1789,
         "Genesungsfall": 257634,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6818,
         "Zuwachs_Fallzahl": 493,
         "Zuwachs_Sterbefall": 2,
@@ -36822,9 +36822,9 @@
         "BelegteBetten": null,
         "Inzidenz": 506.842918208269,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 436,
         "Zeitraum": "17.10.2022 - 23.10.2022",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 506.5,
         "Fallzahl_aktiv": 5948,
         "Krh_N_belegt": 1283,
@@ -36843,6 +36843,44 @@
         "H_Datum": "18.10.2022",
         "Datum_Bett": "23.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.10.2022",
+        "Fallzahl": 265925,
+        "ObjectId": 963,
+        "Sterbefall": 1789,
+        "Genesungsfall": 258414,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6828,
+        "Zuwachs_Fallzahl": 554,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 780,
+        "BelegteBetten": null,
+        "Inzidenz": 481.5187327131,
+        "Datum_neu": 1666656000000,
+        "F\u00e4lle_Meldedatum": 62,
+        "Zeitraum": "18.10.2022 - 24.10.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 406.9,
+        "Fallzahl_aktiv": 5722,
+        "Krh_N_belegt": 1283,
+        "Krh_I_belegt": 103,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -226,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 14.79,
+        "H_Zeitraum": "18.10.2022 - 25.10.2022",
+        "H_Datum": "18.10.2022",
+        "Datum_Bett": "24.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
