### PR TITLE
New data set: 2022-11-02T110304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-10-28T100104Z.json
+pjson/2022-11-02T110304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-01T105904Z.json pjson/2022-11-02T110304Z.json```:
```
--- pjson/2022-11-01T105904Z.json	2022-11-01 10:59:04.859035673 +0000
+++ pjson/2022-11-02T110304Z.json	2022-11-02 11:03:04.950746252 +0000
@@ -36100,7 +36100,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664928000000,
-        "F\u00e4lle_Meldedatum": 919,
+        "F\u00e4lle_Meldedatum": 920,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -36176,7 +36176,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 669,
+        "F\u00e4lle_Meldedatum": 670,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -36594,7 +36594,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 720,
+        "F\u00e4lle_Meldedatum": 721,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -36632,7 +36632,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 455,
+        "F\u00e4lle_Meldedatum": 454,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -36670,7 +36670,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 415,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -36706,7 +36706,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 662,
         "BelegteBetten": null,
-        "Inzidenz": 557.13208089371,
+        "Inzidenz": null,
         "Datum_neu": 1666310400000,
         "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
@@ -36744,7 +36744,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 247,
         "BelegteBetten": null,
-        "Inzidenz": 472.5385250907,
+        "Inzidenz": null,
         "Datum_neu": 1666396800000,
         "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
@@ -36782,7 +36782,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 152,
         "BelegteBetten": null,
-        "Inzidenz": 436.797298753547,
+        "Inzidenz": null,
         "Datum_neu": 1666483200000,
         "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
@@ -36820,9 +36820,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 829,
         "BelegteBetten": null,
-        "Inzidenz": 506.842918208269,
+        "Inzidenz": null,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 512,
+        "F\u00e4lle_Meldedatum": 513,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -36858,15 +36858,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 780,
         "BelegteBetten": null,
-        "Inzidenz": 481.5187327131,
+        "Inzidenz": null,
         "Datum_neu": 1666656000000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 545,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 406.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1283,
-        "Krh_I_belegt": 103,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36876,7 +36876,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 17.71,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.10.2022"
@@ -36914,7 +36914,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.43,
+        "H_Inzidenz": 15.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.10.2022"
@@ -36925,26 +36925,26 @@
         "Datum": "27.10.2022",
         "Fallzahl": 266892,
         "ObjectId": 965,
-        "Sterbefall": 1789,
-        "Genesungsfall": 259571,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6874,
-        "Zuwachs_Fallzahl": 403,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 548,
         "BelegteBetten": null,
         "Inzidenz": 449.728797729804,
         "Datum_neu": 1666828800000,
-        "F\u00e4lle_Meldedatum": 294,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 404.2,
-        "Fallzahl_aktiv": 5532,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1189,
         "Krh_I_belegt": 90,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -145,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36952,7 +36952,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.52,
+        "H_Inzidenz": 15.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.10.2022"
@@ -36963,26 +36963,26 @@
         "Datum": "28.10.2022",
         "Fallzahl": 267189,
         "ObjectId": 966,
-        "Sterbefall": 1795,
-        "Genesungsfall": 260086,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6878,
-        "Zuwachs_Fallzahl": 297,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 515,
         "BelegteBetten": null,
         "Inzidenz": 432.307194942347,
         "Datum_neu": 1666915200000,
-        "F\u00e4lle_Meldedatum": 205,
+        "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 391.3,
-        "Fallzahl_aktiv": 5308,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 1189,
         "Krh_I_belegt": 90,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -224,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -36990,7 +36990,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.79,
+        "H_Inzidenz": 14.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.10.2022"
@@ -37002,7 +37002,7 @@
         "Fallzahl": 267189,
         "ObjectId": 967,
         "Sterbefall": null,
-        "Genesungsfall": 260355,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -37012,7 +37012,7 @@
         "BelegteBetten": null,
         "Inzidenz": 359.387909048457,
         "Datum_neu": 1667001600000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 358.9,
@@ -37028,7 +37028,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.69,
+        "H_Inzidenz": 12.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.10.2022"
@@ -37040,7 +37040,7 @@
         "Fallzahl": 267189,
         "ObjectId": 968,
         "Sterbefall": null,
-        "Genesungsfall": 260492,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -37050,7 +37050,7 @@
         "BelegteBetten": null,
         "Inzidenz": 324.185495168648,
         "Datum_neu": 1667088000000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 323.6,
@@ -37062,11 +37062,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.02,
+        "H_Inzidenz": 12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.10.2022"
@@ -37078,7 +37078,7 @@
         "Fallzahl": 267189,
         "ObjectId": 969,
         "Sterbefall": null,
-        "Genesungsfall": 261135,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -37088,8 +37088,8 @@
         "BelegteBetten": null,
         "Inzidenz": 307.302704838536,
         "Datum_neu": 1667174400000,
-        "F\u00e4lle_Meldedatum": 71,
-        "Zeitraum": "24.10.2022 - 30.10.2022",
+        "F\u00e4lle_Meldedatum": 117,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 306.7,
         "Fallzahl_aktiv": null,
@@ -37104,9 +37104,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.15,
-        "H_Zeitraum": "24.10.2022 - 31.10.2022",
-        "H_Datum": "25.10.2022",
+        "H_Inzidenz": 11.4,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "30.10.2022"
       }
     },
@@ -37117,24 +37117,24 @@
         "ObjectId": 970,
         "Sterbefall": 1795,
         "Genesungsfall": 261838,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6896,
-        "Zuwachs_Fallzahl": 401,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1752,
         "BelegteBetten": null,
         "Inzidenz": 286.109414849671,
         "Datum_neu": 1667260800000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "25.10.2022 - 31.10.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 386,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 214.6,
         "Fallzahl_aktiv": 3957,
-        "Krh_N_belegt": 1189,
-        "Krh_I_belegt": 90,
+        "Krh_N_belegt": 995,
+        "Krh_I_belegt": 91,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1351,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37142,11 +37142,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.07,
-        "H_Zeitraum": "25.10.2022 - 01.11.2022",
-        "H_Datum": "25.10.2022",
+        "H_Inzidenz": 8.01,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "31.10.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "02.11.2022",
+        "Fallzahl": 268175,
+        "ObjectId": 971,
+        "Sterbefall": 1796,
+        "Genesungsfall": 262279,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6913,
+        "Zuwachs_Fallzahl": 585,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 441,
+        "BelegteBetten": null,
+        "Inzidenz": 282.696935953159,
+        "Datum_neu": 1667347200000,
+        "F\u00e4lle_Meldedatum": 70,
+        "Zeitraum": "26.10.2022 - 01.11.2022",
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": 213.4,
+        "Fallzahl_aktiv": 4100,
+        "Krh_N_belegt": 995,
+        "Krh_I_belegt": 91,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 143,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.08,
+        "H_Zeitraum": "26.10.2022 - 02.11.2022",
+        "H_Datum": "01.11.2022",
+        "Datum_Bett": "01.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
