### PR TITLE
New data set: 2022-11-09T112903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-08T110304Z.json
+pjson/2022-11-09T112903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-08T110304Z.json pjson/2022-11-09T112903Z.json```:
```
--- pjson/2022-11-08T110304Z.json	2022-11-08 11:03:05.405205889 +0000
+++ pjson/2022-11-09T112903Z.json	2022-11-09 11:29:03.785868177 +0000
@@ -23484,7 +23484,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636243200000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -23750,7 +23750,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1636848000000,
-        "F\u00e4lle_Meldedatum": 294,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -24396,7 +24396,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638316800000,
-        "F\u00e4lle_Meldedatum": 1117,
+        "F\u00e4lle_Meldedatum": 1116,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -24472,7 +24472,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638489600000,
-        "F\u00e4lle_Meldedatum": 1003,
+        "F\u00e4lle_Meldedatum": 1002,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -24624,7 +24624,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1638835200000,
-        "F\u00e4lle_Meldedatum": 1253,
+        "F\u00e4lle_Meldedatum": 1252,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -24700,7 +24700,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639008000000,
-        "F\u00e4lle_Meldedatum": 887,
+        "F\u00e4lle_Meldedatum": 885,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -24738,7 +24738,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639094400000,
-        "F\u00e4lle_Meldedatum": 788,
+        "F\u00e4lle_Meldedatum": 787,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -24776,7 +24776,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639180800000,
-        "F\u00e4lle_Meldedatum": 479,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -24852,7 +24852,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639353600000,
-        "F\u00e4lle_Meldedatum": 864,
+        "F\u00e4lle_Meldedatum": 862,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -24890,7 +24890,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639440000000,
-        "F\u00e4lle_Meldedatum": 1053,
+        "F\u00e4lle_Meldedatum": 1051,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -24928,7 +24928,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639526400000,
-        "F\u00e4lle_Meldedatum": 689,
+        "F\u00e4lle_Meldedatum": 687,
         "Zeitraum": null,
         "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
@@ -25004,7 +25004,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639699200000,
-        "F\u00e4lle_Meldedatum": 542,
+        "F\u00e4lle_Meldedatum": 540,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25080,7 +25080,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639872000000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 178,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25118,7 +25118,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1639958400000,
-        "F\u00e4lle_Meldedatum": 550,
+        "F\u00e4lle_Meldedatum": 549,
         "Zeitraum": null,
         "Hosp_Meldedatum": 41,
         "Inzidenz_RKI": null,
@@ -25156,7 +25156,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640044800000,
-        "F\u00e4lle_Meldedatum": 935,
+        "F\u00e4lle_Meldedatum": 932,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
@@ -25194,7 +25194,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640131200000,
-        "F\u00e4lle_Meldedatum": 422,
+        "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -25232,7 +25232,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640217600000,
-        "F\u00e4lle_Meldedatum": 401,
+        "F\u00e4lle_Meldedatum": 399,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -25270,7 +25270,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640304000000,
-        "F\u00e4lle_Meldedatum": 187,
+        "F\u00e4lle_Meldedatum": 186,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -25460,7 +25460,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640736000000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -25498,7 +25498,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640822400000,
-        "F\u00e4lle_Meldedatum": 415,
+        "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -25536,7 +25536,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1640908800000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 131,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -25650,7 +25650,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641168000000,
-        "F\u00e4lle_Meldedatum": 656,
+        "F\u00e4lle_Meldedatum": 654,
         "Zeitraum": null,
         "Hosp_Meldedatum": 29,
         "Inzidenz_RKI": null,
