### PR TITLE
New data set: 2022-10-26T100004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-25T095804Z.json
+pjson/2022-10-26T100004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-25T095804Z.json pjson/2022-10-26T100004Z.json```:
```
--- pjson/2022-10-25T095804Z.json	2022-10-25 09:58:04.947310529 +0000
+++ pjson/2022-10-26T100004Z.json	2022-10-26 10:00:04.741561879 +0000
@@ -33592,7 +33592,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659225600000,
-        "F\u00e4lle_Meldedatum": 58,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -33668,7 +33668,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1659398400000,
-        "F\u00e4lle_Meldedatum": 554,
+        "F\u00e4lle_Meldedatum": 553,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -33934,7 +33934,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 459,
+        "F\u00e4lle_Meldedatum": 460,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -36480,7 +36480,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665792000000,
-        "F\u00e4lle_Meldedatum": 256,
+        "F\u00e4lle_Meldedatum": 257,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -36594,13 +36594,13 @@
         "BelegteBetten": null,
         "Inzidenz": 588.203599267215,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 719,
+        "F\u00e4lle_Meldedatum": 718,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 493,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1190,
-        "Krh_I_belegt": 86,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36610,7 +36610,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 24.41,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.10.2022"
@@ -36632,7 +36632,7 @@
         "BelegteBetten": null,
         "Inzidenz": 605.80480620712,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 451,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 428.4,
@@ -36648,7 +36648,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.5,
+        "H_Inzidenz": 25.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.10.2022"
@@ -36670,7 +36670,7 @@
         "BelegteBetten": null,
         "Inzidenz": 581.019433169295,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 410,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 511.4,
@@ -36686,7 +36686,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21.44,
+        "H_Inzidenz": 23.35,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.10.2022"
@@ -36708,9 +36708,9 @@
         "BelegteBetten": null,
         "Inzidenz": 557.13208089371,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 405,
+        "F\u00e4lle_Meldedatum": 410,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 506.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
@@ -36724,7 +36724,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 19.74,
+        "H_Inzidenz": 22.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.10.2022"
@@ -36746,7 +36746,7 @@
         "BelegteBetten": null,
         "Inzidenz": 472.5385250907,
         "Datum_neu": 1666396800000,
-        "F\u00e4lle_Meldedatum": 180,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 469.1,
@@ -36762,7 +36762,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 17.24,
+        "H_Inzidenz": 21.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.10.2022"
@@ -36784,7 +36784,7 @@
         "BelegteBetten": null,
         "Inzidenz": 436.797298753547,
         "Datum_neu": 1666483200000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 94,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 423,
@@ -36800,7 +36800,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.23,
+        "H_Inzidenz": 21.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.10.2022"
@@ -36811,26 +36811,26 @@
         "Datum": "24.10.2022",
         "Fallzahl": 265371,
         "ObjectId": 962,
-        "Sterbefall": 1789,
-        "Genesungsfall": 257634,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6818,
-        "Zuwachs_Fallzahl": 493,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 829,
         "BelegteBetten": null,
         "Inzidenz": 506.842918208269,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 436,
-        "Zeitraum": "17.10.2022 - 23.10.2022",
-        "Hosp_Meldedatum": 4,
+        "F\u00e4lle_Meldedatum": 493,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 506.5,
-        "Fallzahl_aktiv": 5948,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
         "Krh_I_belegt": 103,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -338,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36838,7 +36838,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.79,
+        "H_Inzidenz": 20.33,
         "H_Zeitraum": "17.10.2022 - 24.10.2022",
         "H_Datum": "18.10.2022",
         "Datum_Bett": "23.10.2022"
@@ -36851,7 +36851,7 @@
         "ObjectId": 963,
         "Sterbefall": 1789,
         "Genesungsfall": 258414,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6828,
         "Zuwachs_Fallzahl": 554,
         "Zuwachs_Sterbefall": 0,
@@ -36860,9 +36860,9 @@
         "BelegteBetten": null,
         "Inzidenz": 481.5187327131,
         "Datum_neu": 1666656000000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 483,
         "Zeitraum": "18.10.2022 - 24.10.2022",
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 406.9,
         "Fallzahl_aktiv": 5722,
         "Krh_N_belegt": 1283,
@@ -36876,11 +36876,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.79,
+        "H_Inzidenz": 14.99,
         "H_Zeitraum": "18.10.2022 - 25.10.2022",
         "H_Datum": "18.10.2022",
         "Datum_Bett": "24.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.10.2022",
+        "Fallzahl": 266489,
+        "ObjectId": 964,
+        "Sterbefall": 1789,
+        "Genesungsfall": 259023,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6869,
+        "Zuwachs_Fallzahl": 564,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 41,
+        "Zuwachs_Genesung": 609,
+        "BelegteBetten": null,
+        "Inzidenz": 456.194547217932,
+        "Datum_neu": 1666742400000,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": "19.10.2022 - 25.10.2022",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 404.4,
+        "Fallzahl_aktiv": 5677,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -45,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.3,
+        "H_Zeitraum": "19.10.2022 - 26.10.2022",
+        "H_Datum": "25.10.2022",
+        "Datum_Bett": "25.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
