### PR TITLE
New data set: 2022-11-10T114005Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-09T112903Z.json
+pjson/2022-11-10T114005Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-09T112903Z.json pjson/2022-11-10T114005Z.json```:
```
--- pjson/2022-11-09T112903Z.json	2022-11-09 11:29:03.785868177 +0000
+++ pjson/2022-11-10T114005Z.json	2022-11-10 11:40:05.450763738 +0000
@@ -33632,7 +33632,7 @@
         "Datum_neu": 1659312000000,
         "F\u00e4lle_Meldedatum": 573,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34886,7 +34886,7 @@
         "Datum_neu": 1662163200000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35380,7 +35380,7 @@
         "Datum_neu": 1663286400000,
         "F\u00e4lle_Meldedatum": 253,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36026,7 +36026,7 @@
         "Datum_neu": 1664755200000,
         "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36064,7 +36064,7 @@
         "Datum_neu": 1664841600000,
         "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36140,7 +36140,7 @@
         "Datum_neu": 1665014400000,
         "F\u00e4lle_Meldedatum": 638,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36292,7 +36292,7 @@
         "Datum_neu": 1665360000000,
         "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 35,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36330,7 +36330,7 @@
         "Datum_neu": 1665446400000,
         "F\u00e4lle_Meldedatum": 809,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36368,7 +36368,7 @@
         "Datum_neu": 1665532800000,
         "F\u00e4lle_Meldedatum": 617,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36442,9 +36442,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665705600000,
-        "F\u00e4lle_Meldedatum": 528,
+        "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36480,7 +36480,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665792000000,
-        "F\u00e4lle_Meldedatum": 257,
+        "F\u00e4lle_Meldedatum": 256,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -36558,7 +36558,7 @@
         "Datum_neu": 1665964800000,
         "F\u00e4lle_Meldedatum": 662,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36596,7 +36596,7 @@
         "Datum_neu": 1666051200000,
         "F\u00e4lle_Meldedatum": 721,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36634,7 +36634,7 @@
         "Datum_neu": 1666137600000,
         "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36672,7 +36672,7 @@
         "Datum_neu": 1666224000000,
         "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36710,7 +36710,7 @@
         "Datum_neu": 1666310400000,
         "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36860,7 +36860,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666656000000,
-        "F\u00e4lle_Meldedatum": 541,
+        "F\u00e4lle_Meldedatum": 540,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -36898,7 +36898,7 @@
         "BelegteBetten": null,
         "Inzidenz": 456.194547217932,
         "Datum_neu": 1666742400000,
-        "F\u00e4lle_Meldedatum": 372,
+        "F\u00e4lle_Meldedatum": 371,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -36936,9 +36936,9 @@
         "BelegteBetten": null,
         "Inzidenz": 449.728797729804,
         "Datum_neu": 1666828800000,
-        "F\u00e4lle_Meldedatum": 297,
+        "F\u00e4lle_Meldedatum": 295,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37128,7 +37128,7 @@
         "Datum_neu": 1667260800000,
         "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37164,13 +37164,13 @@
         "BelegteBetten": null,
         "Inzidenz": 282.696935953159,
         "Datum_neu": 1667347200000,
-        "F\u00e4lle_Meldedatum": 345,
+        "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 213.4,
+        "Hosp_Meldedatum": 17,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37180,7 +37180,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.49,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.11.2022"
@@ -37202,9 +37202,9 @@
         "BelegteBetten": null,
         "Inzidenz": 281.798915190919,
         "Datum_neu": 1667433600000,
-        "F\u00e4lle_Meldedatum": 316,
+        "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 235,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37218,7 +37218,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.8,
+        "H_Inzidenz": 11.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.11.2022"
@@ -37240,7 +37240,7 @@
         "BelegteBetten": null,
         "Inzidenz": 285.570602392327,
         "Datum_neu": 1667520000000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 245.6,
@@ -37256,7 +37256,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.12,
+        "H_Inzidenz": 12.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.11.2022"
@@ -37278,7 +37278,7 @@
         "BelegteBetten": null,
         "Inzidenz": 285.750206544775,
         "Datum_neu": 1667606400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 249,
@@ -37294,7 +37294,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.7,
+        "H_Inzidenz": 11.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.11.2022"
@@ -37316,7 +37316,7 @@
         "BelegteBetten": null,
         "Inzidenz": 275.333165702791,
         "Datum_neu": 1667692800000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 229.6,
@@ -37332,7 +37332,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.67,
+        "H_Inzidenz": 11.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.11.2022"
@@ -37354,9 +37354,9 @@
         "BelegteBetten": null,
         "Inzidenz": 265.095729013255,
         "Datum_neu": 1667779200000,
-        "F\u00e4lle_Meldedatum": 308,
+        "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 215.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37366,11 +37366,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.55,
+        "H_Inzidenz": 11.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.11.2022"
@@ -37381,26 +37381,26 @@
         "Datum": "08.11.2022",
         "Fallzahl": 269381,
         "ObjectId": 977,
-        "Sterbefall": 1802,
-        "Genesungsfall": 264412,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6972,
-        "Zuwachs_Fallzahl": 292,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 486,
         "BelegteBetten": null,
         "Inzidenz": 302.45339272244,
         "Datum_neu": 1667865600000,
-        "F\u00e4lle_Meldedatum": 198,
-        "Zeitraum": "01.11.2022 - 07.11.2022",
-        "Hosp_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 208,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 262.9,
-        "Fallzahl_aktiv": 3167,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
         "Krh_I_belegt": 91,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -195,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37408,7 +37408,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.45,
+        "H_Inzidenz": 12.27,
         "H_Zeitraum": "01.11.2022 - 08.11.2022",
         "H_Datum": "01.11.2022",
         "Datum_Bett": "07.11.2022"
@@ -37421,8 +37421,8 @@
         "ObjectId": 978,
         "Sterbefall": 1802,
         "Genesungsfall": 264808,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6983,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 6945,
         "Zuwachs_Fallzahl": 206,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 11,
@@ -37430,9 +37430,9 @@
         "BelegteBetten": null,
         "Inzidenz": 265.275333165703,
         "Datum_neu": 1667952000000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": "02.11.2022 - 08.11.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 245.4,
         "Fallzahl_aktiv": 2977,
         "Krh_N_belegt": 757,
@@ -37446,11 +37446,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.01,
+        "H_Inzidenz": 9.75,
         "H_Zeitraum": "02.11.2022 - 09.11.2022",
         "H_Datum": "08.11.2022",
         "Datum_Bett": "08.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.11.2022",
+        "Fallzahl": 269733,
+        "ObjectId": 979,
+        "Sterbefall": 1804,
+        "Genesungsfall": 265135,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6947,
+        "Zuwachs_Fallzahl": 146,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 327,
+        "BelegteBetten": null,
+        "Inzidenz": 230.43212759079,
+        "Datum_neu": 1668038400000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": "03.11.2022 - 09.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 217.2,
+        "Fallzahl_aktiv": 2794,
+        "Krh_N_belegt": 757,
+        "Krh_I_belegt": 72,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -183,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.09,
+        "H_Zeitraum": "03.11.2022 - 10.11.2022",
+        "H_Datum": "08.11.2022",
+        "Datum_Bett": "09.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
