### PR TITLE
New data set: 2022-12-05T110404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-02T110403Z.json
+pjson/2022-12-05T110404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-02T110403Z.json pjson/2022-12-05T110404Z.json```:
```
--- pjson/2022-12-02T110403Z.json	2022-12-02 11:04:04.354232701 +0000
+++ pjson/2022-12-05T110404Z.json	2022-12-05 11:04:04.557183204 +0000
@@ -36368,7 +36368,7 @@
         "Datum_neu": 1665532800000,
         "F\u00e4lle_Meldedatum": 617,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 28,
+        "Hosp_Meldedatum": 27,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37166,7 +37166,7 @@
         "Datum_neu": 1667347200000,
         "F\u00e4lle_Meldedatum": 342,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37508,7 +37508,7 @@
         "Datum_neu": 1668124800000,
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37518,7 +37518,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37736,7 +37736,7 @@
         "Datum_neu": 1668643200000,
         "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37746,7 +37746,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37784,7 +37784,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37822,7 +37822,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37886,7 +37886,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -37898,7 +37898,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37924,7 +37924,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669075200000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 142,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -38038,13 +38038,13 @@
         "BelegteBetten": null,
         "Inzidenz": 112.3,
         "Datum_neu": 1669334400000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 110.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 514,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38054,7 +38054,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.68,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.11.2022"
@@ -38076,13 +38076,13 @@
         "BelegteBetten": null,
         "Inzidenz": 125.543302561155,
         "Datum_neu": 1669420800000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 107.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 514,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38092,7 +38092,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.11.2022"
@@ -38114,13 +38114,13 @@
         "BelegteBetten": null,
         "Inzidenz": 121.412407054851,
         "Datum_neu": 1669507200000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 100.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 514,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38130,7 +38130,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.34,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.11.2022"
@@ -38152,7 +38152,7 @@
         "BelegteBetten": null,
         "Inzidenz": 119.6,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 97.6,
@@ -38190,7 +38190,7 @@
         "BelegteBetten": null,
         "Inzidenz": 127.339344085635,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 226,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 92.6,
@@ -38206,7 +38206,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.26,
+        "H_Inzidenz": 8.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2022"
@@ -38228,7 +38228,7 @@
         "BelegteBetten": null,
         "Inzidenz": 139.911634756996,
         "Datum_neu": 1669766400000,
-        "F\u00e4lle_Meldedatum": 134,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 107.9,
@@ -38244,7 +38244,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.11,
+        "H_Inzidenz": 8.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2022"
@@ -38255,36 +38255,36 @@
         "Datum": "01.12.2022",
         "Fallzahl": 271891,
         "ObjectId": 1000,
-        "Sterbefall": 1812,
-        "Genesungsfall": 268520,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7128,
-        "Zuwachs_Fallzahl": 161,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 118,
         "BelegteBetten": null,
         "Inzidenz": 140.809655519236,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 122,
-        "Zeitraum": "24.11.2022 - 30.11.2022",
-        "Hosp_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 135,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 114.9,
-        "Fallzahl_aktiv": 1559,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 42,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.94,
-        "H_Zeitraum": "24.11.2022 - 30.11.2022",
-        "H_Datum": "29.11.2022",
+        "H_Inzidenz": 8.46,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "30.11.2022"
       }
     },
@@ -38295,7 +38295,7 @@
         "ObjectId": 1001,
         "Sterbefall": 1812,
         "Genesungsfall": 268654,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7140,
         "Zuwachs_Fallzahl": 140,
         "Zuwachs_Sterbefall": 0,
@@ -38304,9 +38304,9 @@
         "BelegteBetten": null,
         "Inzidenz": 148.173425769604,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 32,
+        "F\u00e4lle_Meldedatum": 116,
         "Zeitraum": "25.11.2022 - 01.12.2022",
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 128.4,
         "Fallzahl_aktiv": 1565,
         "Krh_N_belegt": 637,
@@ -38320,11 +38320,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.18,
+        "H_Inzidenz": 7.17,
         "H_Zeitraum": "25.11.2022 - 01.12.2022",
         "H_Datum": "29.11.2022",
         "Datum_Bett": "01.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.12.2022",
+        "Fallzahl": 272064,
+        "ObjectId": 1002,
+        "Sterbefall": 1812,
+        "Genesungsfall": 268655,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7140,
+        "Zuwachs_Fallzahl": 33,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 134.703114336003,
+        "Datum_neu": 1670025600000,
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": "26.11.2022 - 02.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 132.5,
+        "Fallzahl_aktiv": 1597,
+        "Krh_N_belegt": 637,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.21,
+        "H_Zeitraum": "26.11.2022 - 02.12.2022",
+        "H_Datum": "29.11.2022",
+        "Datum_Bett": "02.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.12.2022",
+        "Fallzahl": 272098,
+        "ObjectId": 1003,
+        "Sterbefall": 1812,
+        "Genesungsfall": 268656,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7140,
+        "Zuwachs_Fallzahl": 34,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": null,
+        "BelegteBetten": null,
+        "Inzidenz": 137.217572470276,
+        "Datum_neu": 1670112000000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "27.11.2022 - 03.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 129.1,
+        "Fallzahl_aktiv": 1630,
+        "Krh_N_belegt": 637,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.74,
+        "H_Zeitraum": "27.11.2022 - 03.12.2022",
+        "H_Datum": "29.11.2022",
+        "Datum_Bett": "03.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.12.2022",
+        "Fallzahl": 272199,
+        "ObjectId": 1004,
+        "Sterbefall": 1818,
+        "Genesungsfall": 268864,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7150,
+        "Zuwachs_Fallzahl": 168,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 210,
+        "BelegteBetten": null,
+        "Inzidenz": 155.177987715076,
+        "Datum_neu": 1670198400000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "28.11.2022 - 04.12.2022",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 124.2,
+        "Fallzahl_aktiv": 1517,
+        "Krh_N_belegt": 637,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -48,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.07,
+        "H_Zeitraum": "28.11.2022 - 04.12.2022",
+        "H_Datum": "29.11.2022",
+        "Datum_Bett": "04.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
