### PR TITLE
New data set: 2022-11-18T115504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-17T105704Z.json
+pjson/2022-11-18T115504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-17T105704Z.json pjson/2022-11-18T115504Z.json```:
```
--- pjson/2022-11-17T105704Z.json	2022-11-17 10:57:04.633636316 +0000
+++ pjson/2022-11-18T115504Z.json	2022-11-18 11:55:04.572063880 +0000
@@ -37314,7 +37314,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 275.333165702791,
+        "Inzidenz": null,
         "Datum_neu": 1667692800000,
         "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
@@ -37352,7 +37352,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 809,
         "BelegteBetten": null,
-        "Inzidenz": 265.095729013255,
+        "Inzidenz": null,
         "Datum_neu": 1667779200000,
         "F\u00e4lle_Meldedatum": 307,
         "Zeitraum": null,
@@ -37390,7 +37390,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 486,
         "BelegteBetten": null,
-        "Inzidenz": 302.45339272244,
+        "Inzidenz": null,
         "Datum_neu": 1667865600000,
         "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
@@ -37428,7 +37428,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 396,
         "BelegteBetten": null,
-        "Inzidenz": 265.275333165703,
+        "Inzidenz": null,
         "Datum_neu": 1667952000000,
         "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
@@ -37466,15 +37466,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 327,
         "BelegteBetten": null,
-        "Inzidenz": 230.43212759079,
+        "Inzidenz": null,
         "Datum_neu": 1668038400000,
         "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 217.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 757,
-        "Krh_I_belegt": 72,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37484,7 +37484,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.94,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.11.2022"
@@ -37522,7 +37522,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.34,
+        "H_Inzidenz": 7.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.11.2022"
@@ -37560,7 +37560,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.02,
+        "H_Inzidenz": 7.62,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.11.2022"
@@ -37598,7 +37598,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.88,
+        "H_Inzidenz": 7.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.11.2022"
@@ -37609,26 +37609,26 @@
         "Datum": "14.11.2022",
         "Fallzahl": 270016,
         "ObjectId": 983,
-        "Sterbefall": 1809,
-        "Genesungsfall": 265692,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 6995,
-        "Zuwachs_Fallzahl": 157,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
         "Inzidenz": 170.623944825604,
         "Datum_neu": 1668384000000,
-        "F\u00e4lle_Meldedatum": 157,
-        "Zeitraum": "07.11.2022 - 13.11.2022",
+        "F\u00e4lle_Meldedatum": 159,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 145.9,
-        "Fallzahl_aktiv": 2515,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 757,
         "Krh_I_belegt": 72,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -179,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37636,9 +37636,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
-        "H_Zeitraum": "07.11.2022 - 14.11.2022",
-        "H_Datum": "08.11.2022",
+        "H_Inzidenz": 7.32,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.11.2022"
       }
     },
@@ -37647,26 +37647,26 @@
         "Datum": "15.11.2022",
         "Fallzahl": 270171,
         "ObjectId": 984,
-        "Sterbefall": 1809,
-        "Genesungsfall": 266095,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7006,
-        "Zuwachs_Fallzahl": 155,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 403,
         "BelegteBetten": null,
         "Inzidenz": 143.324113653508,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 135,
-        "Zeitraum": "08.11.2022 - 14.11.2022",
+        "F\u00e4lle_Meldedatum": 137,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 123.9,
-        "Fallzahl_aktiv": 2267,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 757,
         "Krh_I_belegt": 72,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -248,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37674,16 +37674,16 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.2,
-        "H_Zeitraum": "08.11.2022 - 15.11.2022",
-        "H_Datum": "08.11.2022",
+        "H_Inzidenz": 7.02,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "14.11.2022"
       }
     },
     {
       "attributes": {
         "Datum": "16.11.2022",
-        "Fallzahl": 270348,
+        "Fallzahl": 270355,
         "ObjectId": 985,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -37694,10 +37694,10 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 133.086676963971,
+        "Inzidenz": 133.1,
         "Datum_neu": 1668556800000,
-        "F\u00e4lle_Meldedatum": 47,
-        "Zeitraum": "09.11.2022 - 15.11.2022",
+        "F\u00e4lle_Meldedatum": 50,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 118.7,
         "Fallzahl_aktiv": null,
@@ -37712,9 +37712,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.66,
-        "H_Zeitraum": "09.11.2022 - 16.11.2022",
-        "H_Datum": "15.11.2022",
+        "H_Inzidenz": 6.31,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.11.2022"
       }
     },
@@ -37725,18 +37725,18 @@
         "ObjectId": 986,
         "Sterbefall": 1811,
         "Genesungsfall": 266765,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7031,
         "Zuwachs_Fallzahl": 194,
         "Zuwachs_Sterbefall": 2,
         "Zuwachs_Krankenhauseinweisung": 25,
         "Zuwachs_Genesung": 670,
         "BelegteBetten": null,
-        "Inzidenz": 115.305865871619,
+        "Inzidenz": 115.3,
         "Datum_neu": 1668643200000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "10.11.2022 - 16.11.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 95,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 92.4,
         "Fallzahl_aktiv": 1789,
         "Krh_N_belegt": 541,
@@ -37750,11 +37750,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.73,
-        "H_Zeitraum": "10.11.2022 - 17.11.2022",
-        "H_Datum": "15.11.2022",
+        "H_Inzidenz": 5.52,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.11.2022",
+        "Fallzahl": 270473,
+        "ObjectId": 987,
+        "Sterbefall": 1811,
+        "Genesungsfall": 266981,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7039,
+        "Zuwachs_Fallzahl": 108,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 216,
+        "BelegteBetten": null,
+        "Inzidenz": 110.636157907971,
+        "Datum_neu": 1668729600000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": "11.11.2022 - 17.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 98.3,
+        "Fallzahl_aktiv": 1681,
+        "Krh_N_belegt": 541,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -108,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.75,
+        "H_Zeitraum": "11.11.2022 - 17.11.2022",
+        "H_Datum": "15.11.2022",
+        "Datum_Bett": "17.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
