### PR TITLE
New data set: 2022-11-01T105904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-28T100104Z.json
+pjson/2022-11-01T105904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-10-28T100104Z.json pjson/2022-11-01T105904Z.json```:
```
--- pjson/2022-10-28T100104Z.json	2022-10-28 10:01:05.061823221 +0000
+++ pjson/2022-11-01T105904Z.json	2022-11-01 10:59:04.859035673 +0000
@@ -35492,7 +35492,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 380,
+        "F\u00e4lle_Meldedatum": 381,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -35872,7 +35872,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664409600000,
-        "F\u00e4lle_Meldedatum": 448,
+        "F\u00e4lle_Meldedatum": 449,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -35910,7 +35910,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664496000000,
-        "F\u00e4lle_Meldedatum": 478,
+        "F\u00e4lle_Meldedatum": 477,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -36062,7 +36062,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 859,
+        "F\u00e4lle_Meldedatum": 860,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -36100,7 +36100,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 921,
+        "F\u00e4lle_Meldedatum": 919,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -36328,7 +36328,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665446400000,
-        "F\u00e4lle_Meldedatum": 809,
+        "F\u00e4lle_Meldedatum": 808,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -36366,7 +36366,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665532800000,
-        "F\u00e4lle_Meldedatum": 619,
+        "F\u00e4lle_Meldedatum": 616,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -36404,7 +36404,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 549,
+        "F\u00e4lle_Meldedatum": 546,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -36594,7 +36594,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 719,
+        "F\u00e4lle_Meldedatum": 720,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -36670,7 +36670,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 417,
+        "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -36708,13 +36708,13 @@
         "BelegteBetten": null,
         "Inzidenz": 557.13208089371,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 413,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 506.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1283,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36724,7 +36724,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 23.15,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.10.2022"
@@ -36749,10 +36749,10 @@
         "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 469.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1283,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36762,7 +36762,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 22.16,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.10.2022"
@@ -36784,13 +36784,13 @@
         "BelegteBetten": null,
         "Inzidenz": 436.797298753547,
         "Datum_neu": 1666483200000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 423,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1283,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36800,7 +36800,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.10.2022"
@@ -36822,13 +36822,13 @@
         "BelegteBetten": null,
         "Inzidenz": 506.842918208269,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 511,
+        "F\u00e4lle_Meldedatum": 512,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 506.5,
+        "Hosp_Meldedatum": 23,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1283,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36838,7 +36838,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 21.25,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.10.2022"
@@ -36876,7 +36876,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.74,
+        "H_Inzidenz": 17.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.10.2022"
@@ -36898,9 +36898,9 @@
         "BelegteBetten": null,
         "Inzidenz": 456.194547217932,
         "Datum_neu": 1666742400000,
-        "F\u00e4lle_Meldedatum": 373,
+        "F\u00e4lle_Meldedatum": 374,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 404.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1189,
@@ -36914,7 +36914,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.3,
+        "H_Inzidenz": 15.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.10.2022"
@@ -36936,9 +36936,9 @@
         "BelegteBetten": null,
         "Inzidenz": 449.728797729804,
         "Datum_neu": 1666828800000,
-        "F\u00e4lle_Meldedatum": 274,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 404.2,
         "Fallzahl_aktiv": 5532,
         "Krh_N_belegt": 1189,
@@ -36952,7 +36952,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.96,
+        "H_Inzidenz": 14.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.10.2022"
@@ -36965,7 +36965,7 @@
         "ObjectId": 966,
         "Sterbefall": 1795,
         "Genesungsfall": 260086,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6878,
         "Zuwachs_Fallzahl": 297,
         "Zuwachs_Sterbefall": 6,
@@ -36974,9 +36974,9 @@
         "BelegteBetten": null,
         "Inzidenz": 432.307194942347,
         "Datum_neu": 1666915200000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "21.10.2022 - 27.10.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 205,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 391.3,
         "Fallzahl_aktiv": 5308,
         "Krh_N_belegt": 1189,
@@ -36990,11 +36990,163 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.29,
-        "H_Zeitraum": "21.10.2022 - 28.10.2022",
-        "H_Datum": "25.10.2022",
+        "H_Inzidenz": 12.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.10.2022",
+        "Fallzahl": 267189,
+        "ObjectId": 967,
+        "Sterbefall": null,
+        "Genesungsfall": 260355,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 359.387909048457,
+        "Datum_neu": 1667001600000,
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 358.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.69,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "28.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.10.2022",
+        "Fallzahl": 267189,
+        "ObjectId": 968,
+        "Sterbefall": null,
+        "Genesungsfall": 260492,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 324.185495168648,
+        "Datum_neu": 1667088000000,
+        "F\u00e4lle_Meldedatum": 38,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 323.6,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.02,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "29.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "31.10.2022",
+        "Fallzahl": 267189,
+        "ObjectId": 969,
+        "Sterbefall": null,
+        "Genesungsfall": 261135,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 307.302704838536,
+        "Datum_neu": 1667174400000,
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": "24.10.2022 - 30.10.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 306.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.15,
+        "H_Zeitraum": "24.10.2022 - 31.10.2022",
+        "H_Datum": "25.10.2022",
+        "Datum_Bett": "30.10.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.11.2022",
+        "Fallzahl": 267590,
+        "ObjectId": 970,
+        "Sterbefall": 1795,
+        "Genesungsfall": 261838,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6896,
+        "Zuwachs_Fallzahl": 401,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 1752,
+        "BelegteBetten": null,
+        "Inzidenz": 286.109414849671,
+        "Datum_neu": 1667260800000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "25.10.2022 - 31.10.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 214.6,
+        "Fallzahl_aktiv": 3957,
+        "Krh_N_belegt": 1189,
+        "Krh_I_belegt": 90,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1351,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.07,
+        "H_Zeitraum": "25.10.2022 - 01.11.2022",
+        "H_Datum": "25.10.2022",
+        "Datum_Bett": "31.10.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
