### PR TITLE
New data set: 2022-12-14T110603Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-13T110204Z.json
+pjson/2022-12-14T110603Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-13T110204Z.json pjson/2022-12-14T110603Z.json```:
```
--- pjson/2022-12-13T110204Z.json	2022-12-13 11:02:04.579356843 +0000
+++ pjson/2022-12-14T110603Z.json	2022-12-14 11:06:04.201405633 +0000
@@ -37470,7 +37470,7 @@
         "Datum_neu": 1668038400000,
         "F\u00e4lle_Meldedatum": 128,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37660,7 +37660,7 @@
         "Datum_neu": 1668470400000,
         "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38266,7 +38266,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 138,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38382,7 +38382,7 @@
         "Datum_neu": 1670112000000,
         "F\u00e4lle_Meldedatum": 23,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38454,15 +38454,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 130,
         "BelegteBetten": null,
-        "Inzidenz": 150.508279751428,
+        "Inzidenz": null,
         "Datum_neu": 1670284800000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 122.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 637,
-        "Krh_I_belegt": 50,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38472,7 +38472,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.12.2022"
@@ -38510,7 +38510,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.33,
+        "H_Inzidenz": 11.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2022"
@@ -38532,7 +38532,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 132,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 122.1,
@@ -38548,7 +38548,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.06,
+        "H_Inzidenz": 11.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2022"
@@ -38570,7 +38570,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.479363482884,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 154,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 128.9,
@@ -38586,7 +38586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.58,
+        "H_Inzidenz": 12.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2022"
@@ -38604,11 +38604,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 0,
+        "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
         "Inzidenz": 127.698552390531,
         "Datum_neu": 1670630400000,
-        "F\u00e4lle_Meldedatum": 33,
+        "F\u00e4lle_Meldedatum": 40,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 128,
@@ -38624,7 +38624,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.51,
+        "H_Inzidenz": 12.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2022"
@@ -38642,11 +38642,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 0,
+        "Zuwachs_Genesung": 35,
         "BelegteBetten": null,
         "Inzidenz": 121.951219512195,
         "Datum_neu": 1670716800000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 15,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 117.2,
@@ -38662,7 +38662,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.34,
+        "H_Inzidenz": 12.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2022"
@@ -38673,34 +38673,34 @@
         "Datum": "12.12.2022",
         "Fallzahl": 273023,
         "ObjectId": 1011,
-        "Sterbefall": 1824,
-        "Genesungsfall": 269578,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7203,
-        "Zuwachs_Fallzahl": 175,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 174,
         "BelegteBetten": null,
         "Inzidenz": 143.14450950106,
         "Datum_neu": 1670803200000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 112.9,
-        "Fallzahl_aktiv": 1621,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
         "Krh_I_belegt": 52,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.12,
+        "H_Inzidenz": 12.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2022"
@@ -38713,7 +38713,7 @@
         "ObjectId": 1012,
         "Sterbefall": 1825,
         "Genesungsfall": 269792,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7221,
         "Zuwachs_Fallzahl": 104,
         "Zuwachs_Sterbefall": 1,
@@ -38722,9 +38722,9 @@
         "BelegteBetten": null,
         "Inzidenz": 132.547864506627,
         "Datum_neu": 1670889600000,
-        "F\u00e4lle_Meldedatum": 18,
-        "Zeitraum": "06.12.2022 - 12.12.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 167,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 118.1,
         "Fallzahl_aktiv": 1510,
         "Krh_N_belegt": 744,
@@ -38738,11 +38738,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.8,
-        "H_Zeitraum": "06.12.2022 - 12.12.2022",
-        "H_Datum": "06.12.2022",
+        "H_Inzidenz": 11.06,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.12.2022",
+        "Fallzahl": 273346,
+        "ObjectId": 1013,
+        "Sterbefall": 1825,
+        "Genesungsfall": 269941,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7224,
+        "Zuwachs_Fallzahl": 219,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 149,
+        "BelegteBetten": null,
+        "Inzidenz": 136.319551708035,
+        "Datum_neu": 1670976000000,
+        "F\u00e4lle_Meldedatum": 42,
+        "Zeitraum": "07.12.2022 - 13.12.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 104.6,
+        "Fallzahl_aktiv": 1580,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 70,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.29,
+        "H_Zeitraum": "07.12.2022 - 13.12.2022",
+        "H_Datum": "13.12.2022",
+        "Datum_Bett": "13.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
