### PR TITLE
New data set: 2022-12-12T110204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-09T111403Z.json
+pjson/2022-12-12T110204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-09T111403Z.json pjson/2022-12-12T110204Z.json```:
```
--- pjson/2022-12-09T111403Z.json	2022-12-09 11:14:04.353040419 +0000
+++ pjson/2022-12-12T110204Z.json	2022-12-12 11:02:04.661927599 +0000
@@ -38226,7 +38226,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
-        "Inzidenz": 139.911634756996,
+        "Inzidenz": null,
         "Datum_neu": 1669766400000,
         "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
@@ -38264,15 +38264,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 118,
         "BelegteBetten": null,
-        "Inzidenz": 140.809655519236,
+        "Inzidenz": null,
         "Datum_neu": 1669852800000,
         "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 114.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 637,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38282,7 +38282,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.08,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.11.2022"
@@ -38302,15 +38302,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 134,
         "BelegteBetten": null,
-        "Inzidenz": 148.173425769604,
+        "Inzidenz": null,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 125,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
-        "Inzidenz_RKI": 128.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 637,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38320,7 +38320,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.29,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.12.2022"
@@ -38340,15 +38340,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
-        "Inzidenz": 134.703114336003,
+        "Inzidenz": null,
         "Datum_neu": 1670025600000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 132.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 637,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38358,7 +38358,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.12.2022"
@@ -38378,15 +38378,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
-        "Inzidenz": 137.217572470276,
+        "Inzidenz": null,
         "Datum_neu": 1670112000000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 129.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 637,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38396,7 +38396,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.64,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.12.2022"
@@ -38418,7 +38418,7 @@
         "BelegteBetten": null,
         "Inzidenz": 155.177987715076,
         "Datum_neu": 1670198400000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 124.2,
@@ -38456,7 +38456,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1670284800000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 122.6,
@@ -38494,9 +38494,9 @@
         "BelegteBetten": null,
         "Inzidenz": 142.785301196164,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 147,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 118.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
@@ -38521,28 +38521,28 @@
         "Datum": "08.12.2022",
         "Fallzahl": 272736,
         "ObjectId": 1007,
-        "Sterbefall": 1822,
-        "Genesungsfall": 269247,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7177,
-        "Zuwachs_Fallzahl": 157,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 99,
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 130,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 122.1,
-        "Fallzahl_aktiv": 1667,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
         "Krh_I_belegt": 52,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 56,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -38561,7 +38561,7 @@
         "ObjectId": 1008,
         "Sterbefall": 1824,
         "Genesungsfall": 269348,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7195,
         "Zuwachs_Fallzahl": 112,
         "Zuwachs_Sterbefall": 2,
@@ -38570,9 +38570,9 @@
         "BelegteBetten": null,
         "Inzidenz": 145.479363482884,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "02.12.2022 - 08.12.2022",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 154,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 128.9,
         "Fallzahl_aktiv": 1676,
         "Krh_N_belegt": 744,
@@ -38587,10 +38587,124 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 8.24,
-        "H_Zeitraum": "02.12.2022 - 08.12.2022",
-        "H_Datum": "06.12.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.12.2022",
+        "Fallzahl": 272876,
+        "ObjectId": 1009,
+        "Sterbefall": null,
+        "Genesungsfall": 269369,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 21,
+        "BelegteBetten": null,
+        "Inzidenz": 127.698552390531,
+        "Datum_neu": 1670630400000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 128,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 744,
+        "Krh_I_belegt": 52,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.24,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "09.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.12.2022",
+        "Fallzahl": 272905,
+        "ObjectId": 1010,
+        "Sterbefall": null,
+        "Genesungsfall": 269404,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 35,
+        "BelegteBetten": null,
+        "Inzidenz": 121.951219512195,
+        "Datum_neu": 1670716800000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 117.2,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 744,
+        "Krh_I_belegt": 52,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.24,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "10.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.12.2022",
+        "Fallzahl": 273023,
+        "ObjectId": 1011,
+        "Sterbefall": 1824,
+        "Genesungsfall": 269578,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7203,
+        "Zuwachs_Fallzahl": 175,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 174,
+        "BelegteBetten": null,
+        "Inzidenz": 143.14450950106,
+        "Datum_neu": 1670803200000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "05.12.2022 - 11.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 112.9,
+        "Fallzahl_aktiv": 1621,
+        "Krh_N_belegt": 744,
+        "Krh_I_belegt": 52,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.24,
+        "H_Zeitraum": "05.12.2022 - 11.12.2022",
+        "H_Datum": "06.12.2022",
+        "Datum_Bett": "11.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
