### PR TITLE
New data set: 2022-11-17T105704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-15T100703Z.json
+pjson/2022-11-17T105704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-15T100703Z.json pjson/2022-11-17T105704Z.json```:
```
--- pjson/2022-11-15T100703Z.json	2022-11-15 10:07:04.274970218 +0000
+++ pjson/2022-11-17T105704Z.json	2022-11-17 10:57:04.633636316 +0000
@@ -37100,7 +37100,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37395,10 +37395,10 @@
         "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 262.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 995,
-        "Krh_I_belegt": 91,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37408,7 +37408,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.74,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.11.2022"
@@ -37433,10 +37433,10 @@
         "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 245.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 757,
-        "Krh_I_belegt": 72,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37446,7 +37446,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.46,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.11.2022"
@@ -37484,7 +37484,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.32,
+        "H_Inzidenz": 8.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.11.2022"
@@ -37522,7 +37522,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.4,
+        "H_Inzidenz": 8.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.11.2022"
@@ -37560,7 +37560,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
+        "H_Inzidenz": 8.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.11.2022"
@@ -37582,7 +37582,7 @@
         "BelegteBetten": null,
         "Inzidenz": 175.4732569417,
         "Datum_neu": 1668297600000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 154,
@@ -37598,7 +37598,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.46,
+        "H_Inzidenz": 7.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.11.2022"
@@ -37620,9 +37620,9 @@
         "BelegteBetten": null,
         "Inzidenz": 170.623944825604,
         "Datum_neu": 1668384000000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": "07.11.2022 - 13.11.2022",
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 145.9,
         "Fallzahl_aktiv": 2515,
         "Krh_N_belegt": 757,
@@ -37632,11 +37632,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.28,
+        "H_Inzidenz": 7.81,
         "H_Zeitraum": "07.11.2022 - 14.11.2022",
         "H_Datum": "08.11.2022",
         "Datum_Bett": "13.11.2022"
@@ -37649,7 +37649,7 @@
         "ObjectId": 984,
         "Sterbefall": 1809,
         "Genesungsfall": 266095,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7006,
         "Zuwachs_Fallzahl": 155,
         "Zuwachs_Sterbefall": 0,
@@ -37658,9 +37658,9 @@
         "BelegteBetten": null,
         "Inzidenz": 143.324113653508,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 22,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": "08.11.2022 - 14.11.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 123.9,
         "Fallzahl_aktiv": 2267,
         "Krh_N_belegt": 757,
@@ -37674,11 +37674,87 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.38,
+        "H_Inzidenz": 7.2,
         "H_Zeitraum": "08.11.2022 - 15.11.2022",
         "H_Datum": "08.11.2022",
         "Datum_Bett": "14.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "16.11.2022",
+        "Fallzahl": 270348,
+        "ObjectId": 985,
+        "Sterbefall": null,
+        "Genesungsfall": null,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 133.086676963971,
+        "Datum_neu": 1668556800000,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": "09.11.2022 - 15.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 118.7,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 541,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.66,
+        "H_Zeitraum": "09.11.2022 - 16.11.2022",
+        "H_Datum": "15.11.2022",
+        "Datum_Bett": "15.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.11.2022",
+        "Fallzahl": 270365,
+        "ObjectId": 986,
+        "Sterbefall": 1811,
+        "Genesungsfall": 266765,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7031,
+        "Zuwachs_Fallzahl": 194,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 25,
+        "Zuwachs_Genesung": 670,
+        "BelegteBetten": null,
+        "Inzidenz": 115.305865871619,
+        "Datum_neu": 1668643200000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "10.11.2022 - 16.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 92.4,
+        "Fallzahl_aktiv": 1789,
+        "Krh_N_belegt": 541,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -478,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.73,
+        "H_Zeitraum": "10.11.2022 - 17.11.2022",
+        "H_Datum": "15.11.2022",
+        "Datum_Bett": "16.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
