### PR TITLE
New data set: 2022-12-13T110204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-12T110503Z.json
+pjson/2022-12-13T110204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-12T110503Z.json pjson/2022-12-13T110204Z.json```:
```
--- pjson/2022-12-12T110503Z.json	2022-12-12 11:05:04.166045954 +0000
+++ pjson/2022-12-13T110204Z.json	2022-12-13 11:02:04.579356843 +0000
@@ -38266,7 +38266,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38304,7 +38304,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 126,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -38416,15 +38416,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 133,
         "BelegteBetten": null,
-        "Inzidenz": 155.177987715076,
+        "Inzidenz": null,
         "Datum_neu": 1670198400000,
         "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 124.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 637,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38434,7 +38434,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.12.2022"
@@ -38472,7 +38472,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.48,
+        "H_Inzidenz": 12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2022"
@@ -38494,7 +38494,7 @@
         "BelegteBetten": null,
         "Inzidenz": 142.785301196164,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": 118.1,
@@ -38506,11 +38506,11 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.64,
+        "H_Inzidenz": 11.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2022"
@@ -38532,7 +38532,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 130,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 122.1,
@@ -38548,7 +38548,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.17,
+        "H_Inzidenz": 11.06,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2022"
@@ -38559,34 +38559,34 @@
         "Datum": "09.12.2022",
         "Fallzahl": 272848,
         "ObjectId": 1008,
-        "Sterbefall": 1824,
-        "Genesungsfall": 269348,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7195,
-        "Zuwachs_Fallzahl": 112,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 101,
         "BelegteBetten": null,
         "Inzidenz": 145.479363482884,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 152,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 128.9,
-        "Fallzahl_aktiv": 1676,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
         "Krh_I_belegt": 52,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 9,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.36,
+        "H_Inzidenz": 11.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2022"
@@ -38598,19 +38598,19 @@
         "Fallzahl": 272876,
         "ObjectId": 1009,
         "Sterbefall": null,
-        "Genesungsfall": 269369,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 21,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": 127.698552390531,
         "Datum_neu": 1670630400000,
         "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 128,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
@@ -38624,7 +38624,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.71,
+        "H_Inzidenz": 10.51,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2022"
@@ -38636,19 +38636,19 @@
         "Fallzahl": 272905,
         "ObjectId": 1010,
         "Sterbefall": null,
-        "Genesungsfall": 269404,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 35,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
         "Inzidenz": 121.951219512195,
         "Datum_neu": 1670716800000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 14,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 117.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
@@ -38662,7 +38662,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.29,
+        "H_Inzidenz": 10.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2022"
@@ -38675,7 +38675,7 @@
         "ObjectId": 1011,
         "Sterbefall": 1824,
         "Genesungsfall": 269578,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7203,
         "Zuwachs_Fallzahl": 175,
         "Zuwachs_Sterbefall": 0,
@@ -38684,9 +38684,9 @@
         "BelegteBetten": null,
         "Inzidenz": 143.14450950106,
         "Datum_neu": 1670803200000,
-        "F\u00e4lle_Meldedatum": 7,
-        "Zeitraum": "05.12.2022 - 11.12.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 85,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 112.9,
         "Fallzahl_aktiv": 1621,
         "Krh_N_belegt": 744,
@@ -38700,11 +38700,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
-        "H_Zeitraum": "05.12.2022 - 11.12.2022",
-        "H_Datum": "06.12.2022",
+        "H_Inzidenz": 10.12,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.12.2022",
+        "Fallzahl": 273127,
+        "ObjectId": 1012,
+        "Sterbefall": 1825,
+        "Genesungsfall": 269792,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7221,
+        "Zuwachs_Fallzahl": 104,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 18,
+        "Zuwachs_Genesung": 214,
+        "BelegteBetten": null,
+        "Inzidenz": 132.547864506627,
+        "Datum_neu": 1670889600000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "06.12.2022 - 12.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 118.1,
+        "Fallzahl_aktiv": 1510,
+        "Krh_N_belegt": 744,
+        "Krh_I_belegt": 52,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -111,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.8,
+        "H_Zeitraum": "06.12.2022 - 12.12.2022",
+        "H_Datum": "06.12.2022",
+        "Datum_Bett": "12.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