@@ -25688,7 +25688,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641254400000,
-        "F\u00e4lle_Meldedatum": 529,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -25764,7 +25764,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641427200000,
-        "F\u00e4lle_Meldedatum": 313,
+        "F\u00e4lle_Meldedatum": 311,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -25802,7 +25802,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641513600000,
-        "F\u00e4lle_Meldedatum": 242,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -25840,7 +25840,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641600000000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -25916,7 +25916,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641772800000,
-        "F\u00e4lle_Meldedatum": 411,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -25954,7 +25954,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1641859200000,
-        "F\u00e4lle_Meldedatum": 357,
+        "F\u00e4lle_Meldedatum": 356,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -26600,7 +26600,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643328000000,
-        "F\u00e4lle_Meldedatum": 1005,
+        "F\u00e4lle_Meldedatum": 1006,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -26752,7 +26752,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643673600000,
-        "F\u00e4lle_Meldedatum": 1662,
+        "F\u00e4lle_Meldedatum": 1663,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -26828,7 +26828,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1643846400000,
-        "F\u00e4lle_Meldedatum": 1244,
+        "F\u00e4lle_Meldedatum": 1242,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -27322,7 +27322,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1644969600000,
-        "F\u00e4lle_Meldedatum": 952,
+        "F\u00e4lle_Meldedatum": 953,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -27398,7 +27398,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645142400000,
-        "F\u00e4lle_Meldedatum": 902,
+        "F\u00e4lle_Meldedatum": 900,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -27664,7 +27664,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1645747200000,
-        "F\u00e4lle_Meldedatum": 798,
+        "F\u00e4lle_Meldedatum": 799,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -27778,7 +27778,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646006400000,
-        "F\u00e4lle_Meldedatum": 1590,
+        "F\u00e4lle_Meldedatum": 1589,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -27854,7 +27854,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646179200000,
-        "F\u00e4lle_Meldedatum": 1364,
+        "F\u00e4lle_Meldedatum": 1365,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -27892,7 +27892,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646265600000,
-        "F\u00e4lle_Meldedatum": 1206,
+        "F\u00e4lle_Meldedatum": 1205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28082,7 +28082,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646697600000,
-        "F\u00e4lle_Meldedatum": 2086,
+        "F\u00e4lle_Meldedatum": 2087,
         "Zeitraum": null,
         "Hosp_Meldedatum": 23,
         "Inzidenz_RKI": null,
@@ -28120,7 +28120,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1646784000000,
-        "F\u00e4lle_Meldedatum": 2098,
+        "F\u00e4lle_Meldedatum": 2097,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -28386,7 +28386,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647388800000,
-        "F\u00e4lle_Meldedatum": 2805,
+        "F\u00e4lle_Meldedatum": 2803,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -28424,7 +28424,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647475200000,
-        "F\u00e4lle_Meldedatum": 2705,
+        "F\u00e4lle_Meldedatum": 2706,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -28500,7 +28500,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647648000000,
-        "F\u00e4lle_Meldedatum": 1529,
+        "F\u00e4lle_Meldedatum": 1528,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -28652,7 +28652,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1647993600000,
-        "F\u00e4lle_Meldedatum": 2136,
+        "F\u00e4lle_Meldedatum": 2135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -28690,7 +28690,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648080000000,
-        "F\u00e4lle_Meldedatum": 2198,
+        "F\u00e4lle_Meldedatum": 2197,
         "Zeitraum": null,
         "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
@@ -28842,7 +28842,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648425600000,
-        "F\u00e4lle_Meldedatum": 2362,
+        "F\u00e4lle_Meldedatum": 2361,
         "Zeitraum": null,
         "Hosp_Meldedatum": 33,
         "Inzidenz_RKI": null,
@@ -28880,7 +28880,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1648512000000,
-        "F\u00e4lle_Meldedatum": 1971,
+        "F\u00e4lle_Meldedatum": 1972,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -36518,7 +36518,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665878400000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 127,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -36556,7 +36556,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 624,
+        "F\u00e4lle_Meldedatum": 662,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -36976,7 +36976,7 @@
         "Datum_neu": 1666915200000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37088,7 +37088,7 @@
         "BelegteBetten": null,
         "Inzidenz": 307.302704838536,
         "Datum_neu": 1667174400000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -37126,13 +37126,13 @@
         "BelegteBetten": null,
         "Inzidenz": 286.109414849671,
         "Datum_neu": 1667260800000,
