### PR TITLE
New data set: 2022-11-14T104904Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-11T112204Z.json
+pjson/2022-11-14T104904Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-11T112204Z.json pjson/2022-11-14T104904Z.json```:
```
--- pjson/2022-11-11T112204Z.json	2022-11-11 11:22:04.584447387 +0000
+++ pjson/2022-11-14T104904Z.json	2022-11-14 10:49:04.731345190 +0000
@@ -36290,7 +36290,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665360000000,
-        "F\u00e4lle_Meldedatum": 865,
+        "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
         "Hosp_Meldedatum": 40,
         "Inzidenz_RKI": null,
@@ -36644,7 +36644,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36708,7 +36708,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 412,
+        "F\u00e4lle_Meldedatum": 411,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -36948,7 +36948,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37062,7 +37062,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37100,7 +37100,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37240,13 +37240,13 @@
         "BelegteBetten": null,
         "Inzidenz": 285.570602392327,
         "Datum_neu": 1667520000000,
-        "F\u00e4lle_Meldedatum": 207,
+        "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 245.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37256,7 +37256,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.52,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.11.2022"
@@ -37278,13 +37278,13 @@
         "BelegteBetten": null,
         "Inzidenz": 285.750206544775,
         "Datum_neu": 1667606400000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 249,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37294,7 +37294,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.17,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.11.2022"
@@ -37316,13 +37316,13 @@
         "BelegteBetten": null,
         "Inzidenz": 275.333165702791,
         "Datum_neu": 1667692800000,
-        "F\u00e4lle_Meldedatum": 45,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 229.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37332,7 +37332,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.14,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.11.2022"
@@ -37354,9 +37354,9 @@
         "BelegteBetten": null,
         "Inzidenz": 265.095729013255,
         "Datum_neu": 1667779200000,
-        "F\u00e4lle_Meldedatum": 309,
+        "F\u00e4lle_Meldedatum": 308,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 215.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37370,7 +37370,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.05,
+        "H_Inzidenz": 12.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.11.2022"
@@ -37392,9 +37392,9 @@
         "BelegteBetten": null,
         "Inzidenz": 302.45339272244,
         "Datum_neu": 1667865600000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 211,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 262.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 995,
@@ -37408,7 +37408,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.59,
+        "H_Inzidenz": 12.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.11.2022"
@@ -37430,9 +37430,9 @@
         "BelegteBetten": null,
         "Inzidenz": 265.275333165703,
         "Datum_neu": 1667952000000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 245.4,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 757,
@@ -37446,7 +37446,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.24,
+        "H_Inzidenz": 10.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.11.2022"
@@ -37468,9 +37468,9 @@
         "BelegteBetten": null,
         "Inzidenz": 230.43212759079,
         "Datum_neu": 1668038400000,
-        "F\u00e4lle_Meldedatum": 124,
-        "Zeitraum": "03.11.2022 - 09.11.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 127,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 217.2,
         "Fallzahl_aktiv": 2794,
         "Krh_N_belegt": 757,
@@ -37484,9 +37484,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.85,
-        "H_Zeitraum": "03.11.2022 - 10.11.2022",
-        "H_Datum": "08.11.2022",
+        "H_Inzidenz": 9.2,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.11.2022"
       }
     },
@@ -37497,7 +37497,7 @@
         "ObjectId": 980,
         "Sterbefall": 1805,
         "Genesungsfall": 265360,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6987,
         "Zuwachs_Fallzahl": 126,
         "Zuwachs_Sterbefall": 1,
@@ -37506,9 +37506,9 @@
         "BelegteBetten": null,
         "Inzidenz": 197.025755235461,
         "Datum_neu": 1668124800000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": "04.11.2022 - 10.11.2022",
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 180.2,
         "Fallzahl_aktiv": 2694,
         "Krh_N_belegt": 757,
@@ -37522,11 +37522,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.21,
-        "H_Zeitraum": "04.11.2022 - 11.11.2022",
-        "H_Datum": "08.11.2022",
+        "H_Inzidenz": 7.07,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.11.2022",
+        "Fallzahl": 269977,
+        "ObjectId": 981,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 179.065339990661,
+        "Datum_neu": 1668211200000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "05.11.2022 - 11.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 163.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 757,
+        "Krh_I_belegt": 72,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.13,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "11.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.11.2022",
+        "Fallzahl": 269994,
+        "ObjectId": 982,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 175.4732569417,
+        "Datum_neu": 1668297600000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "06.11.2022 - 12.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 154,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 757,
+        "Krh_I_belegt": 72,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.52,
+        "H_Zeitraum": "06.11.2022 - 13.11.2022",
+        "H_Datum": "08.11.2022",
+        "Datum_Bett": "12.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.11.2022",
+        "Fallzahl": 270016,
+        "ObjectId": 983,
+        "Sterbefall": 1809,
+        "Genesungsfall": 265692,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 6995,
+        "Zuwachs_Fallzahl": 157,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 332,
+        "BelegteBetten": null,
+        "Inzidenz": 170.623944825604,
+        "Datum_neu": 1668384000000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "07.11.2022 - 13.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 145.9,
+        "Fallzahl_aktiv": 2515,
+        "Krh_N_belegt": 757,
+        "Krh_I_belegt": 72,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -179,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.07,
+        "H_Zeitraum": "07.11.2022 - 14.11.2022",
+        "H_Datum": "08.11.2022",
+        "Datum_Bett": "13.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
