### PR TITLE
New data set: 2022-11-04T105505Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-03T105708Z.json
+pjson/2022-11-04T105505Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-03T105708Z.json pjson/2022-11-04T105505Z.json```:
```
--- pjson/2022-11-03T105708Z.json	2022-11-03 10:57:08.565528313 +0000
+++ pjson/2022-11-04T105505Z.json	2022-11-04 10:55:05.744340253 +0000
@@ -36024,7 +36024,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664755200000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -36062,7 +36062,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664841600000,
-        "F\u00e4lle_Meldedatum": 860,
+        "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -36290,7 +36290,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 867,
+        "F\u00e4lle_Meldedatum": 865,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -36556,7 +36556,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 665,
+        "F\u00e4lle_Meldedatum": 664,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -36632,7 +36632,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666137600000,
-        "F\u00e4lle_Meldedatum": 454,
+        "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -36670,7 +36670,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 416,
+        "F\u00e4lle_Meldedatum": 415,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -36822,7 +36822,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 513,
+        "F\u00e4lle_Meldedatum": 509,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -36860,7 +36860,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666656000000,
-        "F\u00e4lle_Meldedatum": 545,
+        "F\u00e4lle_Meldedatum": 542,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -36898,7 +36898,7 @@
         "BelegteBetten": null,
         "Inzidenz": 456.194547217932,
         "Datum_neu": 1666742400000,
-        "F\u00e4lle_Meldedatum": 374,
+        "F\u00e4lle_Meldedatum": 373,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -36936,13 +36936,13 @@
         "BelegteBetten": null,
         "Inzidenz": 449.728797729804,
         "Datum_neu": 1666828800000,
-        "F\u00e4lle_Meldedatum": 301,
+        "F\u00e4lle_Meldedatum": 298,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 404.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1189,
-        "Krh_I_belegt": 90,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36952,7 +36952,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 16.08,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.10.2022"
@@ -36990,7 +36990,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.29,
+        "H_Inzidenz": 15.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.10.2022"
@@ -37012,7 +37012,7 @@
         "BelegteBetten": null,
         "Inzidenz": 359.387909048457,
         "Datum_neu": 1667001600000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 358.9,
@@ -37028,7 +37028,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.65,
+        "H_Inzidenz": 14.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.10.2022"
@@ -37066,7 +37066,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.46,
+        "H_Inzidenz": 14.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.10.2022"
@@ -37088,7 +37088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 307.302704838536,
         "Datum_neu": 1667174400000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 306.7,
@@ -37104,7 +37104,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.03,
+        "H_Inzidenz": 14.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.10.2022"
@@ -37126,9 +37126,9 @@
         "BelegteBetten": null,
         "Inzidenz": 286.109414849671,
         "Datum_neu": 1667260800000,
-        "F\u00e4lle_Meldedatum": 417,
+        "F\u00e4lle_Meldedatum": 420,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 214.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37142,7 +37142,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.02,
+        "H_Inzidenz": 11.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.10.2022"
@@ -37153,34 +37153,34 @@
         "Datum": "02.11.2022",
         "Fallzahl": 268175,
         "ObjectId": 971,
-        "Sterbefall": 1796,
-        "Genesungsfall": 262279,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6913,
-        "Zuwachs_Fallzahl": 585,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 441,
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1667347200000,
-        "F\u00e4lle_Meldedatum": 326,
+        "F\u00e4lle_Meldedatum": 345,
         "Zeitraum": "26.10.2022 - 01.11.2022",
-        "Hosp_Meldedatum": 10,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 213.4,
-        "Fallzahl_aktiv": 4100,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
         "Krh_I_belegt": 91,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 143,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.79,
+        "H_Inzidenz": 11.82,
         "H_Zeitraum": "26.10.2022 - 02.11.2022",
         "H_Datum": "01.11.2022",
         "Datum_Bett": "01.11.2022"
@@ -37193,7 +37193,7 @@
         "ObjectId": 972,
         "Sterbefall": 1796,
         "Genesungsfall": 262712,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6922,
         "Zuwachs_Fallzahl": 364,
         "Zuwachs_Sterbefall": 0,
@@ -37202,9 +37202,9 @@
         "BelegteBetten": null,
         "Inzidenz": 281.798915190919,
         "Datum_neu": 1667433600000,
-        "F\u00e4lle_Meldedatum": 67,
+        "F\u00e4lle_Meldedatum": 298,
         "Zeitraum": "27.10.2022 - 02.11.2022",
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 235,
         "Fallzahl_aktiv": 4031,
         "Krh_N_belegt": 995,
@@ -37218,11 +37218,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.57,
+        "H_Inzidenz": 10.46,
         "H_Zeitraum": "27.10.2022 - 03.11.2022",
         "H_Datum": "01.11.2022",
         "Datum_Bett": "02.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.11.2022",
+        "Fallzahl": 268809,
+        "ObjectId": 973,
+        "Sterbefall": 1796,
+        "Genesungsfall": 263117,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6955,
+        "Zuwachs_Fallzahl": 270,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 33,
+        "Zuwachs_Genesung": 405,
+        "BelegteBetten": null,
+        "Inzidenz": 285.570602392327,
+        "Datum_neu": 1667520000000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "28.10.2022 - 03.11.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 245.6,
+        "Fallzahl_aktiv": 3896,
+        "Krh_N_belegt": 995,
+        "Krh_I_belegt": 91,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -135,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.34,
+        "H_Zeitraum": "28.10.2022 - 04.11.2022",
+        "H_Datum": "01.11.2022",
+        "Datum_Bett": "03.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