-        "F\u00e4lle_Meldedatum": 420,
+        "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
-        "Inzidenz_RKI": 214.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37142,7 +37142,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.33,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.10.2022"
@@ -37164,7 +37164,7 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1667347200000,
-        "F\u00e4lle_Meldedatum": 346,
+        "F\u00e4lle_Meldedatum": 345,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 213.4,
@@ -37180,7 +37180,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.37,
+        "H_Inzidenz": 12.49,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.11.2022"
@@ -37202,9 +37202,9 @@
         "BelegteBetten": null,
         "Inzidenz": 281.798915190919,
         "Datum_neu": 1667433600000,
-        "F\u00e4lle_Meldedatum": 317,
+        "F\u00e4lle_Meldedatum": 316,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 235,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37218,7 +37218,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.7,
+        "H_Inzidenz": 11.8,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.11.2022"
@@ -37240,7 +37240,7 @@
         "BelegteBetten": null,
         "Inzidenz": 285.570602392327,
         "Datum_neu": 1667520000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 245.6,
@@ -37256,7 +37256,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.85,
+        "H_Inzidenz": 12.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.11.2022"
@@ -37294,7 +37294,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.2,
+        "H_Inzidenz": 11.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.11.2022"
@@ -37316,7 +37316,7 @@
         "BelegteBetten": null,
         "Inzidenz": 275.333165702791,
         "Datum_neu": 1667692800000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 229.6,
@@ -37332,7 +37332,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.98,
+        "H_Inzidenz": 11.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.11.2022"
@@ -37343,26 +37343,26 @@
         "Datum": "07.11.2022",
         "Fallzahl": 269089,
         "ObjectId": 976,
-        "Sterbefall": 1801,
-        "Genesungsfall": 263926,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6961,
-        "Zuwachs_Fallzahl": 280,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 809,
         "BelegteBetten": null,
         "Inzidenz": 265.095729013255,
         "Datum_neu": 1667779200000,
-        "F\u00e4lle_Meldedatum": 294,
-        "Zeitraum": "31.10.2022 - 06.11.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 308,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 215.7,
-        "Fallzahl_aktiv": 3362,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
         "Krh_I_belegt": 91,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -534,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37370,37 +37370,37 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.69,
-        "H_Zeitraum": "31.10.2022 - 07.11.2022",
-        "H_Datum": "01.11.2022",
+        "H_Inzidenz": 11.55,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.11.2022"
       }
     },
     {
       "attributes": {
         "Datum": "08.11.2022",
-        "Fallzahl": 269384,
+        "Fallzahl": 269381,
         "ObjectId": 977,
         "Sterbefall": 1802,
         "Genesungsfall": 264412,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6972,
-        "Zuwachs_Fallzahl": 295,
+        "Zuwachs_Fallzahl": 292,
         "Zuwachs_Sterbefall": 1,
         "Zuwachs_Krankenhauseinweisung": 11,
         "Zuwachs_Genesung": 486,
         "BelegteBetten": null,
         "Inzidenz": 302.45339272244,
         "Datum_neu": 1667865600000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 198,
         "Zeitraum": "01.11.2022 - 07.11.2022",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 262.9,
-        "Fallzahl_aktiv": 3170,
+        "Fallzahl_aktiv": 3167,
         "Krh_N_belegt": 995,
         "Krh_I_belegt": 91,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -192,
+        "Fallzahl_aktiv_Zuwachs": -195,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37408,11 +37408,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.52,
+        "H_Inzidenz": 11.45,
         "H_Zeitraum": "01.11.2022 - 08.11.2022",
         "H_Datum": "01.11.2022",
         "Datum_Bett": "07.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.11.2022",
+        "Fallzahl": 269587,
+        "ObjectId": 978,
+        "Sterbefall": 1802,
+        "Genesungsfall": 264808,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6983,
+        "Zuwachs_Fallzahl": 206,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 396,
+        "BelegteBetten": null,
+        "Inzidenz": 265.275333165703,
+        "Datum_neu": 1667952000000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "02.11.2022 - 08.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 245.4,
+        "Fallzahl_aktiv": 2977,
+        "Krh_N_belegt": 757,
+        "Krh_I_belegt": 72,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -190,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.01,
+        "H_Zeitraum": "02.11.2022 - 09.11.2022",
+        "H_Datum": "08.11.2022",
+        "Datum_Bett": "08.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
