### PR TITLE
New data set: 2022-11-10T115703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-10T114005Z.json
+pjson/2022-11-10T115703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-10T114005Z.json pjson/2022-11-10T115703Z.json```:
```
--- pjson/2022-11-10T114005Z.json	2022-11-10 11:40:05.450763738 +0000
+++ pjson/2022-11-10T115703Z.json	2022-11-10 11:57:04.287498203 +0000
@@ -33632,7 +33632,7 @@
         "Datum_neu": 1659312000000,
         "F\u00e4lle_Meldedatum": 573,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34886,7 +34886,7 @@
         "Datum_neu": 1662163200000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35380,7 +35380,7 @@
         "Datum_neu": 1663286400000,
         "F\u00e4lle_Meldedatum": 253,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36026,7 +36026,7 @@
         "Datum_neu": 1664755200000,
         "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36064,7 +36064,7 @@
         "Datum_neu": 1664841600000,
         "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36140,7 +36140,7 @@
         "Datum_neu": 1665014400000,
         "F\u00e4lle_Meldedatum": 638,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36292,7 +36292,7 @@
         "Datum_neu": 1665360000000,
         "F\u00e4lle_Meldedatum": 864,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 35,
+        "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36330,7 +36330,7 @@
         "Datum_neu": 1665446400000,
         "F\u00e4lle_Meldedatum": 809,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 27,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36368,7 +36368,7 @@
         "Datum_neu": 1665532800000,
         "F\u00e4lle_Meldedatum": 617,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36444,7 +36444,7 @@
         "Datum_neu": 1665705600000,
         "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36558,7 +36558,7 @@
         "Datum_neu": 1665964800000,
         "F\u00e4lle_Meldedatum": 662,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 25,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36596,7 +36596,7 @@
         "Datum_neu": 1666051200000,
         "F\u00e4lle_Meldedatum": 721,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36634,7 +36634,7 @@
         "Datum_neu": 1666137600000,
         "F\u00e4lle_Meldedatum": 453,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36672,7 +36672,7 @@
         "Datum_neu": 1666224000000,
         "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36710,7 +36710,7 @@
         "Datum_neu": 1666310400000,
         "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36938,7 +36938,7 @@
         "Datum_neu": 1666828800000,
         "F\u00e4lle_Meldedatum": 295,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37128,7 +37128,7 @@
         "Datum_neu": 1667260800000,
         "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 22,
+        "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37166,7 +37166,7 @@
         "Datum_neu": 1667347200000,
         "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37204,7 +37204,7 @@
         "Datum_neu": 1667433600000,
         "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 235,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37356,7 +37356,7 @@
         "Datum_neu": 1667779200000,
         "F\u00e4lle_Meldedatum": 309,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 215.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37394,7 +37394,7 @@
         "Datum_neu": 1667865600000,
         "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 262.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37422,7 +37422,7 @@
         "Sterbefall": 1802,
         "Genesungsfall": 264808,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6945,
+        "Hospitalisierung": 6983,
         "Zuwachs_Fallzahl": 206,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 11,
@@ -37432,7 +37432,7 @@
         "Datum_neu": 1667952000000,
         "F\u00e4lle_Meldedatum": 144,
         "Zeitraum": "02.11.2022 - 08.11.2022",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 245.4,
         "Fallzahl_aktiv": 2977,
         "Krh_N_belegt": 757,
@@ -37460,7 +37460,7 @@
         "Sterbefall": 1804,
         "Genesungsfall": 265135,
         "Anzeige_Indikator": "x",
-        "Hospitalisierung": 6947,
+        "Hospitalisierung": 6985,
         "Zuwachs_Fallzahl": 146,
         "Zuwachs_Sterbefall": 2,
         "Zuwachs_Krankenhauseinweisung": 2,
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
