### PR TITLE
New data set: 2022-11-15T100703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-11T112204Z.json
+pjson/2022-11-15T100703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-14T104904Z.json pjson/2022-11-15T100703Z.json```:
```
--- pjson/2022-11-14T104904Z.json	2022-11-14 10:49:04.731345190 +0000
+++ pjson/2022-11-15T100703Z.json	2022-11-15 10:07:04.274970218 +0000
@@ -36896,7 +36896,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 609,
         "BelegteBetten": null,
-        "Inzidenz": 456.194547217932,
+        "Inzidenz": null,
         "Datum_neu": 1666742400000,
         "F\u00e4lle_Meldedatum": 371,
         "Zeitraum": null,
@@ -36934,7 +36934,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 548,
         "BelegteBetten": null,
-        "Inzidenz": 449.728797729804,
+        "Inzidenz": null,
         "Datum_neu": 1666828800000,
         "F\u00e4lle_Meldedatum": 295,
         "Zeitraum": null,
@@ -36972,7 +36972,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 515,
         "BelegteBetten": null,
-        "Inzidenz": 432.307194942347,
+        "Inzidenz": null,
         "Datum_neu": 1666915200000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
@@ -37010,9 +37010,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 359.387909048457,
+        "Inzidenz": null,
         "Datum_neu": 1667001600000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -37048,7 +37048,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 324.185495168648,
+        "Inzidenz": null,
         "Datum_neu": 1667088000000,
         "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": null,
@@ -37086,7 +37086,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 307.302704838536,
+        "Inzidenz": null,
         "Datum_neu": 1667174400000,
         "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
@@ -37124,7 +37124,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 1752,
         "BelegteBetten": null,
-        "Inzidenz": 286.109414849671,
+        "Inzidenz": null,
         "Datum_neu": 1667260800000,
         "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
@@ -37162,7 +37162,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 441,
         "BelegteBetten": null,
-        "Inzidenz": 282.696935953159,
+        "Inzidenz": null,
         "Datum_neu": 1667347200000,
         "F\u00e4lle_Meldedatum": 344,
         "Zeitraum": null,
@@ -37200,7 +37200,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 433,
         "BelegteBetten": null,
-        "Inzidenz": 281.798915190919,
+        "Inzidenz": null,
         "Datum_neu": 1667433600000,
         "F\u00e4lle_Meldedatum": 315,
         "Zeitraum": null,
@@ -37238,7 +37238,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 405,
         "BelegteBetten": null,
-        "Inzidenz": 285.570602392327,
+        "Inzidenz": null,
         "Datum_neu": 1667520000000,
         "F\u00e4lle_Meldedatum": 206,
         "Zeitraum": null,
@@ -37276,11 +37276,11 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 285.750206544775,
+        "Inzidenz": null,
         "Datum_neu": 1667606400000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37316,7 +37316,7 @@
         "BelegteBetten": null,
         "Inzidenz": 275.333165702791,
         "Datum_neu": 1667692800000,
-        "F\u00e4lle_Meldedatum": 44,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -37354,13 +37354,13 @@
         "BelegteBetten": null,
         "Inzidenz": 265.095729013255,
         "Datum_neu": 1667779200000,
-        "F\u00e4lle_Meldedatum": 308,
+        "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 215.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37370,7 +37370,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.12,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.11.2022"
@@ -37392,7 +37392,7 @@
         "BelegteBetten": null,
         "Inzidenz": 302.45339272244,
         "Datum_neu": 1667865600000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 262.9,
@@ -37408,7 +37408,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.71,
+        "H_Inzidenz": 12.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.11.2022"
@@ -37430,7 +37430,7 @@
         "BelegteBetten": null,
         "Inzidenz": 265.275333165703,
         "Datum_neu": 1667952000000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 245.4,
@@ -37446,7 +37446,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.36,
+        "H_Inzidenz": 10.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.11.2022"
@@ -37457,26 +37457,26 @@
         "Datum": "10.11.2022",
         "Fallzahl": 269733,
         "ObjectId": 979,
