### PR TITLE
New data set: 2022-12-08T114303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-07T111603Z.json
+pjson/2022-12-08T114303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-07T111603Z.json pjson/2022-12-08T114303Z.json```:
```
--- pjson/2022-12-07T111603Z.json	2022-12-07 11:16:04.067330021 +0000
+++ pjson/2022-12-08T114303Z.json	2022-12-08 11:43:04.332607594 +0000
@@ -37708,7 +37708,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37962,7 +37962,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669161600000,
-        "F\u00e4lle_Meldedatum": 146,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -38000,7 +38000,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 93,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38012,7 +38012,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38076,7 +38076,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669420800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 17,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38152,7 +38152,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -38188,15 +38188,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
-        "Inzidenz": 127.339344085635,
+        "Inzidenz": null,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 226,
+        "F\u00e4lle_Meldedatum": 225,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 92.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 514,
-        "Krh_I_belegt": 48,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38206,7 +38206,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.24,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.11.2022"
@@ -38244,7 +38244,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.24,
+        "H_Inzidenz": 9.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2022"
@@ -38266,7 +38266,7 @@
         "BelegteBetten": null,
         "Inzidenz": 140.809655519236,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 114.9,
@@ -38282,7 +38282,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.68,
+        "H_Inzidenz": 10.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.11.2022"
@@ -38304,7 +38304,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.173425769604,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 123,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 128.4,
@@ -38320,7 +38320,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.77,
+        "H_Inzidenz": 9.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.12.2022"
@@ -38342,7 +38342,7 @@
         "BelegteBetten": null,
         "Inzidenz": 134.703114336003,
         "Datum_neu": 1670025600000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 132.5,
@@ -38358,7 +38358,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.49,
+        "H_Inzidenz": 10.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.12.2022"
@@ -38382,7 +38382,7 @@
         "Datum_neu": 1670112000000,
         "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 129.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
@@ -38396,7 +38396,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.32,
+        "H_Inzidenz": 10.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.12.2022"
@@ -38407,34 +38407,34 @@
         "Datum": "05.12.2022",
         "Fallzahl": 272199,
         "ObjectId": 1004,
-        "Sterbefall": 1818,
-        "Genesungsfall": 268864,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7150,
-        "Zuwachs_Fallzahl": 168,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 133,
         "BelegteBetten": null,
         "Inzidenz": 155.177987715076,
         "Datum_neu": 1670198400000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 124.2,
-        "Fallzahl_aktiv": 1517,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 29,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.05,
+        "H_Inzidenz": 10.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2022"
@@ -38445,34 +38445,34 @@
         "Datum": "06.12.2022",
         "Fallzahl": 272395,
         "ObjectId": 1005,
-        "Sterbefall": 1820,
-        "Genesungsfall": 268994,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7152,
-        "Zuwachs_Fallzahl": 196,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 130,
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1670284800000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 122.6,
-        "Fallzahl_aktiv": 1581,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 637,
         "Krh_I_belegt": 50,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 64,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.81,
+        "H_Inzidenz": 9.99,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2022"
@@ -38485,7 +38485,7 @@
         "ObjectId": 1006,
         "Sterbefall": 1820,
         "Genesungsfall": 269148,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7167,
         "Zuwachs_Fallzahl": 184,
         "Zuwachs_Sterbefall": 0,
@@ -38494,9 +38494,9 @@
         "BelegteBetten": null,
         "Inzidenz": 142.785301196164,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 47,
-        "Zeitraum": "30.11.2022 - 06.12.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 140,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 118.1,
         "Fallzahl_aktiv": 1611,
         "Krh_N_belegt": 744,
@@ -38510,11 +38510,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.81,
-        "H_Zeitraum": "30.11.2022 - 06.12.2022",
-        "H_Datum": "06.12.2022",
+        "H_Inzidenz": 9.03,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.12.2022",
+        "Fallzahl": 272736,
+        "ObjectId": 1007,
+        "Sterbefall": 1822,
+        "Genesungsfall": 269247,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7177,
+        "Zuwachs_Fallzahl": 157,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 99,
+        "BelegteBetten": null,
+        "Inzidenz": 145.83857178778,
+        "Datum_neu": 1670457600000,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": "01.12.2022 - 07.12.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 122.1,
+        "Fallzahl_aktiv": 1667,
+        "Krh_N_belegt": 744,
+        "Krh_I_belegt": 52,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 56,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.59,
+        "H_Zeitraum": "01.12.2022 - 07.12.2022",
+        "H_Datum": "06.12.2022",
+        "Datum_Bett": "07.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
