### PR TITLE
New data set: 2022-11-25T110204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-24T111403Z.json
+pjson/2022-11-25T110204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-24T111403Z.json pjson/2022-11-25T110204Z.json```:
```
--- pjson/2022-11-24T111403Z.json	2022-11-24 11:14:04.031120505 +0000
+++ pjson/2022-11-25T110204Z.json	2022-11-25 11:02:04.849079880 +0000
@@ -36556,7 +36556,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665964800000,
-        "F\u00e4lle_Meldedatum": 662,
+        "F\u00e4lle_Meldedatum": 661,
         "Zeitraum": null,
         "Hosp_Meldedatum": 26,
         "Inzidenz_RKI": null,
@@ -36594,7 +36594,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 721,
+        "F\u00e4lle_Meldedatum": 722,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -36898,7 +36898,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666742400000,
-        "F\u00e4lle_Meldedatum": 371,
+        "F\u00e4lle_Meldedatum": 370,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -37658,7 +37658,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -37696,7 +37696,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668556800000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -37750,7 +37750,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.27,
+        "H_Inzidenz": 8.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2022"
@@ -37768,7 +37768,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 216,
+        "Zuwachs_Genesung": 215,
         "BelegteBetten": null,
         "Inzidenz": 110.636157907971,
         "Datum_neu": 1668729600000,
@@ -37788,7 +37788,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.94,
+        "H_Inzidenz": 8.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2022"
@@ -37826,7 +37826,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.09,
+        "H_Inzidenz": 9.23,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2022"
@@ -37864,7 +37864,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.16,
+        "H_Inzidenz": 9.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2022"
@@ -37886,7 +37886,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.150616042243,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 81.2,
@@ -37902,7 +37902,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.14,
+        "H_Inzidenz": 9.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2022"
@@ -37920,13 +37920,13 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 201,
+        "Zuwachs_Genesung": 202,
         "BelegteBetten": null,
         "Inzidenz": 115.485470024067,
         "Datum_neu": 1669075200000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 84.5,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 541,
@@ -37940,7 +37940,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.72,
+        "H_Inzidenz": 9.53,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2022"
@@ -37951,26 +37951,26 @@
         "Datum": "23.11.2022",
         "Fallzahl": 270941,
         "ObjectId": 992,
-        "Sterbefall": 1811,
-        "Genesungsfall": 267762,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7082,
-        "Zuwachs_Fallzahl": 135,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 164,
         "BelegteBetten": null,
         "Inzidenz": 113.509824347139,
         "Datum_neu": 1669161600000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 89.3,
-        "Fallzahl_aktiv": 1368,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 514,
         "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -29,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -37978,7 +37978,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
+        "H_Inzidenz": 7.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2022"
@@ -37991,24 +37991,24 @@
         "ObjectId": 993,
         "Sterbefall": 1811,
         "Genesungsfall": 267900,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7089,
         "Zuwachs_Fallzahl": 132,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 7,
-        "Zuwachs_Genesung": 138,
+        "Zuwachs_Genesung": 139,
         "BelegteBetten": null,
         "Inzidenz": 111.893386975107,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "18.11.2022 - 24.11.2022",
+        "F\u00e4lle_Meldedatum": 84,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 105.2,
         "Fallzahl_aktiv": 1362,
         "Krh_N_belegt": 514,
         "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -6,
+        "Fallzahl_aktiv_Zuwachs": -7,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -38016,11 +38016,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.78,
-        "H_Zeitraum": "18.11.2022 - 24.11.2022",
-        "H_Datum": "22.11.2022",
+        "H_Inzidenz": 7.49,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "23.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.11.2022",
+        "Fallzahl": 271182,
+        "ObjectId": 994,
+        "Sterbefall": 1811,
+        "Genesungsfall": 268008,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7091,
+        "Zuwachs_Fallzahl": 109,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 108,
+        "BelegteBetten": null,
+        "Inzidenz": 112.252595280003,
+        "Datum_neu": 1669334400000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "19.11.2022 - 25.11.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 110.6,
+        "Fallzahl_aktiv": 1363,
+        "Krh_N_belegt": 514,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.91,
+        "H_Zeitraum": "19.11.2022 - 25.11.2022",
+        "H_Datum": "22.11.2022",
+        "Datum_Bett": "24.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
