### PR TITLE
New data set: 2022-11-23T110103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-22T110504Z.json
+pjson/2022-11-23T110103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-22T110504Z.json pjson/2022-11-23T110103Z.json```:
```
--- pjson/2022-11-22T110504Z.json	2022-11-22 11:05:04.719374117 +0000
+++ pjson/2022-11-23T110103Z.json	2022-11-23 11:01:04.071086138 +0000
@@ -37656,15 +37656,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 403,
         "BelegteBetten": null,
-        "Inzidenz": 143.324113653508,
+        "Inzidenz": null,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 123.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 757,
-        "Krh_I_belegt": 72,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37674,7 +37674,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.42,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.11.2022"
@@ -37712,7 +37712,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.02,
+        "H_Inzidenz": 7.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2022"
@@ -37750,7 +37750,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.31,
+        "H_Inzidenz": 6.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2022"
@@ -37788,7 +37788,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.46,
+        "H_Inzidenz": 7.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2022"
@@ -37810,7 +37810,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668816000000,
-        "F\u00e4lle_Meldedatum": 41,
+        "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 92.4,
@@ -37826,7 +37826,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.01,
+        "H_Inzidenz": 7.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2022"
@@ -37864,7 +37864,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.86,
+        "H_Inzidenz": 7.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2022"
@@ -37875,26 +37875,26 @@
         "Datum": "21.11.2022",
         "Fallzahl": 270642,
         "ObjectId": 990,
-        "Sterbefall": 1811,
-        "Genesungsfall": 267397,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7045,
-        "Zuwachs_Fallzahl": 169,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 416,
         "BelegteBetten": null,
         "Inzidenz": 113.150616042243,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 81.2,
-        "Fallzahl_aktiv": 1434,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 541,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -247,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37902,7 +37902,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.66,
+        "H_Inzidenz": 7.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2022"
@@ -37915,7 +37915,7 @@
         "ObjectId": 991,
         "Sterbefall": 1811,
         "Genesungsfall": 267598,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7064,
         "Zuwachs_Fallzahl": 164,
         "Zuwachs_Sterbefall": 0,
@@ -37924,9 +37924,9 @@
         "BelegteBetten": null,
         "Inzidenz": 115.485470024067,
         "Datum_neu": 1669075200000,
-        "F\u00e4lle_Meldedatum": 34,
-        "Zeitraum": "16.11.2022 - 22.11.2022",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 128,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 84.5,
         "Fallzahl_aktiv": 1397,
         "Krh_N_belegt": 541,
@@ -37940,11 +37940,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.73,
-        "H_Zeitraum": "16.11.2022 - 22.11.2022",
-        "H_Datum": "15.11.2022",
+        "H_Inzidenz": 6.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "23.11.2022",
+        "Fallzahl": 270941,
+        "ObjectId": 992,
+        "Sterbefall": 1811,
+        "Genesungsfall": 267762,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7082,
+        "Zuwachs_Fallzahl": 135,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 164,
+        "BelegteBetten": null,
+        "Inzidenz": 113.509824347139,
+        "Datum_neu": 1669161600000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "17.11.2022 - 23.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 89.3,
+        "Fallzahl_aktiv": 1368,
+        "Krh_N_belegt": 514,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -29,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.14,
+        "H_Zeitraum": "17.11.2022 - 23.11.2022",
+        "H_Datum": "22.11.2022",
+        "Datum_Bett": "22.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
