### PR TITLE
New data set: 2022-12-19T112504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-14T110603Z.json
+pjson/2022-12-19T112504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-16T112204Z.json pjson/2022-12-19T112504Z.json```:
```
--- pjson/2022-12-16T112204Z.json	2022-12-16 11:22:04.760665382 +0000
+++ pjson/2022-12-19T112504Z.json	2022-12-19 11:25:04.779349589 +0000
@@ -37772,7 +37772,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668729600000,
-        "F\u00e4lle_Meldedatum": 221,
+        "F\u00e4lle_Meldedatum": 222,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -37886,7 +37886,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 276,
+        "F\u00e4lle_Meldedatum": 277,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -37924,7 +37924,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669075200000,
-        "F\u00e4lle_Meldedatum": 211,
+        "F\u00e4lle_Meldedatum": 212,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -37962,7 +37962,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669161600000,
-        "F\u00e4lle_Meldedatum": 238,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -38038,7 +38038,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669334400000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 176,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -38076,7 +38076,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669420800000,
-        "F\u00e4lle_Meldedatum": 38,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38114,7 +38114,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669507200000,
-        "F\u00e4lle_Meldedatum": 36,
+        "F\u00e4lle_Meldedatum": 39,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38152,7 +38152,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669593600000,
-        "F\u00e4lle_Meldedatum": 227,
+        "F\u00e4lle_Meldedatum": 337,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -38190,7 +38190,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -38228,7 +38228,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669766400000,
-        "F\u00e4lle_Meldedatum": 142,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -38266,7 +38266,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 149,
+        "F\u00e4lle_Meldedatum": 208,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38304,7 +38304,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669939200000,
-        "F\u00e4lle_Meldedatum": 139,
+        "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
         "Hosp_Meldedatum": 15,
         "Inzidenz_RKI": null,
@@ -38342,7 +38342,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670025600000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 88,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -38380,7 +38380,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670112000000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 26,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -38418,7 +38418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670198400000,
-        "F\u00e4lle_Meldedatum": 166,
+        "F\u00e4lle_Meldedatum": 266,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38456,7 +38456,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670284800000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 240,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -38494,7 +38494,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 169,
+        "F\u00e4lle_Meldedatum": 177,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -38532,7 +38532,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -38570,13 +38570,13 @@
         "BelegteBetten": null,
         "Inzidenz": 145.479363482884,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
-        "Inzidenz_RKI": 128.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 744,
-        "Krh_I_belegt": 52,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38586,7 +38586,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.71,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.12.2022"
@@ -38608,13 +38608,13 @@
         "BelegteBetten": null,
         "Inzidenz": 127.698552390531,
         "Datum_neu": 1670630400000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 128,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 744,
-        "Krh_I_belegt": 52,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38624,7 +38624,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.12.2022"
@@ -38662,7 +38662,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.91,
+        "H_Inzidenz": 13.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2022"
@@ -38684,7 +38684,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.14450950106,
         "Datum_neu": 1670803200000,
-        "F\u00e4lle_Meldedatum": 143,
+        "F\u00e4lle_Meldedatum": 148,
         "Zeitraum": null,
         "Hosp_Meldedatum": 30,
         "Inzidenz_RKI": 112.9,
@@ -38700,7 +38700,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.16,
+        "H_Inzidenz": 13.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2022"
@@ -38722,7 +38722,7 @@
         "BelegteBetten": null,
         "Inzidenz": 132.547864506627,
         "Datum_neu": 1670889600000,
-        "F\u00e4lle_Meldedatum": 236,
+        "F\u00e4lle_Meldedatum": 292,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 118.1,
@@ -38738,7 +38738,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.96,
+        "H_Inzidenz": 13.31,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2022"
@@ -38749,34 +38749,34 @@
         "Datum": "14.12.2022",
         "Fallzahl": 274770,
         "ObjectId": 1013,