-        "Sterbefall": 1804,
-        "Genesungsfall": 265135,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6985,
-        "Zuwachs_Fallzahl": 146,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 327,
         "BelegteBetten": null,
         "Inzidenz": 230.43212759079,
         "Datum_neu": 1668038400000,
-        "F\u00e4lle_Meldedatum": 127,
+        "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 217.2,
-        "Fallzahl_aktiv": 2794,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 757,
         "Krh_I_belegt": 72,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -183,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37484,7 +37484,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.2,
+        "H_Inzidenz": 9.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.11.2022"
@@ -37495,26 +37495,26 @@
         "Datum": "11.11.2022",
         "Fallzahl": 269859,
         "ObjectId": 980,
-        "Sterbefall": 1805,
-        "Genesungsfall": 265360,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6987,
-        "Zuwachs_Fallzahl": 126,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 225,
         "BelegteBetten": null,
         "Inzidenz": 197.025755235461,
         "Datum_neu": 1668124800000,
-        "F\u00e4lle_Meldedatum": 106,
-        "Zeitraum": "04.11.2022 - 10.11.2022",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 113,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 180.2,
-        "Fallzahl_aktiv": 2694,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 757,
         "Krh_I_belegt": 72,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -100,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37522,7 +37522,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.07,
+        "H_Inzidenz": 7.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.11.2022"
@@ -37544,8 +37544,8 @@
         "BelegteBetten": null,
         "Inzidenz": 179.065339990661,
         "Datum_neu": 1668211200000,
-        "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "05.11.2022 - 11.11.2022",
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 163.9,
         "Fallzahl_aktiv": null,
@@ -37560,7 +37560,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.13,
+        "H_Inzidenz": 6.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.11.2022"
@@ -37582,8 +37582,8 @@
         "BelegteBetten": null,
         "Inzidenz": 175.4732569417,
         "Datum_neu": 1668297600000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "06.11.2022 - 12.11.2022",
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 154,
         "Fallzahl_aktiv": null,
@@ -37598,9 +37598,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.52,
-        "H_Zeitraum": "06.11.2022 - 13.11.2022",
-        "H_Datum": "08.11.2022",
+        "H_Inzidenz": 6.46,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.11.2022"
       }
     },
@@ -37611,7 +37611,7 @@
         "ObjectId": 983,
         "Sterbefall": 1809,
         "Genesungsfall": 265692,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 6995,
         "Zuwachs_Fallzahl": 157,
         "Zuwachs_Sterbefall": 4,
@@ -37620,9 +37620,9 @@
         "BelegteBetten": null,
         "Inzidenz": 170.623944825604,
         "Datum_neu": 1668384000000,
-        "F\u00e4lle_Meldedatum": 22,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": "07.11.2022 - 13.11.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 145.9,
         "Fallzahl_aktiv": 2515,
         "Krh_N_belegt": 757,
@@ -37636,11 +37636,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.07,
+        "H_Inzidenz": 6.28,
         "H_Zeitraum": "07.11.2022 - 14.11.2022",
         "H_Datum": "08.11.2022",
         "Datum_Bett": "13.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.11.2022",
+        "Fallzahl": 270171,
+        "ObjectId": 984,
+        "Sterbefall": 1809,
+        "Genesungsfall": 266095,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7006,
+        "Zuwachs_Fallzahl": 155,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 403,
+        "BelegteBetten": null,
+        "Inzidenz": 143.324113653508,
+        "Datum_neu": 1668470400000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "08.11.2022 - 14.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 123.9,
+        "Fallzahl_aktiv": 2267,
+        "Krh_N_belegt": 757,
+        "Krh_I_belegt": 72,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -248,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.38,
+        "H_Zeitraum": "08.11.2022 - 15.11.2022",
+        "H_Datum": "08.11.2022",
+        "Datum_Bett": "14.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
