### PR TITLE
New data set: 2022-12-21T105103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-20T112503Z.json
+pjson/2022-12-21T105103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-20T112503Z.json pjson/2022-12-21T105103Z.json```:
```
--- pjson/2022-12-20T112503Z.json	2022-12-20 11:25:04.386748698 +0000
+++ pjson/2022-12-21T105103Z.json	2022-12-21 10:51:04.367821339 +0000
@@ -36292,7 +36292,7 @@
         "Datum_neu": 1665360000000,
         "F\u00e4lle_Meldedatum": 866,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 37,
+        "Hosp_Meldedatum": 36,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -37886,7 +37886,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668988800000,
-        "F\u00e4lle_Meldedatum": 277,
+        "F\u00e4lle_Meldedatum": 278,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": null,
@@ -38000,7 +38000,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669248000000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38532,7 +38532,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.83857178778,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 209,
+        "F\u00e4lle_Meldedatum": 210,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -38570,7 +38570,7 @@
         "BelegteBetten": null,
         "Inzidenz": 145.479363482884,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 246,
+        "F\u00e4lle_Meldedatum": 245,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38646,7 +38646,7 @@
         "BelegteBetten": null,
         "Inzidenz": 121.951219512195,
         "Datum_neu": 1670716800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38722,13 +38722,13 @@
         "BelegteBetten": null,
         "Inzidenz": 132.547864506627,
         "Datum_neu": 1670889600000,
-        "F\u00e4lle_Meldedatum": 322,
+        "F\u00e4lle_Meldedatum": 324,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 118.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 744,
-        "Krh_I_belegt": 52,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38738,7 +38738,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.43,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.12.2022"
@@ -38776,7 +38776,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.87,
+        "H_Inzidenz": 14.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2022"
@@ -38798,7 +38798,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.712238226948,
         "Datum_neu": 1671062400000,
-        "F\u00e4lle_Meldedatum": 213,
+        "F\u00e4lle_Meldedatum": 215,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 116.3,
@@ -38814,7 +38814,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.19,
+        "H_Inzidenz": 15.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.12.2022"
@@ -38836,7 +38836,7 @@
         "BelegteBetten": null,
         "Inzidenz": 180.502173210245,
         "Datum_neu": 1671148800000,
-        "F\u00e4lle_Meldedatum": 173,
+        "F\u00e4lle_Meldedatum": 172,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 122.8,
@@ -38852,7 +38852,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.27,
+        "H_Inzidenz": 14.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.12.2022"
@@ -38874,7 +38874,7 @@
         "BelegteBetten": null,
         "Inzidenz": 151.406300513668,
         "Datum_neu": 1671235200000,
-        "F\u00e4lle_Meldedatum": 66,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 143.7,
@@ -38890,7 +38890,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.06,
+        "H_Inzidenz": 13.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.12.2022"
@@ -38912,7 +38912,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1671321600000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 134.1,
@@ -38928,7 +38928,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.56,
+        "H_Inzidenz": 13.38,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.12.2022"
@@ -38950,9 +38950,9 @@
         "BelegteBetten": null,
         "Inzidenz": 192.715255576709,
         "Datum_neu": 1671408000000,
-        "F\u00e4lle_Meldedatum": 219,
-        "Zeitraum": "12.12.2022 - 18.12.2022",
-        "Hosp_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 252,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 131.3,
         "Fallzahl_aktiv": 2616,
         "Krh_N_belegt": 865,
@@ -38966,9 +38966,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.9,
-        "H_Zeitraum": "12.12.2022 - 18.12.2022",
-        "H_Datum": "13.12.2022",
+        "H_Inzidenz": 12.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "18.12.2022"
       }
     },
@@ -38979,7 +38979,7 @@
         "ObjectId": 1019,
         "Sterbefall": 1826,
         "Genesungsfall": 272332,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7292,
         "Zuwachs_Fallzahl": 259,
         "Zuwachs_Sterbefall": 0,
@@ -38988,9 +38988,9 @@
         "BelegteBetten": null,
         "Inzidenz": 216.423003699846,
         "Datum_neu": 1671494400000,
-        "F\u00e4lle_Meldedatum": 40,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": "13.12.2022 - 19.12.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 169.3,
         "Fallzahl_aktiv": 2345,
         "Krh_N_belegt": 865,
@@ -39004,11 +39004,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.43,
+        "H_Inzidenz": 9.99,
         "H_Zeitraum": "13.12.2022 - 19.12.2022",
         "H_Datum": "13.12.2022",
         "Datum_Bett": "19.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.12.2022",
+        "Fallzahl": 276767,
+        "ObjectId": 1020,
+        "Sterbefall": 1826,
+        "Genesungsfall": 272569,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7313,
+        "Zuwachs_Fallzahl": 264,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 21,
+        "Zuwachs_Genesung": 237,
+        "BelegteBetten": null,
+        "Inzidenz": 204.389525485829,
+        "Datum_neu": 1671580800000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "14.12.2022 - 20.12.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 155.4,
+        "Fallzahl_aktiv": 2372,
+        "Krh_N_belegt": 837,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 27,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.52,
+        "H_Zeitraum": "14.12.2022 - 20.12.2022",
+        "H_Datum": "20.12.2022",
+        "Datum_Bett": "20.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
