### PR TITLE
New data set: 2022-12-06T105004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-05T110404Z.json
+pjson/2022-12-06T105004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-05T110404Z.json pjson/2022-12-06T105004Z.json```:
```
--- pjson/2022-12-05T110404Z.json	2022-12-05 11:04:04.557183204 +0000
+++ pjson/2022-12-06T105004Z.json	2022-12-06 10:50:05.343947765 +0000
@@ -37962,7 +37962,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669161600000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 146,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -38036,7 +38036,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 108,
         "BelegteBetten": null,
-        "Inzidenz": 112.3,
+        "Inzidenz": null,
         "Datum_neu": 1669334400000,
         "F\u00e4lle_Meldedatum": 106,
         "Zeitraum": null,
@@ -38074,7 +38074,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 125.543302561155,
+        "Inzidenz": null,
         "Datum_neu": 1669420800000,
         "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
@@ -38112,7 +38112,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 34,
         "BelegteBetten": null,
-        "Inzidenz": 121.412407054851,
+        "Inzidenz": null,
         "Datum_neu": 1669507200000,
         "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
@@ -38150,15 +38150,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 135,
         "BelegteBetten": null,
-        "Inzidenz": 119.6,
+        "Inzidenz": null,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 97.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 514,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38168,7 +38168,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.11.2022"
@@ -38190,7 +38190,7 @@
         "BelegteBetten": null,
         "Inzidenz": 127.339344085635,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 226,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 92.6,
@@ -38206,7 +38206,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.29,
+        "H_Inzidenz": 8.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2022"
@@ -38228,7 +38228,7 @@
         "BelegteBetten": null,
         "Inzidenz": 139.911634756996,
         "Datum_neu": 1669766400000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 107.9,
@@ -38244,7 +38244,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.19,
+        "H_Inzidenz": 8.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2022"
@@ -38266,7 +38266,7 @@
         "BelegteBetten": null,
         "Inzidenz": 140.809655519236,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 135,
+        "F\u00e4lle_Meldedatum": 137,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 114.9,
@@ -38282,7 +38282,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.46,
+        "H_Inzidenz": 8.68,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.11.2022"
@@ -38293,36 +38293,36 @@
         "Datum": "02.12.2022",
         "Fallzahl": 272031,
         "ObjectId": 1001,
-        "Sterbefall": 1812,
-        "Genesungsfall": 268654,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7140,
-        "Zuwachs_Fallzahl": 140,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 134,
         "BelegteBetten": null,
         "Inzidenz": 148.173425769604,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 116,
-        "Zeitraum": "25.11.2022 - 01.12.2022",
+        "F\u00e4lle_Meldedatum": 123,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 128.4,
-        "Fallzahl_aktiv": 1565,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 6,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.17,
-        "H_Zeitraum": "25.11.2022 - 01.12.2022",
-        "H_Datum": "29.11.2022",
+        "H_Inzidenz": 7.77,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.12.2022"
       }
     },
@@ -38331,22 +38331,22 @@
         "Datum": "03.12.2022",
         "Fallzahl": 272064,
         "ObjectId": 1002,
-        "Sterbefall": 1812,
-        "Genesungsfall": 268655,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7140,
-        "Zuwachs_Fallzahl": 33,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
         "Inzidenz": 134.703114336003,
         "Datum_neu": 1670025600000,
-        "F\u00e4lle_Meldedatum": 55,
-        "Zeitraum": "26.11.2022 - 02.12.2022",
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 132.5,
-        "Fallzahl_aktiv": 1597,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
@@ -38358,9 +38358,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.21,
-        "H_Zeitraum": "26.11.2022 - 02.12.2022",
-        "H_Datum": "29.11.2022",
+        "H_Inzidenz": 7.49,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.12.2022"
       }
     },
@@ -38369,22 +38369,22 @@
         "Datum": "04.12.2022",
         "Fallzahl": 272098,
         "ObjectId": 1003,
-        "Sterbefall": 1812,
-        "Genesungsfall": 268656,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7140,
-        "Zuwachs_Fallzahl": 34,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
         "Inzidenz": 137.217572470276,
         "Datum_neu": 1670112000000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 21,
         "Zeitraum": "27.11.2022 - 03.12.2022",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 129.1,
-        "Fallzahl_aktiv": 1630,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
@@ -38392,11 +38392,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": 7.32,
         "H_Zeitraum": "27.11.2022 - 03.12.2022",
         "H_Datum": "29.11.2022",
         "Datum_Bett": "03.12.2022"
@@ -38409,36 +38409,74 @@
         "ObjectId": 1004,
         "Sterbefall": 1818,
         "Genesungsfall": 268864,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7150,
         "Zuwachs_Fallzahl": 168,
         "Zuwachs_Sterbefall": 6,
         "Zuwachs_Krankenhauseinweisung": 10,
-        "Zuwachs_Genesung": 210,
+        "Zuwachs_Genesung": 133,
         "BelegteBetten": null,
         "Inzidenz": 155.177987715076,
         "Datum_neu": 1670198400000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 134,
         "Zeitraum": "28.11.2022 - 04.12.2022",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 124.2,
         "Fallzahl_aktiv": 1517,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -48,
+        "Fallzahl_aktiv_Zuwachs": 29,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.07,
+        "H_Inzidenz": 7.05,
         "H_Zeitraum": "28.11.2022 - 04.12.2022",
         "H_Datum": "29.11.2022",
         "Datum_Bett": "04.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "06.12.2022",
+        "Fallzahl": 272395,
+        "ObjectId": 1005,
+        "Sterbefall": 1820,
+        "Genesungsfall": 268994,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7152,
+        "Zuwachs_Fallzahl": 196,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 130,
+        "BelegteBetten": null,
+        "Inzidenz": 150.508279751428,
+        "Datum_neu": 1670284800000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "29.11.2022 - 05.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 122.6,
+        "Fallzahl_aktiv": 1581,
+        "Krh_N_belegt": 637,
+        "Krh_I_belegt": 50,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 64,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.81,
+        "H_Zeitraum": "29.11.2022 - 05.12.2022",
+        "H_Datum": "29.11.2022",
+        "Datum_Bett": "05.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
