### PR TITLE
New data set: 2022-11-03T105708Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-02T110304Z.json
+pjson/2022-11-03T105708Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-02T110304Z.json pjson/2022-11-03T105708Z.json```:
```
--- pjson/2022-11-02T110304Z.json	2022-11-02 11:03:04.950746252 +0000
+++ pjson/2022-11-03T105708Z.json	2022-11-03 10:57:08.565528313 +0000
@@ -36746,7 +36746,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666396800000,
-        "F\u00e4lle_Meldedatum": 196,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -36901,10 +36901,10 @@
         "F\u00e4lle_Meldedatum": 374,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 404.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1189,
-        "Krh_I_belegt": 90,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36914,7 +36914,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.9,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.10.2022"
@@ -36936,7 +36936,7 @@
         "BelegteBetten": null,
         "Inzidenz": 449.728797729804,
         "Datum_neu": 1666828800000,
-        "F\u00e4lle_Meldedatum": 300,
+        "F\u00e4lle_Meldedatum": 301,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 404.2,
@@ -36952,7 +36952,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.19,
+        "H_Inzidenz": 16.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.10.2022"
@@ -36990,7 +36990,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.15,
+        "H_Inzidenz": 15.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.10.2022"
@@ -37012,7 +37012,7 @@
         "BelegteBetten": null,
         "Inzidenz": 359.387909048457,
         "Datum_neu": 1667001600000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 358.9,
@@ -37028,7 +37028,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.27,
+        "H_Inzidenz": 13.65,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.10.2022"
@@ -37050,7 +37050,7 @@
         "BelegteBetten": null,
         "Inzidenz": 324.185495168648,
         "Datum_neu": 1667088000000,
-        "F\u00e4lle_Meldedatum": 76,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 323.6,
@@ -37066,7 +37066,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12,
+        "H_Inzidenz": 13.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.10.2022"
@@ -37088,7 +37088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 307.302704838536,
         "Datum_neu": 1667174400000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 306.7,
@@ -37104,7 +37104,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.4,
+        "H_Inzidenz": 13.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.10.2022"
@@ -37115,10 +37115,10 @@
         "Datum": "01.11.2022",
         "Fallzahl": 267590,
         "ObjectId": 970,
-        "Sterbefall": 1795,
-        "Genesungsfall": 261838,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6896,
+        "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
@@ -37126,11 +37126,11 @@
         "BelegteBetten": null,
         "Inzidenz": 286.109414849671,
         "Datum_neu": 1667260800000,
-        "F\u00e4lle_Meldedatum": 386,
+        "F\u00e4lle_Meldedatum": 417,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 214.6,
-        "Fallzahl_aktiv": 3957,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
         "Krh_I_belegt": 91,
         "Krh_I_frei": null,
@@ -37142,7 +37142,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.01,
+        "H_Inzidenz": 10.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.10.2022"
@@ -37155,7 +37155,7 @@
         "ObjectId": 971,
         "Sterbefall": 1796,
         "Genesungsfall": 262279,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6913,
         "Zuwachs_Fallzahl": 585,
         "Zuwachs_Sterbefall": 1,
@@ -37164,9 +37164,9 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1667347200000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": "26.10.2022 - 01.11.2022",
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 213.4,
         "Fallzahl_aktiv": 4100,
         "Krh_N_belegt": 995,
@@ -37180,11 +37180,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.08,
+        "H_Inzidenz": 9.79,
         "H_Zeitraum": "26.10.2022 - 02.11.2022",
         "H_Datum": "01.11.2022",
         "Datum_Bett": "01.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.11.2022",
+        "Fallzahl": 268539,
+        "ObjectId": 972,
+        "Sterbefall": 1796,
+        "Genesungsfall": 262712,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6922,
+        "Zuwachs_Fallzahl": 364,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 433,
+        "BelegteBetten": null,
+        "Inzidenz": 281.798915190919,
+        "Datum_neu": 1667433600000,
+        "F\u00e4lle_Meldedatum": 67,
+        "Zeitraum": "27.10.2022 - 02.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 235,
+        "Fallzahl_aktiv": 4031,
+        "Krh_N_belegt": 995,
+        "Krh_I_belegt": 91,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -69,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.57,
+        "H_Zeitraum": "27.10.2022 - 03.11.2022",
+        "H_Datum": "01.11.2022",
+        "Datum_Bett": "02.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
