### PR TITLE
New data set: 2022-12-02T110403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-01T110304Z.json
+pjson/2022-12-02T110403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-01T110304Z.json pjson/2022-12-02T110403Z.json```:
```
--- pjson/2022-12-01T110304Z.json	2022-12-01 11:03:04.863294044 +0000
+++ pjson/2022-12-02T110403Z.json	2022-12-02 11:04:04.354232701 +0000
@@ -36176,7 +36176,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1665100800000,
-        "F\u00e4lle_Meldedatum": 669,
+        "F\u00e4lle_Meldedatum": 668,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -37734,7 +37734,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668643200000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -37960,15 +37960,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 164,
         "BelegteBetten": null,
-        "Inzidenz": 113.509824347139,
+        "Inzidenz": null,
         "Datum_neu": 1669161600000,
         "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 89.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 514,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -37978,7 +37978,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.99,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.11.2022"
@@ -37998,15 +37998,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 139,
         "BelegteBetten": null,
-        "Inzidenz": 111.893386975107,
+        "Inzidenz": null,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 105.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 514,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38016,7 +38016,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.11.2022"
@@ -38054,7 +38054,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.66,
+        "H_Inzidenz": 8.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2022"
@@ -38076,7 +38076,7 @@
         "BelegteBetten": null,
         "Inzidenz": 125.543302561155,
         "Datum_neu": 1669420800000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 107.9,
@@ -38092,7 +38092,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.31,
+        "H_Inzidenz": 8.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2022"
@@ -38114,7 +38114,7 @@
         "BelegteBetten": null,
         "Inzidenz": 121.412407054851,
         "Datum_neu": 1669507200000,
-        "F\u00e4lle_Meldedatum": 28,
+        "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 100.3,
@@ -38130,7 +38130,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.29,
+        "H_Inzidenz": 8.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2022"
@@ -38152,7 +38152,7 @@
         "BelegteBetten": null,
         "Inzidenz": 119.6,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 97.6,
@@ -38168,7 +38168,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.51,
+        "H_Inzidenz": 8.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2022"
@@ -38190,7 +38190,7 @@
         "BelegteBetten": null,
         "Inzidenz": 127.339344085635,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 223,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 92.6,
@@ -38206,7 +38206,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.11,
+        "H_Inzidenz": 8.26,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2022"
@@ -38217,34 +38217,34 @@
         "Datum": "30.11.2022",
         "Fallzahl": 271730,
         "ObjectId": 999,
-        "Sterbefall": 1811,
-        "Genesungsfall": 268402,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7122,
-        "Zuwachs_Fallzahl": 177,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
         "Inzidenz": 139.911634756996,
         "Datum_neu": 1669766400000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 107.9,
-        "Fallzahl_aktiv": 1517,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 122,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.42,
+        "H_Inzidenz": 8.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2022"
@@ -38257,7 +38257,7 @@
         "ObjectId": 1000,
         "Sterbefall": 1812,
         "Genesungsfall": 268520,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7128,
         "Zuwachs_Fallzahl": 161,
         "Zuwachs_Sterbefall": 1,
@@ -38266,9 +38266,9 @@
         "BelegteBetten": null,
         "Inzidenz": 140.809655519236,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": "24.11.2022 - 30.11.2022",
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 114.9,
         "Fallzahl_aktiv": 1559,
         "Krh_N_belegt": 637,
@@ -38282,11 +38282,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
+        "H_Inzidenz": 7.94,
         "H_Zeitraum": "24.11.2022 - 30.11.2022",
         "H_Datum": "29.11.2022",
         "Datum_Bett": "30.11.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "02.12.2022",
+        "Fallzahl": 272031,
+        "ObjectId": 1001,
+        "Sterbefall": 1812,
+        "Genesungsfall": 268654,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7140,
+        "Zuwachs_Fallzahl": 140,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 134,
+        "BelegteBetten": null,
+        "Inzidenz": 148.173425769604,
+        "Datum_neu": 1669939200000,
+        "F\u00e4lle_Meldedatum": 32,
+        "Zeitraum": "25.11.2022 - 01.12.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 128.4,
+        "Fallzahl_aktiv": 1565,
+        "Krh_N_belegt": 637,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 6,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.18,
+        "H_Zeitraum": "25.11.2022 - 01.12.2022",
+        "H_Datum": "29.11.2022",
+        "Datum_Bett": "01.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
