### PR TITLE
New data set: 2022-10-27T100504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-26T100004Z.json
+pjson/2022-10-27T100504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-26T100004Z.json pjson/2022-10-27T100504Z.json```:
```
--- pjson/2022-10-26T100004Z.json	2022-10-26 10:00:04.741561879 +0000
+++ pjson/2022-10-27T100504Z.json	2022-10-27 10:05:04.703710414 +0000
@@ -36592,7 +36592,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 850,
         "BelegteBetten": null,
-        "Inzidenz": 588.203599267215,
+        "Inzidenz": null,
         "Datum_neu": 1666051200000,
         "F\u00e4lle_Meldedatum": 718,
         "Zeitraum": null,
@@ -36630,15 +36630,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 911,
         "BelegteBetten": null,
-        "Inzidenz": 605.80480620712,
+        "Inzidenz": null,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 455,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 428.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1283,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36648,7 +36648,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 25.03,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.10.2022"
@@ -36670,7 +36670,7 @@
         "BelegteBetten": null,
         "Inzidenz": 581.019433169295,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 511.4,
@@ -36686,7 +36686,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.35,
+        "H_Inzidenz": 23.62,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.10.2022"
@@ -36708,7 +36708,7 @@
         "BelegteBetten": null,
         "Inzidenz": 557.13208089371,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 410,
+        "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 506.5,
@@ -36724,7 +36724,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.53,
+        "H_Inzidenz": 22.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.10.2022"
@@ -36746,7 +36746,7 @@
         "BelegteBetten": null,
         "Inzidenz": 472.5385250907,
         "Datum_neu": 1666396800000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 469.1,
@@ -36762,7 +36762,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21.47,
+        "H_Inzidenz": 21.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.10.2022"
@@ -36800,7 +36800,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21.07,
+        "H_Inzidenz": 21.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.10.2022"
@@ -36822,7 +36822,7 @@
         "BelegteBetten": null,
         "Inzidenz": 506.842918208269,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 493,
+        "F\u00e4lle_Meldedatum": 507,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 506.5,
@@ -36838,9 +36838,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 20.33,
-        "H_Zeitraum": "17.10.2022 - 24.10.2022",
-        "H_Datum": "18.10.2022",
+        "H_Inzidenz": 20.7,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "23.10.2022"
       }
     },
@@ -36849,26 +36849,26 @@
         "Datum": "25.10.2022",
         "Fallzahl": 265925,
         "ObjectId": 963,
-        "Sterbefall": 1789,
-        "Genesungsfall": 258414,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6828,
-        "Zuwachs_Fallzahl": 554,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 780,
         "BelegteBetten": null,
         "Inzidenz": 481.5187327131,
         "Datum_neu": 1666656000000,
-        "F\u00e4lle_Meldedatum": 483,
-        "Zeitraum": "18.10.2022 - 24.10.2022",
-        "Hosp_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 542,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 406.9,
-        "Fallzahl_aktiv": 5722,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1283,
         "Krh_I_belegt": 103,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -226,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36876,9 +36876,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.99,
-        "H_Zeitraum": "18.10.2022 - 25.10.2022",
-        "H_Datum": "18.10.2022",
+        "H_Inzidenz": 16.08,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.10.2022"
       }
     },
@@ -36889,7 +36889,7 @@
         "ObjectId": 964,
         "Sterbefall": 1789,
         "Genesungsfall": 259023,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6869,
         "Zuwachs_Fallzahl": 564,
         "Zuwachs_Sterbefall": 0,
@@ -36898,8 +36898,8 @@
         "BelegteBetten": null,
         "Inzidenz": 456.194547217932,
         "Datum_neu": 1666742400000,
-        "F\u00e4lle_Meldedatum": 47,
-        "Zeitraum": "19.10.2022 - 25.10.2022",
+        "F\u00e4lle_Meldedatum": 337,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 404.4,
         "Fallzahl_aktiv": 5677,
@@ -36914,11 +36914,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.3,
-        "H_Zeitraum": "19.10.2022 - 26.10.2022",
-        "H_Datum": "25.10.2022",
+        "H_Inzidenz": 13.28,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.10.2022",
+        "Fallzahl": 266892,
+        "ObjectId": 965,
+        "Sterbefall": 1789,
+        "Genesungsfall": 259571,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6874,
+        "Zuwachs_Fallzahl": 403,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 548,
+        "BelegteBetten": null,
+        "Inzidenz": 449.728797729804,
+        "Datum_neu": 1666828800000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "20.10.2022 - 26.10.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 404.2,
+        "Fallzahl_aktiv": 5532,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -145,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.01,
+        "H_Zeitraum": "20.10.2022 - 27.10.2022",
+        "H_Datum": "25.10.2022",
+        "Datum_Bett": "26.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
