### PR TITLE
New data set: 2022-11-28T115004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-25T110204Z.json
+pjson/2022-11-28T115004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-25T110204Z.json pjson/2022-11-28T115004Z.json```:
```
--- pjson/2022-11-25T110204Z.json	2022-11-25 11:02:04.849079880 +0000
+++ pjson/2022-11-28T115004Z.json	2022-11-28 11:50:04.452210096 +0000
@@ -36064,7 +36064,7 @@
         "Datum_neu": 1664841600000,
         "F\u00e4lle_Meldedatum": 859,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 32,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36292,7 +36292,7 @@
         "Datum_neu": 1665360000000,
         "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 40,
+        "Hosp_Meldedatum": 37,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36330,7 +36330,7 @@
         "Datum_neu": 1665446400000,
         "F\u00e4lle_Meldedatum": 809,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
+        "Hosp_Meldedatum": 28,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36558,7 +36558,7 @@
         "Datum_neu": 1665964800000,
         "F\u00e4lle_Meldedatum": 661,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 26,
+        "Hosp_Meldedatum": 25,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36596,7 +36596,7 @@
         "Datum_neu": 1666051200000,
         "F\u00e4lle_Meldedatum": 722,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36672,7 +36672,7 @@
         "Datum_neu": 1666224000000,
         "F\u00e4lle_Meldedatum": 414,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36710,7 +36710,7 @@
         "Datum_neu": 1666310400000,
         "F\u00e4lle_Meldedatum": 412,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36786,7 +36786,7 @@
         "Datum_neu": 1666483200000,
         "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36976,7 +36976,7 @@
         "Datum_neu": 1666915200000,
         "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37128,7 +37128,7 @@
         "Datum_neu": 1667260800000,
         "F\u00e4lle_Meldedatum": 421,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37166,7 +37166,7 @@
         "Datum_neu": 1667347200000,
         "F\u00e4lle_Meldedatum": 343,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37204,7 +37204,7 @@
         "Datum_neu": 1667433600000,
         "F\u00e4lle_Meldedatum": 314,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37242,7 +37242,7 @@
         "Datum_neu": 1667520000000,
         "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37737,10 +37737,10 @@
         "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 92.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 541,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37750,7 +37750,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.67,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.11.2022"
@@ -37775,10 +37775,10 @@
         "F\u00e4lle_Meldedatum": 123,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 98.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 541,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37788,7 +37788,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.11.2022"
@@ -37813,10 +37813,10 @@
         "F\u00e4lle_Meldedatum": 42,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 92.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 541,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37826,7 +37826,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.23,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.11.2022"
@@ -37851,10 +37851,10 @@
         "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 85.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 541,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37864,7 +37864,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.11.2022"
@@ -37886,7 +37886,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.150616042243,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 81.2,
@@ -37902,7 +37902,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.4,
+        "H_Inzidenz": 8.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2022"
@@ -37924,7 +37924,7 @@
         "BelegteBetten": null,
         "Inzidenz": 115.485470024067,
         "Datum_neu": 1669075200000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 84.5,
@@ -37940,7 +37940,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.53,
+        "H_Inzidenz": 7.74,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2022"
@@ -37962,7 +37962,7 @@
         "BelegteBetten": null,
         "Inzidenz": 113.509824347139,
         "Datum_neu": 1669161600000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 89.3,
@@ -37978,7 +37978,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.22,
+        "H_Inzidenz": 7.42,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2022"
@@ -38000,7 +38000,7 @@
         "BelegteBetten": null,
         "Inzidenz": 111.893386975107,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 91,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 105.2,
@@ -38016,7 +38016,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.49,
+        "H_Inzidenz": 7.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2022"
@@ -38029,18 +38029,18 @@
         "ObjectId": 994,
         "Sterbefall": 1811,
         "Genesungsfall": 268008,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7091,
         "Zuwachs_Fallzahl": 109,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 2,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 112.252595280003,
+        "Inzidenz": 112.3,
         "Datum_neu": 1669334400000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "19.11.2022 - 25.11.2022",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 94,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 110.6,
         "Fallzahl_aktiv": 1363,
         "Krh_N_belegt": 514,
@@ -38054,11 +38054,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.91,
-        "H_Zeitraum": "19.11.2022 - 25.11.2022",
-        "H_Datum": "22.11.2022",
+        "H_Inzidenz": 7.37,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.11.2022",
+        "Fallzahl": 271280,
+        "ObjectId": 995,
+        "Sterbefall": null,
+        "Genesungsfall": 268043,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1669420800000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 107.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 514,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.18,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "25.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.11.2022",
+        "Fallzahl": 271303,
+        "ObjectId": 996,
+        "Sterbefall": null,
+        "Genesungsfall": 268077,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": null,
+        "Datum_neu": 1669507200000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 100.3,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 514,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "26.11.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.11.2022",
+        "Fallzahl": 271313,
+        "ObjectId": 997,
+        "Sterbefall": 1811,
+        "Genesungsfall": 268221,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7095,
+        "Zuwachs_Fallzahl": 131,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 213,
+        "BelegteBetten": null,
+        "Inzidenz": 119.616365530371,
+        "Datum_neu": 1669593600000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "21.11.2022 - 27.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 97.6,
+        "Fallzahl_aktiv": 1281,
+        "Krh_N_belegt": 514,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -82,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.32,
+        "H_Zeitraum": "21.11.2022 - 27.11.2022",
+        "H_Datum": "22.11.2022",
+        "Datum_Bett": "27.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
