### PR TITLE
New data set: 2022-12-09T111403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-07T111603Z.json
+pjson/2022-12-09T111403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-08T114303Z.json pjson/2022-12-09T111403Z.json```:
```
--- pjson/2022-12-08T114303Z.json	2022-12-08 11:43:04.332607594 +0000
+++ pjson/2022-12-09T111403Z.json	2022-12-09 11:14:04.353040419 +0000
@@ -29994,7 +29994,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37356,7 +37356,7 @@
         "Datum_neu": 1667779200000,
         "F\u00e4lle_Meldedatum": 308,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38000,7 +38000,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 93,
+        "F\u00e4lle_Meldedatum": 92,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38228,13 +38228,13 @@
         "BelegteBetten": null,
         "Inzidenz": 139.911634756996,
         "Datum_neu": 1669766400000,
-        "F\u00e4lle_Meldedatum": 137,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 107.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 637,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38244,7 +38244,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.89,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.11.2022"
@@ -38282,7 +38282,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.66,
+        "H_Inzidenz": 11.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.11.2022"
@@ -38304,7 +38304,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.173425769604,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": 128.4,
@@ -38320,7 +38320,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.87,
+        "H_Inzidenz": 10.29,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.12.2022"
@@ -38358,7 +38358,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.24,
+        "H_Inzidenz": 10.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.12.2022"
@@ -38380,7 +38380,7 @@
         "BelegteBetten": null,
         "Inzidenz": 137.217572470276,
         "Datum_neu": 1670112000000,
-        "F\u00e4lle_Meldedatum": 25,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 129.1,
@@ -38392,11 +38392,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.14,
+        "H_Inzidenz": 10.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.12.2022"
@@ -38434,7 +38434,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.02,
+        "H_Inzidenz": 10.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2022"
@@ -38456,7 +38456,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1670284800000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 122.6,
@@ -38472,7 +38472,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.99,
+        "H_Inzidenz": 11.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2022"
@@ -38483,34 +38483,34 @@
         "Datum": "07.12.2022",
         "Fallzahl": 272579,
         "ObjectId": 1006,
-        "Sterbefall": 1820,
-        "Genesungsfall": 269148,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7167,
-        "Zuwachs_Fallzahl": 184,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 154,
         "BelegteBetten": null,
         "Inzidenz": 142.785301196164,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 149,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 118.1,
-        "Fallzahl_aktiv": 1611,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
         "Krh_I_belegt": 52,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 30,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.03,
+        "H_Inzidenz": 10.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2022"
@@ -38523,7 +38523,7 @@
         "ObjectId": 1007,
         "Sterbefall": 1822,
         "Genesungsfall": 269247,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7177,
         "Zuwachs_Fallzahl": 157,
         "Zuwachs_Sterbefall": 2,
@@ -38532,9 +38532,9 @@
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 49,
-        "Zeitraum": "01.12.2022 - 07.12.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 126,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 122.1,
         "Fallzahl_aktiv": 1667,
         "Krh_N_belegt": 744,
@@ -38548,11 +38548,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
-        "H_Zeitraum": "01.12.2022 - 07.12.2022",
-        "H_Datum": "06.12.2022",
+        "H_Inzidenz": 9.1,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "09.12.2022",
+        "Fallzahl": 272848,
+        "ObjectId": 1008,
+        "Sterbefall": 1824,
+        "Genesungsfall": 269348,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7195,
+        "Zuwachs_Fallzahl": 112,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 101,
+        "BelegteBetten": null,
+        "Inzidenz": 145.479363482884,
+        "Datum_neu": 1670544000000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": "02.12.2022 - 08.12.2022",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 128.9,
+        "Fallzahl_aktiv": 1676,
+        "Krh_N_belegt": 744,
+        "Krh_I_belegt": 52,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 9,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.24,
+        "H_Zeitraum": "02.12.2022 - 08.12.2022",
+        "H_Datum": "06.12.2022",
+        "Datum_Bett": "08.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
