### PR TITLE
New data set: 2022-12-22T110204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-21T105103Z.json
+pjson/2022-12-22T110204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-21T105103Z.json pjson/2022-12-22T110204Z.json```:
```
--- pjson/2022-12-21T105103Z.json	2022-12-21 10:51:04.367821339 +0000
+++ pjson/2022-12-22T110204Z.json	2022-12-22 11:02:04.960435314 +0000
@@ -38228,7 +38228,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669766400000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -38266,7 +38266,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1669852800000,
-        "F\u00e4lle_Meldedatum": 208,
+        "F\u00e4lle_Meldedatum": 209,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38530,9 +38530,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 99,
         "BelegteBetten": null,
-        "Inzidenz": 145.83857178778,
+        "Inzidenz": null,
         "Datum_neu": 1670457600000,
-        "F\u00e4lle_Meldedatum": 210,
+        "F\u00e4lle_Meldedatum": 213,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -38568,9 +38568,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 101,
         "BelegteBetten": null,
-        "Inzidenz": 145.479363482884,
+        "Inzidenz": null,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 245,
+        "F\u00e4lle_Meldedatum": 247,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38606,7 +38606,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 24,
         "BelegteBetten": null,
-        "Inzidenz": 127.698552390531,
+        "Inzidenz": null,
         "Datum_neu": 1670630400000,
         "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
@@ -38644,7 +38644,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 35,
         "BelegteBetten": null,
-        "Inzidenz": 121.951219512195,
+        "Inzidenz": null,
         "Datum_neu": 1670716800000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
@@ -38682,7 +38682,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 174,
         "BelegteBetten": null,
-        "Inzidenz": 143.14450950106,
+        "Inzidenz": null,
         "Datum_neu": 1670803200000,
         "F\u00e4lle_Meldedatum": 201,
         "Zeitraum": null,
@@ -38720,9 +38720,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 214,
         "BelegteBetten": null,
-        "Inzidenz": 132.547864506627,
+        "Inzidenz": null,
         "Datum_neu": 1670889600000,
-        "F\u00e4lle_Meldedatum": 324,
+        "F\u00e4lle_Meldedatum": 325,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -38760,7 +38760,7 @@
         "BelegteBetten": null,
         "Inzidenz": 136.319551708035,
         "Datum_neu": 1670976000000,
-        "F\u00e4lle_Meldedatum": 193,
+        "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 104.6,
@@ -38798,7 +38798,7 @@
         "BelegteBetten": null,
         "Inzidenz": 148.712238226948,
         "Datum_neu": 1671062400000,
-        "F\u00e4lle_Meldedatum": 215,
+        "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 116.3,
@@ -38836,9 +38836,9 @@
         "BelegteBetten": null,
         "Inzidenz": 180.502173210245,
         "Datum_neu": 1671148800000,
-        "F\u00e4lle_Meldedatum": 172,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 122.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
@@ -38939,26 +38939,26 @@
         "Datum": "19.12.2022",
         "Fallzahl": 276463,
         "ObjectId": 1018,
-        "Sterbefall": 1826,
-        "Genesungsfall": 272021,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7276,
-        "Zuwachs_Fallzahl": 255,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 571,
         "BelegteBetten": null,
         "Inzidenz": 192.715255576709,
         "Datum_neu": 1671408000000,
-        "F\u00e4lle_Meldedatum": 252,
+        "F\u00e4lle_Meldedatum": 259,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 131.3,
-        "Fallzahl_aktiv": 2616,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -316,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -38977,26 +38977,26 @@
         "Datum": "20.12.2022",
         "Fallzahl": 276503,
         "ObjectId": 1019,
-        "Sterbefall": 1826,
-        "Genesungsfall": 272332,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7292,
-        "Zuwachs_Fallzahl": 259,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 311,
         "BelegteBetten": null,
         "Inzidenz": 216.423003699846,
         "Datum_neu": 1671494400000,
-        "F\u00e4lle_Meldedatum": 217,
-        "Zeitraum": "13.12.2022 - 19.12.2022",
+        "F\u00e4lle_Meldedatum": 229,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 169.3,
-        "Fallzahl_aktiv": 2345,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -52,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39005,8 +39005,8 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 9.99,
-        "H_Zeitraum": "13.12.2022 - 19.12.2022",
-        "H_Datum": "13.12.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.12.2022"
       }
     },
@@ -39017,7 +39017,7 @@
         "ObjectId": 1020,
         "Sterbefall": 1826,
         "Genesungsfall": 272569,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7313,
         "Zuwachs_Fallzahl": 264,
         "Zuwachs_Sterbefall": 0,
@@ -39026,9 +39026,9 @@
         "BelegteBetten": null,
         "Inzidenz": 204.389525485829,
         "Datum_neu": 1671580800000,
-        "F\u00e4lle_Meldedatum": 46,
-        "Zeitraum": "14.12.2022 - 20.12.2022",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 208,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 155.4,
         "Fallzahl_aktiv": 2372,
         "Krh_N_belegt": 837,
@@ -39043,9 +39043,47 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 7.52,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "20.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.12.2022",
+        "Fallzahl": 276967,
+        "ObjectId": 1021,
+        "Sterbefall": 1826,
+        "Genesungsfall": 272783,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7317,
+        "Zuwachs_Fallzahl": 200,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 214,
+        "BelegteBetten": null,
+        "Inzidenz": 210.855274973957,
+        "Datum_neu": 1671667200000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "15.12.2022 - 21.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 185.5,
+        "Fallzahl_aktiv": 2358,
+        "Krh_N_belegt": 837,
+        "Krh_I_belegt": 68,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -14,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.52,
         "H_Zeitraum": "14.12.2022 - 20.12.2022",
         "H_Datum": "20.12.2022",
-        "Datum_Bett": "20.12.2022"
+        "Datum_Bett": "21.12.2022"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
