### PR TITLE
New data set: 2022-10-28T100104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-27T100504Z.json
+pjson/2022-10-28T100104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-27T100504Z.json pjson/2022-10-28T100104Z.json```:
```
--- pjson/2022-10-27T100504Z.json	2022-10-27 10:05:04.703710414 +0000
+++ pjson/2022-10-28T100104Z.json	2022-10-28 10:01:05.061823221 +0000
@@ -35492,7 +35492,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 381,
+        "F\u00e4lle_Meldedatum": 380,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -36378,7 +36378,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36404,7 +36404,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 548,
+        "F\u00e4lle_Meldedatum": 549,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -36530,7 +36530,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36568,7 +36568,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36594,7 +36594,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 718,
+        "F\u00e4lle_Meldedatum": 719,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -36634,7 +36634,7 @@
         "Datum_neu": 1666137600000,
         "F\u00e4lle_Meldedatum": 455,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36668,15 +36668,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 624,
         "BelegteBetten": null,
-        "Inzidenz": 581.019433169295,
+        "Inzidenz": null,
         "Datum_neu": 1666224000000,
         "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 511.4,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1283,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36686,7 +36686,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.62,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.10.2022"
@@ -36708,7 +36708,7 @@
         "BelegteBetten": null,
         "Inzidenz": 557.13208089371,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 411,
+        "F\u00e4lle_Meldedatum": 413,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 506.5,
@@ -36724,7 +36724,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.8,
+        "H_Inzidenz": 23.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.10.2022"
@@ -36762,7 +36762,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21.69,
+        "H_Inzidenz": 22.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.10.2022"
@@ -36800,7 +36800,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21.32,
+        "H_Inzidenz": 21.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.10.2022"
@@ -36822,7 +36822,7 @@
         "BelegteBetten": null,
         "Inzidenz": 506.842918208269,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 507,
+        "F\u00e4lle_Meldedatum": 511,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 506.5,
@@ -36838,7 +36838,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 20.7,
+        "H_Inzidenz": 21.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.10.2022"
@@ -36860,7 +36860,7 @@
         "BelegteBetten": null,
         "Inzidenz": 481.5187327131,
         "Datum_neu": 1666656000000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 406.9,
@@ -36876,7 +36876,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.08,
+        "H_Inzidenz": 16.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.10.2022"
@@ -36887,26 +36887,26 @@
         "Datum": "26.10.2022",
         "Fallzahl": 266489,
         "ObjectId": 964,
-        "Sterbefall": 1789,
-        "Genesungsfall": 259023,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6869,
-        "Zuwachs_Fallzahl": 564,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 41,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 609,
         "BelegteBetten": null,
         "Inzidenz": 456.194547217932,
         "Datum_neu": 1666742400000,
-        "F\u00e4lle_Meldedatum": 337,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 404.4,
-        "Fallzahl_aktiv": 5677,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1189,
         "Krh_I_belegt": 90,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -45,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36914,7 +36914,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.28,
+        "H_Inzidenz": 14.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.10.2022"
@@ -36927,7 +36927,7 @@
         "ObjectId": 965,
         "Sterbefall": 1789,
         "Genesungsfall": 259571,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6874,
         "Zuwachs_Fallzahl": 403,
         "Zuwachs_Sterbefall": 0,
@@ -36936,9 +36936,9 @@
         "BelegteBetten": null,
         "Inzidenz": 449.728797729804,
         "Datum_neu": 1666828800000,
-        "F\u00e4lle_Meldedatum": 31,
-        "Zeitraum": "20.10.2022 - 26.10.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 274,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 404.2,
         "Fallzahl_aktiv": 5532,
         "Krh_N_belegt": 1189,
@@ -36948,14 +36948,52 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 1,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 12.96,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.10.2022",
+        "Fallzahl": 267189,
+        "ObjectId": 966,
+        "Sterbefall": 1795,
+        "Genesungsfall": 260086,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6878,
+        "Zuwachs_Fallzahl": 297,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 515,
+        "BelegteBetten": null,
+        "Inzidenz": 432.307194942347,
+        "Datum_neu": 1666915200000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "21.10.2022 - 27.10.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 391.3,
+        "Fallzahl_aktiv": 5308,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -224,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.01,
-        "H_Zeitraum": "20.10.2022 - 27.10.2022",
+        "H_Inzidenz": 10.29,
+        "H_Zeitraum": "21.10.2022 - 28.10.2022",
         "H_Datum": "25.10.2022",
-        "Datum_Bett": "26.10.2022"
+        "Datum_Bett": "27.10.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
