### PR TITLE
New data set: 2022-11-30T110603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-29T112803Z.json
+pjson/2022-11-30T110603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-29T112803Z.json pjson/2022-11-30T110603Z.json```:
```
--- pjson/2022-11-29T112803Z.json	2022-11-29 11:28:04.307778623 +0000
+++ pjson/2022-11-30T110603Z.json	2022-11-30 11:06:04.395552371 +0000
@@ -36176,7 +36176,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 670,
+        "F\u00e4lle_Meldedatum": 669,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -36476,7 +36476,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 129,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665792000000,
@@ -36514,7 +36514,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 173,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665878400000,
@@ -36552,7 +36552,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 420,
+        "Zuwachs_Genesung": 118,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665964800000,
@@ -37008,7 +37008,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 136,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667001600000,
@@ -37046,7 +37046,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 639,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667088000000,
@@ -37084,7 +37084,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 706,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667174400000,
@@ -37122,7 +37122,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1752,
+        "Zuwachs_Genesung": 271,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667260800000,
@@ -37274,7 +37274,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 212,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667606400000,
@@ -37312,7 +37312,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 109,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667692800000,
@@ -37350,7 +37350,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 809,
+        "Zuwachs_Genesung": 488,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667779200000,
@@ -37540,7 +37540,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668211200000,
@@ -37578,7 +37578,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 57,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668297600000,
@@ -37616,7 +37616,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 332,
+        "Zuwachs_Genesung": 207,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668384000000,
@@ -37692,7 +37692,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 317,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668556800000,
@@ -37730,7 +37730,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 670,
+        "Zuwachs_Genesung": 353,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668643200000,
@@ -37772,7 +37772,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668729600000,
-        "F\u00e4lle_Meldedatum": 124,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -37806,7 +37806,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668816000000,
@@ -37844,7 +37844,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 57,
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668902400000,
@@ -37882,9 +37882,9 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 416,
+        "Zuwachs_Genesung": 291,
         "BelegteBetten": null,
-        "Inzidenz": 113.150616042243,
+        "Inzidenz": null,
         "Datum_neu": 1668988800000,
         "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
@@ -37922,15 +37922,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 202,
         "BelegteBetten": null,
-        "Inzidenz": 115.485470024067,
+        "Inzidenz": null,
         "Datum_neu": 1669075200000,
         "F\u00e4lle_Meldedatum": 143,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 84.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 541,
-        "Krh_I_belegt": 56,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37940,7 +37940,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.96,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.11.2022"
@@ -37978,7 +37978,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.77,
+        "H_Inzidenz": 7.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2022"
@@ -38000,7 +38000,7 @@
         "BelegteBetten": null,
         "Inzidenz": 111.893386975107,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 91,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 105.2,
@@ -38016,7 +38016,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.36,
+        "H_Inzidenz": 8.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2022"
@@ -38038,7 +38038,7 @@
         "BelegteBetten": null,
         "Inzidenz": 112.3,
         "Datum_neu": 1669334400000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 105,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 110.6,
@@ -38054,7 +38054,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.01,
+        "H_Inzidenz": 8.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2022"
@@ -38072,11 +38072,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 125.543302561155,
         "Datum_neu": 1669420800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 107.9,
@@ -38092,7 +38092,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.2,
+        "H_Inzidenz": 7.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2022"
@@ -38110,9 +38110,9 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": null,
+        "Zuwachs_Genesung": 34,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 121.412407054851,
         "Datum_neu": 1669507200000,
         "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
@@ -38130,7 +38130,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.95,
+        "H_Inzidenz": 7.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2022"
@@ -38141,26 +38141,26 @@
         "Datum": "28.11.2022",
         "Fallzahl": 271313,
         "ObjectId": 997,
-        "Sterbefall": 1811,
-        "Genesungsfall": 268221,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7095,
-        "Zuwachs_Fallzahl": 131,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 20,
-        "Zuwachs_Genesung": 213,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 135,
         "BelegteBetten": null,
         "Inzidenz": 119.6,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 179,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 97.6,
-        "Fallzahl_aktiv": 1281,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 514,
         "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -82,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -38168,7 +38168,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.8,
+        "H_Inzidenz": 8.06,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2022"
@@ -38181,7 +38181,7 @@
         "ObjectId": 998,
         "Sterbefall": 1811,
         "Genesungsfall": 268347,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7117,
         "Zuwachs_Fallzahl": 240,
         "Zuwachs_Sterbefall": 0,
@@ -38190,9 +38190,9 @@
         "BelegteBetten": null,
         "Inzidenz": 127.339344085635,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": "22.11.2022 - 28.11.2022",
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 92.6,
         "Fallzahl_aktiv": 1395,
         "Krh_N_belegt": 514,
@@ -38206,11 +38206,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.12,
+        "H_Inzidenz": 7.17,
         "H_Zeitraum": "22.11.2022 - 28.11.2022",
         "H_Datum": "22.11.2023",
         "Datum_Bett": "28.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.11.2022",
+        "Fallzahl": 271730,
+        "ObjectId": 999,
+        "Sterbefall": 1811,
+        "Genesungsfall": 268402,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7122,
+        "Zuwachs_Fallzahl": 177,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 55,
+        "BelegteBetten": null,
+        "Inzidenz": 139.911634756996,
+        "Datum_neu": 1669766400000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "23.11.2022 - 29.11.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 107.9,
+        "Fallzahl_aktiv": 1517,
+        "Krh_N_belegt": 637,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 122,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.06,
+        "H_Zeitraum": "23.11.2022 - 29.11.2022",
+        "H_Datum": "29.11.2022",
+        "Datum_Bett": "29.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
