### PR TITLE
New data set: 2022-11-21T125304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-18T115504Z.json
+pjson/2022-11-21T125304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-18T115504Z.json pjson/2022-11-21T125304Z.json```:
```
--- pjson/2022-11-18T115504Z.json	2022-11-18 11:55:04.572063880 +0000
+++ pjson/2022-11-21T125304Z.json	2022-11-21 12:53:04.746945728 +0000
@@ -37392,7 +37392,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667865600000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -37430,7 +37430,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667952000000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -37504,15 +37504,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 225,
         "BelegteBetten": null,
-        "Inzidenz": 197.025755235461,
+        "Inzidenz": null,
         "Datum_neu": 1668124800000,
-        "F\u00e4lle_Meldedatum": 113,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 180.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 757,
-        "Krh_I_belegt": 72,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37522,7 +37522,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.64,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.11.2022"
@@ -37542,15 +37542,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 179.065339990661,
+        "Inzidenz": null,
         "Datum_neu": 1668211200000,
         "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 163.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 757,
-        "Krh_I_belegt": 72,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37560,7 +37560,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.62,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.11.2022"
@@ -37580,15 +37580,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 175.4732569417,
+        "Inzidenz": null,
         "Datum_neu": 1668297600000,
         "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 154,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 757,
-        "Krh_I_belegt": 72,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37598,7 +37598,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.32,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.11.2022"
@@ -37620,7 +37620,7 @@
         "BelegteBetten": null,
         "Inzidenz": 170.623944825604,
         "Datum_neu": 1668384000000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 145.9,
@@ -37636,7 +37636,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.32,
+        "H_Inzidenz": 7.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.11.2022"
@@ -37658,9 +37658,9 @@
         "BelegteBetten": null,
         "Inzidenz": 143.324113653508,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 123.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 757,
@@ -37674,7 +37674,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.02,
+        "H_Inzidenz": 7.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.11.2022"
@@ -37712,7 +37712,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.31,
+        "H_Inzidenz": 6.93,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2022"
@@ -37723,26 +37723,26 @@
         "Datum": "17.11.2022",
         "Fallzahl": 270365,
         "ObjectId": 986,
-        "Sterbefall": 1811,
-        "Genesungsfall": 266765,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7031,
-        "Zuwachs_Fallzahl": 194,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 25,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 670,
         "BelegteBetten": null,
         "Inzidenz": 115.3,
         "Datum_neu": 1668643200000,
-        "F\u00e4lle_Meldedatum": 95,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 92.4,
-        "Fallzahl_aktiv": 1789,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 541,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -478,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37750,7 +37750,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.52,
+        "H_Inzidenz": 6.18,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2022"
@@ -37763,7 +37763,7 @@
         "ObjectId": 987,
         "Sterbefall": 1811,
         "Genesungsfall": 266981,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7039,
         "Zuwachs_Fallzahl": 108,
         "Zuwachs_Sterbefall": 0,
@@ -37772,9 +37772,9 @@
         "BelegteBetten": null,
         "Inzidenz": 110.636157907971,
         "Datum_neu": 1668729600000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "11.11.2022 - 17.11.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 117,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 98.3,
         "Fallzahl_aktiv": 1681,
         "Krh_N_belegt": 541,
@@ -37788,11 +37788,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.75,
-        "H_Zeitraum": "11.11.2022 - 17.11.2022",
-        "H_Datum": "15.11.2022",
+        "H_Inzidenz": 5.96,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "19.11.2022",
+        "Fallzahl": 270607,
+        "ObjectId": 988,
+        "Sterbefall": null,
+        "Genesungsfall": 267049,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1668816000000,
+        "F\u00e4lle_Meldedatum": 35,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 92.4,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 541,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.1,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "18.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.11.2022",
+        "Fallzahl": 270618,
+        "ObjectId": 989,
+        "Sterbefall": null,
+        "Genesungsfall": 267105,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1668902400000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 85.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 541,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.58,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "19.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.11.2022",
+        "Fallzahl": 270642,
+        "ObjectId": 990,
+        "Sterbefall": 1811,
+        "Genesungsfall": 267397,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7045,
+        "Zuwachs_Fallzahl": 169,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 416,
+        "BelegteBetten": null,
+        "Inzidenz": 113.150616042243,
+        "Datum_neu": 1668988800000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "15.11.2022 - 21.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 81.2,
+        "Fallzahl_aktiv": 1434,
+        "Krh_N_belegt": 541,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -247,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.38,
+        "H_Zeitraum": "15.11.2022 - 21.11.2022",
+        "H_Datum": "15.11.2022",
+        "Datum_Bett": "20.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
