### PR TITLE
New data set: 2022-12-20T112503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-19T114005Z.json
+pjson/2022-12-20T112503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-19T114005Z.json pjson/2022-12-20T112503Z.json```:
```
--- pjson/2022-12-19T114005Z.json	2022-12-19 11:40:06.088224195 +0000
+++ pjson/2022-12-20T112503Z.json	2022-12-20 11:25:04.386748698 +0000
@@ -37759,7 +37759,7 @@
     {
       "attributes": {
         "Datum": "18.11.2022",
-        "Fallzahl": 271047,
+        "Fallzahl": 271048,
         "ObjectId": 987,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -37772,7 +37772,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668729600000,
-        "F\u00e4lle_Meldedatum": 222,
+        "F\u00e4lle_Meldedatum": 223,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -37797,7 +37797,7 @@
     {
       "attributes": {
         "Datum": "19.11.2022",
-        "Fallzahl": 271124,
+        "Fallzahl": 271125,
         "ObjectId": 988,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -37835,7 +37835,7 @@
     {
       "attributes": {
         "Datum": "20.11.2022",
-        "Fallzahl": 271155,
+        "Fallzahl": 271156,
         "ObjectId": 989,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -37873,7 +37873,7 @@
     {
       "attributes": {
         "Datum": "21.11.2022",
-        "Fallzahl": 271432,
+        "Fallzahl": 271433,
         "ObjectId": 990,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -37911,7 +37911,7 @@
     {
       "attributes": {
         "Datum": "22.11.2022",
-        "Fallzahl": 271644,
+        "Fallzahl": 271645,
         "ObjectId": 991,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -37949,7 +37949,7 @@
     {
       "attributes": {
         "Datum": "23.11.2022",
-        "Fallzahl": 271884,
+        "Fallzahl": 271885,
         "ObjectId": 992,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -37987,7 +37987,7 @@
     {
       "attributes": {
         "Datum": "24.11.2022",
-        "Fallzahl": 272043,
+        "Fallzahl": 272044,
         "ObjectId": 993,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38025,7 +38025,7 @@
     {
       "attributes": {
         "Datum": "25.11.2022",
-        "Fallzahl": 272219,
+        "Fallzahl": 272220,
         "ObjectId": 994,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38063,7 +38063,7 @@
     {
       "attributes": {
         "Datum": "26.11.2022",
-        "Fallzahl": 272258,
+        "Fallzahl": 272259,
         "ObjectId": 995,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38101,7 +38101,7 @@
     {
       "attributes": {
         "Datum": "27.11.2022",
-        "Fallzahl": 272297,
+        "Fallzahl": 272298,
         "ObjectId": 996,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38139,7 +38139,7 @@
     {
       "attributes": {
         "Datum": "28.11.2022",
-        "Fallzahl": 272634,
+        "Fallzahl": 272635,
         "ObjectId": 997,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38177,7 +38177,7 @@
     {
       "attributes": {
         "Datum": "29.11.2022",
-        "Fallzahl": 272960,
+        "Fallzahl": 272962,
         "ObjectId": 998,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38190,7 +38190,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669680000000,
-        "F\u00e4lle_Meldedatum": 326,
+        "F\u00e4lle_Meldedatum": 327,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -38215,7 +38215,7 @@
     {
       "attributes": {
         "Datum": "30.11.2022",
-        "Fallzahl": 273176,
+        "Fallzahl": 273178,
         "ObjectId": 999,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38253,7 +38253,7 @@
     {
       "attributes": {
         "Datum": "01.12.2022",
-        "Fallzahl": 273384,
+        "Fallzahl": 273386,
         "ObjectId": 1000,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38291,7 +38291,7 @@
     {
       "attributes": {
         "Datum": "02.12.2022",
-        "Fallzahl": 273589,
+        "Fallzahl": 273591,
         "ObjectId": 1001,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38306,7 +38306,7 @@
         "Datum_neu": 1669939200000,
         "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38329,7 +38329,7 @@
     {
       "attributes": {
         "Datum": "03.12.2022",
-        "Fallzahl": 273677,
+        "Fallzahl": 273680,
         "ObjectId": 1002,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38342,7 +38342,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670025600000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -38367,7 +38367,7 @@
     {
       "attributes": {
         "Datum": "04.12.2022",
-        "Fallzahl": 273703,
+        "Fallzahl": 273708,
         "ObjectId": 1003,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38380,7 +38380,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670112000000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 28,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -38405,7 +38405,7 @@
     {
       "attributes": {
         "Datum": "05.12.2022",
-        "Fallzahl": 273969,
+        "Fallzahl": 274001,
         "ObjectId": 1004,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38418,7 +38418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670198400000,
-        "F\u00e4lle_Meldedatum": 266,
+        "F\u00e4lle_Meldedatum": 293,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38443,7 +38443,7 @@
     {
       "attributes": {
         "Datum": "06.12.2022",
-        "Fallzahl": 274209,
+        "Fallzahl": 274285,
         "ObjectId": 1005,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38456,7 +38456,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670284800000,
-        "F\u00e4lle_Meldedatum": 240,
+        "F\u00e4lle_Meldedatum": 284,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -38481,7 +38481,7 @@
     {
       "attributes": {
         "Datum": "07.12.2022",
-        "Fallzahl": 274386,
+        "Fallzahl": 274516,
         "ObjectId": 1006,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38494,7 +38494,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 177,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -38519,7 +38519,7 @@
     {
       "attributes": {
         "Datum": "08.12.2022",
-        "Fallzahl": 274544,
+        "Fallzahl": 274725,
         "ObjectId": 1007,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38532,7 +38532,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -38557,7 +38557,7 @@
     {
       "attributes": {
         "Datum": "09.12.2022",
-        "Fallzahl": 274754,
+        "Fallzahl": 274971,
         "ObjectId": 1008,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38570,7 +38570,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.479363482884,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 246,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38595,7 +38595,7 @@
     {
       "attributes": {
         "Datum": "10.12.2022",
-        "Fallzahl": 274808,
+        "Fallzahl": 275039,
         "ObjectId": 1009,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38608,7 +38608,7 @@
         "BelegteBetten": null,
         "Inzidenz": 127.698552390531,
         "Datum_neu": 1670630400000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38633,7 +38633,7 @@
     {
       "attributes": {
         "Datum": "11.12.2022",
-        "Fallzahl": 274825,
+        "Fallzahl": 275057,
         "ObjectId": 1010,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38646,13 +38646,13 @@
         "BelegteBetten": null,
         "Inzidenz": 121.951219512195,
         "Datum_neu": 1670716800000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 117.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 744,
-        "Krh_I_belegt": 52,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38662,7 +38662,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.11,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.12.2022"
@@ -38671,7 +38671,7 @@
     {
       "attributes": {
         "Datum": "12.12.2022",
-        "Fallzahl": 274973,
+        "Fallzahl": 275258,
         "ObjectId": 1011,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38684,13 +38684,13 @@
         "BelegteBetten": null,
         "Inzidenz": 143.14450950106,
         "Datum_neu": 1670803200000,
-        "F\u00e4lle_Meldedatum": 148,
+        "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 30,
-        "Inzidenz_RKI": 112.9,
+        "Hosp_Meldedatum": 32,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 744,
-        "Krh_I_belegt": 52,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38700,7 +38700,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.12.2022"
@@ -38709,7 +38709,7 @@
     {
       "attributes": {
         "Datum": "13.12.2022",
-        "Fallzahl": 275265,
+        "Fallzahl": 275580,
         "ObjectId": 1012,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38722,7 +38722,7 @@
         "BelegteBetten": null,
         "Inzidenz": 132.547864506627,
         "Datum_neu": 1670889600000,
-        "F\u00e4lle_Meldedatum": 292,
+        "F\u00e4lle_Meldedatum": 322,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 118.1,
@@ -38738,7 +38738,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.31,
+        "H_Inzidenz": 13.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2022"
@@ -38747,7 +38747,7 @@
     {
       "attributes": {
         "Datum": "14.12.2022",
-        "Fallzahl": 275450,
+        "Fallzahl": 275773,
         "ObjectId": 1013,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38760,9 +38760,9 @@
         "BelegteBetten": null,
         "Inzidenz": 136.319551708035,
         "Datum_neu": 1670976000000,
-        "F\u00e4lle_Meldedatum": 185,
+        "F\u00e4lle_Meldedatum": 193,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 104.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
@@ -38776,7 +38776,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.69,
+        "H_Inzidenz": 14.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2022"
@@ -38785,7 +38785,7 @@
     {
       "attributes": {
         "Datum": "15.12.2022",
-        "Fallzahl": 275664,
+        "Fallzahl": 275986,
         "ObjectId": 1014,
         "Sterbefall": null,
         "Genesungsfall": null,
@@ -38798,7 +38798,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.712238226948,
         "Datum_neu": 1671062400000,
-        "F\u00e4lle_Meldedatum": 214,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 116.3,
@@ -38814,7 +38814,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.77,
+        "H_Inzidenz": 15.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.12.2022"
@@ -38823,66 +38823,66 @@
     {
       "attributes": {
         "Datum": "16.12.2022",
-        "Fallzahl": 275831,
+        "Fallzahl": 276159,
         "ObjectId": 1015,
-        "Sterbefall": 1826,
-        "Genesungsfall": 271232,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7261,
-        "Zuwachs_Fallzahl": 231,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 14,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 124,
         "BelegteBetten": null,
         "Inzidenz": 180.502173210245,
         "Datum_neu": 1671148800000,
-        "F\u00e4lle_Meldedatum": 167,
-        "Zeitraum": "09.12.2022 - 15.12.2022",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 173,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 122.8,
-        "Fallzahl_aktiv": 2773,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 106,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.11,
-        "H_Zeitraum": "09.12.2022 - 15.12.2022",
-        "H_Datum": "13.12.2022",
+        "H_Inzidenz": 14.27,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.12.2022"
       }
     },
     {
       "attributes": {
         "Datum": "17.12.2022",
-        "Fallzahl": 275890,
+        "Fallzahl": 276225,
         "ObjectId": 1016,
-        "Sterbefall": 1826,
-        "Genesungsfall": 271450,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7261,
-        "Zuwachs_Fallzahl": 95,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 218,
         "BelegteBetten": null,
         "Inzidenz": 151.406300513668,
         "Datum_neu": 1671235200000,
-        "F\u00e4lle_Meldedatum": 59,
-        "Zeitraum": "10.12.2022 - 16.12.2022",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 66,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 143.7,
-        "Fallzahl_aktiv": 2614,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -123,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -38890,37 +38890,37 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.25,
-        "H_Zeitraum": "10.12.2022 - 16.12.2022",
-        "H_Datum": "13.12.2022",
+        "H_Inzidenz": 13.06,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.12.2022"
       }
     },
     {
       "attributes": {
         "Datum": "18.12.2022",
-        "Fallzahl": 275898,
+        "Fallzahl": 276244,
         "ObjectId": 1017,
-        "Sterbefall": 1826,
-        "Genesungsfall": 271768,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7261,
-        "Zuwachs_Fallzahl": 97,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 318,
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1671321600000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "11.12.2022 - 17.12.2022",
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 134.1,
-        "Fallzahl_aktiv": 2304,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -221,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -38928,20 +38928,20 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.44,
-        "H_Zeitraum": "11.12.2022 - 17.12.2022",
-        "H_Datum": "13.12.2022",
+        "H_Inzidenz": 12.56,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.12.2022"
       }
     },
     {
       "attributes": {
         "Datum": "19.12.2022",
-        "Fallzahl": 275919,
+        "Fallzahl": 276463,
         "ObjectId": 1018,
         "Sterbefall": 1826,
         "Genesungsfall": 272021,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7276,
         "Zuwachs_Fallzahl": 255,
         "Zuwachs_Sterbefall": 0,
@@ -38950,11 +38950,11 @@
         "BelegteBetten": null,
         "Inzidenz": 192.715255576709,
         "Datum_neu": 1671408000000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": "12.12.2022 - 18.12.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 131.3,
-        "Fallzahl_aktiv": 2072,
+        "Fallzahl_aktiv": 2616,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
@@ -38966,11 +38966,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.62,
+        "H_Inzidenz": 11.9,
         "H_Zeitraum": "12.12.2022 - 18.12.2022",
         "H_Datum": "13.12.2022",
         "Datum_Bett": "18.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.12.2022",
+        "Fallzahl": 276503,
+        "ObjectId": 1019,
+        "Sterbefall": 1826,
+        "Genesungsfall": 272332,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7292,
+        "Zuwachs_Fallzahl": 259,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 311,
+        "BelegteBetten": null,
+        "Inzidenz": 216.423003699846,
+        "Datum_neu": 1671494400000,
+        "F\u00e4lle_Meldedatum": 40,
+        "Zeitraum": "13.12.2022 - 19.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 169.3,
+        "Fallzahl_aktiv": 2345,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -52,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.43,
+        "H_Zeitraum": "13.12.2022 - 19.12.2022",
+        "H_Datum": "13.12.2022",
+        "Datum_Bett": "19.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
