### PR TITLE
New data set: 2022-11-07T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-03T105708Z.json
+pjson/2022-11-07T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-04T105505Z.json pjson/2022-11-07T110504Z.json```:
```
--- pjson/2022-11-04T105505Z.json	2022-11-04 10:55:05.744340253 +0000
+++ pjson/2022-11-07T110504Z.json	2022-11-07 11:05:04.599280821 +0000
@@ -35492,7 +35492,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663545600000,
-        "F\u00e4lle_Meldedatum": 381,
+        "F\u00e4lle_Meldedatum": 382,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -36328,7 +36328,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665446400000,
-        "F\u00e4lle_Meldedatum": 808,
+        "F\u00e4lle_Meldedatum": 809,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -36366,7 +36366,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665532800000,
-        "F\u00e4lle_Meldedatum": 616,
+        "F\u00e4lle_Meldedatum": 617,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -36606,7 +36606,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36670,7 +36670,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666224000000,
-        "F\u00e4lle_Meldedatum": 415,
+        "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -36758,7 +36758,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36796,7 +36796,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36910,7 +36910,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36936,7 +36936,7 @@
         "BelegteBetten": null,
         "Inzidenz": 449.728797729804,
         "Datum_neu": 1666828800000,
-        "F\u00e4lle_Meldedatum": 298,
+        "F\u00e4lle_Meldedatum": 296,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -36977,10 +36977,10 @@
         "F\u00e4lle_Meldedatum": 218,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 391.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1189,
-        "Krh_I_belegt": 90,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -36990,7 +36990,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.88,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.10.2022"
@@ -37015,10 +37015,10 @@
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 358.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1189,
-        "Krh_I_belegt": 90,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37028,7 +37028,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.52,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.10.2022"
@@ -37053,10 +37053,10 @@
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 323.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 1189,
-        "Krh_I_belegt": 90,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37066,7 +37066,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.42,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.10.2022"
@@ -37088,7 +37088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 307.302704838536,
         "Datum_neu": 1667174400000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 306.7,
@@ -37126,7 +37126,7 @@
         "BelegteBetten": null,
         "Inzidenz": 286.109414849671,
         "Datum_neu": 1667260800000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": 214.6,
@@ -37142,7 +37142,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.01,
+        "H_Inzidenz": 11.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.10.2022"
@@ -37164,8 +37164,8 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1667347200000,
-        "F\u00e4lle_Meldedatum": 345,
-        "Zeitraum": "26.10.2022 - 01.11.2022",
+        "F\u00e4lle_Meldedatum": 348,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 213.4,
         "Fallzahl_aktiv": null,
@@ -37180,8 +37180,8 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.82,
-        "H_Zeitraum": "26.10.2022 - 02.11.2022",
+        "H_Inzidenz": 12.12,
+        "H_Zeitraum": null,
         "H_Datum": "01.11.2022",
         "Datum_Bett": "01.11.2022"
       }
@@ -37191,26 +37191,26 @@
         "Datum": "03.11.2022",
         "Fallzahl": 268539,
         "ObjectId": 972,
-        "Sterbefall": 1796,
-        "Genesungsfall": 262712,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6922,
-        "Zuwachs_Fallzahl": 364,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 433,
         "BelegteBetten": null,
         "Inzidenz": 281.798915190919,
         "Datum_neu": 1667433600000,
-        "F\u00e4lle_Meldedatum": 298,
-        "Zeitraum": "27.10.2022 - 02.11.2022",
+        "F\u00e4lle_Meldedatum": 313,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 235,
-        "Fallzahl_aktiv": 4031,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
         "Krh_I_belegt": 91,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -69,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37218,8 +37218,8 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.46,
-        "H_Zeitraum": "27.10.2022 - 03.11.2022",
+        "H_Inzidenz": 11.38,
+        "H_Zeitraum": null,
         "H_Datum": "01.11.2022",
         "Datum_Bett": "02.11.2022"
       }
@@ -37231,7 +37231,7 @@
         "ObjectId": 973,
         "Sterbefall": 1796,
         "Genesungsfall": 263117,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6955,
         "Zuwachs_Fallzahl": 270,
         "Zuwachs_Sterbefall": 0,
@@ -37240,9 +37240,9 @@
         "BelegteBetten": null,
         "Inzidenz": 285.570602392327,
         "Datum_neu": 1667520000000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": "28.10.2022 - 03.11.2022",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 245.6,
         "Fallzahl_aktiv": 3896,
         "Krh_N_belegt": 995,
@@ -37252,15 +37252,129 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.34,
+        "H_Inzidenz": 11.3,
         "H_Zeitraum": "28.10.2022 - 04.11.2022",
         "H_Datum": "01.11.2022",
         "Datum_Bett": "03.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.11.2022",
+        "Fallzahl": 269047,
+        "ObjectId": 974,
+        "Sterbefall": 1801,
+        "Genesungsfall": 263118,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 285.750206544775,
+        "Datum_neu": 1667606400000,
+        "F\u00e4lle_Meldedatum": 50,
+        "Zeitraum": "29.10.2022 - 04.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 249,
+        "Fallzahl_aktiv": 4128,
+        "Krh_N_belegt": 995,
+        "Krh_I_belegt": 91,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.19,
+        "H_Zeitraum": "29.10.2022 - 05.11.2022",
+        "H_Datum": "01.11.2022",
+        "Datum_Bett": "04.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.11.2022",
+        "Fallzahl": 269067,
+        "ObjectId": 975,
+        "Sterbefall": 1801,
+        "Genesungsfall": 263119,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 275.333165702791,
+        "Datum_neu": 1667692800000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": "30.10.2022 - 05.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 229.6,
+        "Fallzahl_aktiv": 4147,
+        "Krh_N_belegt": 995,
+        "Krh_I_belegt": 91,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.57,
+        "H_Zeitraum": "30.10.2022 - 06.11.2022",
+        "H_Datum": "01.11.2022",
+        "Datum_Bett": "05.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.11.2022",
+        "Fallzahl": 269089,
+        "ObjectId": 976,
+        "Sterbefall": 1801,
+        "Genesungsfall": 263926,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6961,
+        "Zuwachs_Fallzahl": 280,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 809,
+        "BelegteBetten": null,
+        "Inzidenz": 265.095729013255,
+        "Datum_neu": 1667779200000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "31.10.2022 - 06.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 215.7,
+        "Fallzahl_aktiv": 3362,
+        "Krh_N_belegt": 995,
+        "Krh_I_belegt": 91,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -534,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.05,
+        "H_Zeitraum": "31.10.2022 - 07.11.2022",
+        "H_Datum": "01.11.2022",
+        "Datum_Bett": "06.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
