### PR TITLE
New data set: 2022-12-01T110304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-11-30T110603Z.json
+pjson/2022-12-01T110304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-11-30T110603Z.json pjson/2022-12-01T110304Z.json```:
```
--- pjson/2022-11-30T110603Z.json	2022-11-30 11:06:04.395552371 +0000
+++ pjson/2022-12-01T110304Z.json	2022-12-01 11:03:04.863294044 +0000
@@ -37164,7 +37164,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667347200000,
-        "F\u00e4lle_Meldedatum": 343,
+        "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -37964,7 +37964,7 @@
         "Datum_neu": 1669161600000,
         "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 89.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 514,
@@ -37978,7 +37978,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.87,
+        "H_Inzidenz": 7.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2022"
@@ -38000,7 +38000,7 @@
         "BelegteBetten": null,
         "Inzidenz": 111.893386975107,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 105.2,
@@ -38016,7 +38016,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.56,
+        "H_Inzidenz": 8.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2022"
@@ -38038,7 +38038,7 @@
         "BelegteBetten": null,
         "Inzidenz": 112.3,
         "Datum_neu": 1669334400000,
-        "F\u00e4lle_Meldedatum": 105,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 110.6,
@@ -38054,7 +38054,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.43,
+        "H_Inzidenz": 8.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2022"
@@ -38092,7 +38092,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.99,
+        "H_Inzidenz": 8.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2022"
@@ -38130,7 +38130,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.94,
+        "H_Inzidenz": 8.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2022"
@@ -38152,9 +38152,9 @@
         "BelegteBetten": null,
         "Inzidenz": 119.6,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 97.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 514,
@@ -38168,7 +38168,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.06,
+        "H_Inzidenz": 8.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2022"
@@ -38179,36 +38179,36 @@
         "Datum": "29.11.2022",
         "Fallzahl": 271553,
         "ObjectId": 998,
-        "Sterbefall": 1811,
-        "Genesungsfall": 268347,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7117,
-        "Zuwachs_Fallzahl": 240,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 22,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
         "Inzidenz": 127.339344085635,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 202,
-        "Zeitraum": "22.11.2022 - 28.11.2022",
+        "F\u00e4lle_Meldedatum": 223,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 92.6,
-        "Fallzahl_aktiv": 1395,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 514,
         "Krh_I_belegt": 48,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 114,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.17,
-        "H_Zeitraum": "22.11.2022 - 28.11.2022",
-        "H_Datum": "22.11.2023",
+        "H_Inzidenz": 8.11,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.11.2022"
       }
     },
@@ -38219,7 +38219,7 @@
         "ObjectId": 999,
         "Sterbefall": 1811,
         "Genesungsfall": 268402,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7122,
         "Zuwachs_Fallzahl": 177,
         "Zuwachs_Sterbefall": 0,
@@ -38228,9 +38228,9 @@
         "BelegteBetten": null,
         "Inzidenz": 139.911634756996,
         "Datum_neu": 1669766400000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "23.11.2022 - 29.11.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 125,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 107.9,
         "Fallzahl_aktiv": 1517,
         "Krh_N_belegt": 637,
@@ -38244,11 +38244,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.06,
-        "H_Zeitraum": "23.11.2022 - 29.11.2022",
-        "H_Datum": "29.11.2022",
+        "H_Inzidenz": 7.42,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.12.2022",
+        "Fallzahl": 271891,
+        "ObjectId": 1000,
+        "Sterbefall": 1812,
+        "Genesungsfall": 268520,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7128,
+        "Zuwachs_Fallzahl": 161,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 118,
+        "BelegteBetten": null,
+        "Inzidenz": 140.809655519236,
+        "Datum_neu": 1669852800000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "24.11.2022 - 30.11.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 114.9,
+        "Fallzahl_aktiv": 1559,
+        "Krh_N_belegt": 637,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 42,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.48,
+        "H_Zeitraum": "24.11.2022 - 30.11.2022",
+        "H_Datum": "29.11.2022",
+        "Datum_Bett": "30.11.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
