### PR TITLE
New data set: 2022-11-22T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-21T125304Z.json
+pjson/2022-11-22T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-21T125304Z.json pjson/2022-11-22T110504Z.json```:
```
--- pjson/2022-11-21T125304Z.json	2022-11-21 12:53:04.746945728 +0000
+++ pjson/2022-11-22T110504Z.json	2022-11-22 11:05:04.719374117 +0000
@@ -36404,7 +36404,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665619200000,
-        "F\u00e4lle_Meldedatum": 546,
+        "F\u00e4lle_Meldedatum": 547,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -36708,7 +36708,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666310400000,
-        "F\u00e4lle_Meldedatum": 411,
+        "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -36822,7 +36822,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666569600000,
-        "F\u00e4lle_Meldedatum": 508,
+        "F\u00e4lle_Meldedatum": 507,
         "Zeitraum": null,
         "Hosp_Meldedatum": 22,
         "Inzidenz_RKI": null,
@@ -37164,7 +37164,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667347200000,
-        "F\u00e4lle_Meldedatum": 344,
+        "F\u00e4lle_Meldedatum": 343,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -37430,7 +37430,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667952000000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -37618,15 +37618,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 332,
         "BelegteBetten": null,
-        "Inzidenz": 170.623944825604,
+        "Inzidenz": null,
         "Datum_neu": 1668384000000,
         "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
-        "Inzidenz_RKI": 145.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 757,
-        "Krh_I_belegt": 72,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37636,7 +37636,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.52,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.11.2022"
@@ -37658,7 +37658,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.324113653508,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 123.9,
@@ -37712,7 +37712,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.93,
+        "H_Inzidenz": 7.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2022"
@@ -37734,7 +37734,7 @@
         "BelegteBetten": null,
         "Inzidenz": 115.3,
         "Datum_neu": 1668643200000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 92.4,
@@ -37750,7 +37750,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.18,
+        "H_Inzidenz": 6.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2022"
@@ -37761,26 +37761,26 @@
         "Datum": "18.11.2022",
         "Fallzahl": 270473,
         "ObjectId": 987,
-        "Sterbefall": 1811,
-        "Genesungsfall": 266981,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7039,
-        "Zuwachs_Fallzahl": 108,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 216,
         "BelegteBetten": null,
         "Inzidenz": 110.636157907971,
         "Datum_neu": 1668729600000,
-        "F\u00e4lle_Meldedatum": 117,
+        "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 98.3,
-        "Fallzahl_aktiv": 1681,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 541,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -108,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37788,7 +37788,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.96,
+        "H_Inzidenz": 6.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2022"
@@ -37800,7 +37800,7 @@
         "Fallzahl": 270607,
         "ObjectId": 988,
         "Sterbefall": null,
-        "Genesungsfall": 267049,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -37810,7 +37810,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668816000000,
-        "F\u00e4lle_Meldedatum": 35,
+        "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 92.4,
@@ -37826,7 +37826,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.1,
+        "H_Inzidenz": 6.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2022"
@@ -37838,7 +37838,7 @@
         "Fallzahl": 270618,
         "ObjectId": 989,
         "Sterbefall": null,
-        "Genesungsfall": 267105,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -37848,9 +37848,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668902400000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 85.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 541,
@@ -37864,7 +37864,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 5.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2022"
@@ -37877,7 +37877,7 @@
         "ObjectId": 990,
         "Sterbefall": 1811,
         "Genesungsfall": 267397,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7045,
         "Zuwachs_Fallzahl": 169,
         "Zuwachs_Sterbefall": 0,
@@ -37886,9 +37886,9 @@
         "BelegteBetten": null,
         "Inzidenz": 113.150616042243,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "15.11.2022 - 21.11.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 133,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 81.2,
         "Fallzahl_aktiv": 1434,
         "Krh_N_belegt": 541,
@@ -37902,11 +37902,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.38,
-        "H_Zeitraum": "15.11.2022 - 21.11.2022",
-        "H_Datum": "15.11.2022",
+        "H_Inzidenz": 5.66,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.11.2022",
+        "Fallzahl": 270806,
+        "ObjectId": 991,
+        "Sterbefall": 1811,
+        "Genesungsfall": 267598,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7064,
+        "Zuwachs_Fallzahl": 164,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 19,
+        "Zuwachs_Genesung": 201,
+        "BelegteBetten": null,
+        "Inzidenz": 115.485470024067,
+        "Datum_neu": 1669075200000,
+        "F\u00e4lle_Meldedatum": 34,
+        "Zeitraum": "16.11.2022 - 22.11.2022",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 84.5,
+        "Fallzahl_aktiv": 1397,
+        "Krh_N_belegt": 541,
+        "Krh_I_belegt": 56,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -37,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.73,
+        "H_Zeitraum": "16.11.2022 - 22.11.2022",
+        "H_Datum": "15.11.2022",
+        "Datum_Bett": "21.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
