### PR TITLE
New data set: 2022-11-11T112204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-10T114005Z.json
+pjson/2022-11-11T112204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-10T115703Z.json pjson/2022-11-11T112204Z.json```:
```
--- pjson/2022-11-10T115703Z.json	2022-11-10 11:57:04.287498203 +0000
+++ pjson/2022-11-11T112204Z.json	2022-11-11 11:22:04.584447387 +0000
@@ -33632,7 +33632,7 @@
         "Datum_neu": 1659312000000,
         "F\u00e4lle_Meldedatum": 573,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -34352,7 +34352,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660953600000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -34466,7 +34466,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1661212800000,
-        "F\u00e4lle_Meldedatum": 312,
+        "F\u00e4lle_Meldedatum": 313,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -34886,7 +34886,7 @@
         "Datum_neu": 1662163200000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35380,7 +35380,7 @@
         "Datum_neu": 1663286400000,
         "F\u00e4lle_Meldedatum": 253,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36290,7 +36290,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 864,
+        "F\u00e4lle_Meldedatum": 865,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -36444,7 +36444,7 @@
         "Datum_neu": 1665705600000,
         "F\u00e4lle_Meldedatum": 527,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36710,7 +36710,7 @@
         "Datum_neu": 1666310400000,
         "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36824,7 +36824,7 @@
         "Datum_neu": 1666569600000,
         "F\u00e4lle_Meldedatum": 508,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 23,
+        "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36938,7 +36938,7 @@
         "Datum_neu": 1666828800000,
         "F\u00e4lle_Meldedatum": 295,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36948,7 +36948,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36976,7 +36976,7 @@
         "Datum_neu": 1666915200000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37128,7 +37128,7 @@
         "Datum_neu": 1667260800000,
         "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37205,10 +37205,10 @@
         "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 235,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37218,7 +37218,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.11.2022"
@@ -37242,7 +37242,7 @@
         "Datum_neu": 1667520000000,
         "F\u00e4lle_Meldedatum": 207,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 245.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37256,7 +37256,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.29,
+        "H_Inzidenz": 12.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.11.2022"
@@ -37294,7 +37294,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.92,
+        "H_Inzidenz": 12.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.11.2022"
@@ -37332,7 +37332,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.9,
+        "H_Inzidenz": 12.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.11.2022"
@@ -37370,7 +37370,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.77,
+        "H_Inzidenz": 12.05,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.11.2022"
@@ -37392,7 +37392,7 @@
         "BelegteBetten": null,
         "Inzidenz": 302.45339272244,
         "Datum_neu": 1667865600000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 262.9,
@@ -37408,9 +37408,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.27,
-        "H_Zeitraum": "01.11.2022 - 08.11.2022",
-        "H_Datum": "01.11.2022",
+        "H_Inzidenz": 12.59,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.11.2022"
       }
     },
@@ -37419,26 +37419,26 @@
         "Datum": "09.11.2022",
         "Fallzahl": 269587,
         "ObjectId": 978,
-        "Sterbefall": 1802,
-        "Genesungsfall": 264808,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6983,
-        "Zuwachs_Fallzahl": 206,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 396,
         "BelegteBetten": null,
         "Inzidenz": 265.275333165703,
         "Datum_neu": 1667952000000,
-        "F\u00e4lle_Meldedatum": 144,
-        "Zeitraum": "02.11.2022 - 08.11.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 147,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 245.4,
-        "Fallzahl_aktiv": 2977,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 757,
         "Krh_I_belegt": 72,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -190,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37446,9 +37446,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.75,
-        "H_Zeitraum": "02.11.2022 - 09.11.2022",
-        "H_Datum": "08.11.2022",
+        "H_Inzidenz": 10.24,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.11.2022"
       }
     },
@@ -37459,7 +37459,7 @@
         "ObjectId": 979,
         "Sterbefall": 1804,
         "Genesungsfall": 265135,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6985,
         "Zuwachs_Fallzahl": 146,
         "Zuwachs_Sterbefall": 2,
@@ -37468,9 +37468,9 @@
         "BelegteBetten": null,
         "Inzidenz": 230.43212759079,
         "Datum_neu": 1668038400000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": "03.11.2022 - 09.11.2022",
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 217.2,
         "Fallzahl_aktiv": 2794,
         "Krh_N_belegt": 757,
@@ -37484,11 +37484,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.09,
+        "H_Inzidenz": 8.85,
         "H_Zeitraum": "03.11.2022 - 10.11.2022",
         "H_Datum": "08.11.2022",
         "Datum_Bett": "09.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.11.2022",
+        "Fallzahl": 269859,
+        "ObjectId": 980,
+        "Sterbefall": 1805,
+        "Genesungsfall": 265360,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6987,
+        "Zuwachs_Fallzahl": 126,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 225,
+        "BelegteBetten": null,
+        "Inzidenz": 197.025755235461,
+        "Datum_neu": 1668124800000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "04.11.2022 - 10.11.2022",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 180.2,
+        "Fallzahl_aktiv": 2694,
+        "Krh_N_belegt": 757,
+        "Krh_I_belegt": 72,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -100,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.21,
+        "H_Zeitraum": "04.11.2022 - 11.11.2022",
+        "H_Datum": "08.11.2022",
+        "Datum_Bett": "10.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
