### PR TITLE
New data set: 2022-11-29T112803Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-28T115004Z.json
+pjson/2022-11-29T112803Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-28T115004Z.json pjson/2022-11-29T112803Z.json```:
```
--- pjson/2022-11-28T115004Z.json	2022-11-28 11:50:04.452210096 +0000
+++ pjson/2022-11-29T112803Z.json	2022-11-29 11:28:04.307778623 +0000
@@ -37732,7 +37732,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 670,
         "BelegteBetten": null,
-        "Inzidenz": 115.3,
+        "Inzidenz": null,
         "Datum_neu": 1668643200000,
         "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
@@ -37770,9 +37770,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 215,
         "BelegteBetten": null,
-        "Inzidenz": 110.636157907971,
+        "Inzidenz": null,
         "Datum_neu": 1668729600000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -37810,7 +37810,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668816000000,
-        "F\u00e4lle_Meldedatum": 42,
+        "F\u00e4lle_Meldedatum": 43,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -37886,13 +37886,13 @@
         "BelegteBetten": null,
         "Inzidenz": 113.150616042243,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 151,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 81.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 541,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37902,7 +37902,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.11,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.11.2022"
@@ -37940,7 +37940,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
+        "H_Inzidenz": 7.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2022"
@@ -37978,7 +37978,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.42,
+        "H_Inzidenz": 7.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2022"
@@ -37989,13 +37989,13 @@
         "Datum": "24.11.2022",
         "Fallzahl": 271073,
         "ObjectId": 993,
-        "Sterbefall": 1811,
-        "Genesungsfall": 267900,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7089,
-        "Zuwachs_Fallzahl": 132,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 139,
         "BelegteBetten": null,
         "Inzidenz": 111.893386975107,
@@ -38004,11 +38004,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 105.2,
-        "Fallzahl_aktiv": 1362,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 514,
         "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -7,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -38016,7 +38016,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.96,
+        "H_Inzidenz": 8.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2022"
@@ -38027,34 +38027,34 @@
         "Datum": "25.11.2022",
         "Fallzahl": 271182,
         "ObjectId": 994,
-        "Sterbefall": 1811,
-        "Genesungsfall": 268008,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7091,
-        "Zuwachs_Fallzahl": 109,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
         "Inzidenz": 112.3,
         "Datum_neu": 1669334400000,
-        "F\u00e4lle_Meldedatum": 94,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 110.6,
-        "Fallzahl_aktiv": 1363,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 514,
         "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.37,
+        "H_Inzidenz": 8.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2022"
@@ -38063,10 +38063,10 @@
     {
       "attributes": {
         "Datum": "26.11.2022",
-        "Fallzahl": 271280,
+        "Fallzahl": 271295,
         "ObjectId": 995,
         "Sterbefall": null,
-        "Genesungsfall": 268043,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -38076,7 +38076,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669420800000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 107.9,
@@ -38092,7 +38092,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.18,
+        "H_Inzidenz": 7.2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2022"
@@ -38101,10 +38101,10 @@
     {
       "attributes": {
         "Datum": "27.11.2022",
-        "Fallzahl": 271303,
+        "Fallzahl": 271323,
         "ObjectId": 996,
         "Sterbefall": null,
-        "Genesungsfall": 268077,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -38114,7 +38114,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669507200000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 100.3,
@@ -38130,7 +38130,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": 6.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2022"
@@ -38143,18 +38143,18 @@
         "ObjectId": 997,
         "Sterbefall": 1811,
         "Genesungsfall": 268221,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7095,
         "Zuwachs_Fallzahl": 131,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Krankenhauseinweisung": 20,
         "Zuwachs_Genesung": 213,
         "BelegteBetten": null,
-        "Inzidenz": 119.616365530371,
+        "Inzidenz": 119.6,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "21.11.2022 - 27.11.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 179,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 97.6,
         "Fallzahl_aktiv": 1281,
         "Krh_N_belegt": 514,
@@ -38168,11 +38168,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
-        "H_Zeitraum": "21.11.2022 - 27.11.2022",
-        "H_Datum": "22.11.2022",
+        "H_Inzidenz": 6.8,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.11.2022",
+        "Fallzahl": 271553,
+        "ObjectId": 998,
+        "Sterbefall": 1811,
+        "Genesungsfall": 268347,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7117,
+        "Zuwachs_Fallzahl": 240,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 22,
+        "Zuwachs_Genesung": 126,
+        "BelegteBetten": null,
+        "Inzidenz": 127.339344085635,
+        "Datum_neu": 1669680000000,
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": "22.11.2022 - 28.11.2022",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 92.6,
+        "Fallzahl_aktiv": 1395,
+        "Krh_N_belegt": 514,
+        "Krh_I_belegt": 48,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 114,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.12,
+        "H_Zeitraum": "22.11.2022 - 28.11.2022",
+        "H_Datum": "22.11.2023",
+        "Datum_Bett": "28.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
