### PR TITLE
New data set: 2022-12-15T112503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-14T110603Z.json
+pjson/2022-12-15T112503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-14T110603Z.json pjson/2022-12-15T112503Z.json```:
```
--- pjson/2022-12-14T110603Z.json	2022-12-14 11:06:04.201405633 +0000
+++ pjson/2022-12-15T112503Z.json	2022-12-15 11:25:04.048540710 +0000
@@ -37354,7 +37354,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1667779200000,
-        "F\u00e4lle_Meldedatum": 308,
+        "F\u00e4lle_Meldedatum": 286,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -37468,7 +37468,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668038400000,
-        "F\u00e4lle_Meldedatum": 128,
+        "F\u00e4lle_Meldedatum": 132,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -37506,7 +37506,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668124800000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -37544,7 +37544,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668211200000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 52,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -37582,7 +37582,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668297600000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -37620,7 +37620,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668384000000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -37658,7 +37658,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668470400000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -37696,7 +37696,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668556800000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -37734,7 +37734,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668643200000,
-        "F\u00e4lle_Meldedatum": 103,
+        "F\u00e4lle_Meldedatum": 120,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -37772,7 +37772,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668729600000,
-        "F\u00e4lle_Meldedatum": 125,
+        "F\u00e4lle_Meldedatum": 135,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -37810,7 +37810,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668816000000,
-        "F\u00e4lle_Meldedatum": 43,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -37848,7 +37848,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668902400000,
-        "F\u00e4lle_Meldedatum": 15,
+        "F\u00e4lle_Meldedatum": 16,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -37886,7 +37886,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 155,
+        "F\u00e4lle_Meldedatum": 136,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -37924,7 +37924,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669075200000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 124,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -37962,7 +37962,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669161600000,
-        "F\u00e4lle_Meldedatum": 147,
+        "F\u00e4lle_Meldedatum": 150,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -38000,7 +38000,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 92,
+        "F\u00e4lle_Meldedatum": 95,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38038,7 +38038,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669334400000,
-        "F\u00e4lle_Meldedatum": 106,
+        "F\u00e4lle_Meldedatum": 103,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -38076,7 +38076,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669420800000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38152,7 +38152,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 189,
+        "F\u00e4lle_Meldedatum": 191,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -38190,7 +38190,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 225,
+        "F\u00e4lle_Meldedatum": 230,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -38266,7 +38266,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 138,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38304,7 +38304,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 126,
+        "F\u00e4lle_Meldedatum": 129,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -38418,7 +38418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670198400000,
-        "F\u00e4lle_Meldedatum": 150,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38456,7 +38456,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670284800000,
-        "F\u00e4lle_Meldedatum": 175,
+        "F\u00e4lle_Meldedatum": 179,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -38492,15 +38492,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 154,
         "BelegteBetten": null,
-        "Inzidenz": 142.785301196164,
+        "Inzidenz": null,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 155,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 118.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 744,
-        "Krh_I_belegt": 52,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38510,7 +38510,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.67,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.12.2022"
@@ -38532,9 +38532,9 @@
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 133,
+        "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 122.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
@@ -38548,7 +38548,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.67,
+        "H_Inzidenz": 11.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.12.2022"
@@ -38570,7 +38570,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.479363482884,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 184,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 128.9,
@@ -38586,7 +38586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.52,
+        "H_Inzidenz": 12.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2022"
@@ -38608,7 +38608,7 @@
         "BelegteBetten": null,
         "Inzidenz": 127.698552390531,
         "Datum_neu": 1670630400000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 128,
@@ -38624,7 +38624,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.07,
+        "H_Inzidenz": 12.27,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2022"
@@ -38662,7 +38662,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.27,
+        "H_Inzidenz": 12.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2022"
@@ -38684,9 +38684,9 @@
         "BelegteBetten": null,
         "Inzidenz": 143.14450950106,
         "Datum_neu": 1670803200000,
-        "F\u00e4lle_Meldedatum": 102,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 112.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
@@ -38700,7 +38700,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.27,
+        "H_Inzidenz": 12.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2022"
@@ -38711,26 +38711,26 @@
         "Datum": "13.12.2022",
         "Fallzahl": 273127,
         "ObjectId": 1012,
-        "Sterbefall": 1825,
-        "Genesungsfall": 269792,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7221,
-        "Zuwachs_Fallzahl": 104,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 18,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 214,
         "BelegteBetten": null,
         "Inzidenz": 132.547864506627,
         "Datum_neu": 1670889600000,
-        "F\u00e4lle_Meldedatum": 167,
+        "F\u00e4lle_Meldedatum": 183,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 118.1,
-        "Fallzahl_aktiv": 1510,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 744,
         "Krh_I_belegt": 52,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -111,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -38738,7 +38738,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.06,
+        "H_Inzidenz": 12.32,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2022"
@@ -38751,7 +38751,7 @@
         "ObjectId": 1013,
         "Sterbefall": 1825,
         "Genesungsfall": 269941,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7224,
         "Zuwachs_Fallzahl": 219,
         "Zuwachs_Sterbefall": 0,
@@ -38760,9 +38760,9 @@
         "BelegteBetten": null,
         "Inzidenz": 136.319551708035,
         "Datum_neu": 1670976000000,
-        "F\u00e4lle_Meldedatum": 42,
-        "Zeitraum": "07.12.2022 - 13.12.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 151,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 104.6,
         "Fallzahl_aktiv": 1580,
         "Krh_N_belegt": 865,
@@ -38776,11 +38776,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.29,
-        "H_Zeitraum": "07.12.2022 - 13.12.2022",
-        "H_Datum": "13.12.2022",
+        "H_Inzidenz": 12.44,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.12.2022",
+        "Fallzahl": 273744,
+        "ObjectId": 1014,
+        "Sterbefall": 1825,
+        "Genesungsfall": 270055,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7247,
+        "Zuwachs_Fallzahl": 398,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 23,
+        "Zuwachs_Genesung": 114,
+        "BelegteBetten": null,
+        "Inzidenz": 148.712238226948,
+        "Datum_neu": 1671062400000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "08.12.2022 - 14.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 116.3,
+        "Fallzahl_aktiv": 1864,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 284,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.01,
+        "H_Zeitraum": "08.12.2022 - 14.12.2022",
+        "H_Datum": "13.12.2022",
+        "Datum_Bett": "14.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