-        "Sterbefall": 1825,
-        "Genesungsfall": 270960,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7224,
-        "Zuwachs_Fallzahl": 219,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
         "Inzidenz": 136.319551708035,
         "Datum_neu": 1670976000000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 185,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 104.6,
-        "Fallzahl_aktiv": 1985,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 70,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.83,
+        "H_Inzidenz": 14.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2022"
@@ -38787,36 +38787,36 @@
         "Datum": "15.12.2022",
         "Fallzahl": 274954,
         "ObjectId": 1014,
-        "Sterbefall": 1825,
-        "Genesungsfall": 271108,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7247,
-        "Zuwachs_Fallzahl": 398,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 23,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 114,
         "BelegteBetten": null,
         "Inzidenz": 148.712238226948,
         "Datum_neu": 1671062400000,
-        "F\u00e4lle_Meldedatum": 184,
-        "Zeitraum": "08.12.2022 - 14.12.2022",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 214,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 116.3,
-        "Fallzahl_aktiv": 2021,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 284,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.11,
-        "H_Zeitraum": "08.12.2022 - 14.12.2022",
-        "H_Datum": "13.12.2022",
+        "H_Inzidenz": 14.77,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "14.12.2022"
       }
     },
@@ -38827,7 +38827,7 @@
         "ObjectId": 1015,
         "Sterbefall": 1826,
         "Genesungsfall": 271232,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7261,
         "Zuwachs_Fallzahl": 231,
         "Zuwachs_Sterbefall": 1,
@@ -38836,9 +38836,9 @@
         "BelegteBetten": null,
         "Inzidenz": 180.502173210245,
         "Datum_neu": 1671148800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 167,
         "Zeitraum": "09.12.2022 - 15.12.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 122.8,
         "Fallzahl_aktiv": 1943,
         "Krh_N_belegt": 865,
@@ -38852,11 +38852,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.78,
+        "H_Inzidenz": 13.11,
         "H_Zeitraum": "09.12.2022 - 15.12.2022",
         "H_Datum": "13.12.2022",
         "Datum_Bett": "15.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.12.2022",
+        "Fallzahl": 275049,
+        "ObjectId": 1016,
+        "Sterbefall": 1826,
+        "Genesungsfall": 271450,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7261,
+        "Zuwachs_Fallzahl": 95,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 218,
+        "BelegteBetten": null,
+        "Inzidenz": 151.406300513668,
+        "Datum_neu": 1671235200000,
+        "F\u00e4lle_Meldedatum": 59,
+        "Zeitraum": "10.12.2022 - 16.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 143.7,
+        "Fallzahl_aktiv": 1773,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -123,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 11.25,
+        "H_Zeitraum": "10.12.2022 - 16.12.2022",
+        "H_Datum": "13.12.2022",
+        "Datum_Bett": "16.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.12.2022",
+        "Fallzahl": 275098,
+        "ObjectId": 1017,
+        "Sterbefall": 1826,
+        "Genesungsfall": 271768,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7261,
+        "Zuwachs_Fallzahl": 97,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 318,
+        "BelegteBetten": null,
+        "Inzidenz": 150.508279751428,
+        "Datum_neu": 1671321600000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "11.12.2022 - 17.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 134.1,
+        "Fallzahl_aktiv": 1504,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -221,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 10.44,
+        "H_Zeitraum": "11.12.2022 - 17.12.2022",
+        "H_Datum": "13.12.2022",
+        "Datum_Bett": "17.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.12.2022",
+        "Fallzahl": 275919,
+        "ObjectId": 1018,
+        "Sterbefall": 1826,
+        "Genesungsfall": 272021,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7276,
+        "Zuwachs_Fallzahl": 918,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 789,
+        "BelegteBetten": null,
+        "Inzidenz": 192.715255576709,
+        "Datum_neu": 1671408000000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "12.12.2022 - 18.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 131.3,
+        "Fallzahl_aktiv": 2072,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 129,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 9.62,
+        "H_Zeitraum": "12.12.2022 - 18.12.2022",
+        "H_Datum": "13.12.2022",
+        "Datum_Bett": "18.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
