### PR TITLE
New data set: 2022-11-24T111403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-23T110103Z.json
+pjson/2022-11-24T111403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-23T110103Z.json pjson/2022-11-24T111403Z.json```:
```
--- pjson/2022-11-23T110103Z.json	2022-11-23 11:01:04.071086138 +0000
+++ pjson/2022-11-24T111403Z.json	2022-11-24 11:14:04.031120505 +0000
@@ -37202,7 +37202,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667433600000,
-        "F\u00e4lle_Meldedatum": 315,
+        "F\u00e4lle_Meldedatum": 314,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -37240,7 +37240,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667520000000,
-        "F\u00e4lle_Meldedatum": 206,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -37354,7 +37354,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667779200000,
-        "F\u00e4lle_Meldedatum": 307,
+        "F\u00e4lle_Meldedatum": 308,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -37620,7 +37620,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668384000000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -37658,7 +37658,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -37694,15 +37694,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": null,
         "BelegteBetten": null,
-        "Inzidenz": 133.1,
+        "Inzidenz": null,
         "Datum_neu": 1668556800000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 118.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 541,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37712,7 +37712,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.57,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.11.2022"
@@ -37734,7 +37734,7 @@
         "BelegteBetten": null,
         "Inzidenz": 115.3,
         "Datum_neu": 1668643200000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 92.4,
@@ -37750,7 +37750,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
+        "H_Inzidenz": 7.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2022"
@@ -37788,7 +37788,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.52,
+        "H_Inzidenz": 7.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2022"
@@ -37826,7 +37826,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.47,
+        "H_Inzidenz": 8.09,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2022"
@@ -37864,7 +37864,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.47,
+        "H_Inzidenz": 8.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2022"
@@ -37902,7 +37902,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.37,
+        "H_Inzidenz": 8.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2022"
@@ -37913,26 +37913,26 @@
         "Datum": "22.11.2022",
         "Fallzahl": 270806,
         "ObjectId": 991,
-        "Sterbefall": 1811,
-        "Genesungsfall": 267598,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7064,
-        "Zuwachs_Fallzahl": 164,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 201,
         "BelegteBetten": null,
         "Inzidenz": 115.485470024067,
         "Datum_neu": 1669075200000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 84.5,
-        "Fallzahl_aktiv": 1397,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 541,
         "Krh_I_belegt": 56,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -37,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37940,7 +37940,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.41,
+        "H_Inzidenz": 7.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2022"
@@ -37953,7 +37953,7 @@
         "ObjectId": 992,
         "Sterbefall": 1811,
         "Genesungsfall": 267762,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7082,
         "Zuwachs_Fallzahl": 135,
         "Zuwachs_Sterbefall": 0,
@@ -37962,9 +37962,9 @@
         "BelegteBetten": null,
         "Inzidenz": 113.509824347139,
         "Datum_neu": 1669161600000,
-        "F\u00e4lle_Meldedatum": 24,
-        "Zeitraum": "17.11.2022 - 23.11.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 140,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 89.3,
         "Fallzahl_aktiv": 1368,
         "Krh_N_belegt": 514,
@@ -37978,11 +37978,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.14,
-        "H_Zeitraum": "17.11.2022 - 23.11.2022",
-        "H_Datum": "22.11.2022",
+        "H_Inzidenz": 6.98,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "24.11.2022",
+        "Fallzahl": 271073,
+        "ObjectId": 993,
+        "Sterbefall": 1811,
+        "Genesungsfall": 267900,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7089,
+        "Zuwachs_Fallzahl": 132,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 138,
+        "BelegteBetten": null,
+        "Inzidenz": 111.893386975107,
+        "Datum_neu": 1669248000000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "18.11.2022 - 24.11.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 105.2,
+        "Fallzahl_aktiv": 1362,
+        "Krh_N_belegt": 514,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -6,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.78,
+        "H_Zeitraum": "18.11.2022 - 24.11.2022",
+        "H_Datum": "22.11.2022",
+        "Datum_Bett": "23.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
