### PR TITLE
New data set: 2022-12-23T131104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-23T124204Z.json
+pjson/2022-12-23T131104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-23T124204Z.json pjson/2022-12-23T131104Z.json```:
```
--- pjson/2022-12-23T124204Z.json	2022-12-23 12:42:04.550561550 +0000
+++ pjson/2022-12-23T131104Z.json	2022-12-23 13:11:04.520681067 +0000
@@ -34886,7 +34886,7 @@
         "Datum_neu": 1662163200000,
         "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -35418,7 +35418,7 @@
         "Datum_neu": 1663372800000,
         "F\u00e4lle_Meldedatum": 97,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36026,7 +36026,7 @@
         "Datum_neu": 1664755200000,
         "F\u00e4lle_Meldedatum": 175,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38494,7 +38494,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670371200000,
-        "F\u00e4lle_Meldedatum": 232,
+        "F\u00e4lle_Meldedatum": 231,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -38758,15 +38758,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 149,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 136.319551708035,
         "Datum_neu": 1670976000000,
         "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": null,
+        "Inzidenz_RKI": 104.6,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38776,7 +38776,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": null,
+        "H_Inzidenz": 14.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.12.2022"
@@ -38796,15 +38796,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 114,
         "BelegteBetten": null,
-        "Inzidenz": null,
+        "Inzidenz": 148.712238226948,
         "Datum_neu": 1671062400000,
         "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": null,
+        "Inzidenz_RKI": 116.3,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": null,
-        "Krh_I_belegt": null,
+        "Krh_N_belegt": 865,
+        "Krh_I_belegt": 68,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -38814,7 +38814,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": null,
+        "H_Inzidenz": 15.34,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.12.2022"
@@ -38836,7 +38836,7 @@
         "BelegteBetten": null,
         "Inzidenz": 180.502173210245,
         "Datum_neu": 1671148800000,
-        "F\u00e4lle_Meldedatum": 174,
+        "F\u00e4lle_Meldedatum": 173,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 122.8,
@@ -38950,9 +38950,9 @@
         "BelegteBetten": null,
         "Inzidenz": 192.715255576709,
         "Datum_neu": 1671408000000,
-        "F\u00e4lle_Meldedatum": 229,
+        "F\u00e4lle_Meldedatum": 259,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 21,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 131.3,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 865,
@@ -38988,7 +38988,7 @@
         "BelegteBetten": null,
         "Inzidenz": 216.423003699846,
         "Datum_neu": 1671494400000,
-        "F\u00e4lle_Meldedatum": 687,
+        "F\u00e4lle_Meldedatum": 229,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 169.3,
@@ -39015,13 +39015,13 @@
         "Datum": "21.12.2022",
         "Fallzahl": 276767,
         "ObjectId": 1020,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1826,
+        "Genesungsfall": 272569,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 7313,
+        "Zuwachs_Fallzahl": 264,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 21,
         "Zuwachs_Genesung": 237,
         "BelegteBetten": null,
         "Inzidenz": 204.389525485829,
@@ -39030,13 +39030,13 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 155.4,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 2372,
         "Krh_N_belegt": 837,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": 27,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -39055,18 +39055,18 @@
         "ObjectId": 1021,
         "Sterbefall": 1826,
         "Genesungsfall": 272783,
-        "Anzeige_Indikator": null,
+        "Anzeige_Indikator": "x",
         "Hospitalisierung": 7317,
         "Zuwachs_Fallzahl": 200,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 4,
         "Zuwachs_Genesung": 214,
         "BelegteBetten": null,
-        "Inzidenz": 287.905456374151,
+        "Inzidenz": 210.855274973957,
         "Datum_neu": 1671667200000,
-        "F\u00e4lle_Meldedatum": 152,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": "15.12.2022 - 21.12.2022",
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 185.5,
         "Fallzahl_aktiv": 2358,
         "Krh_N_belegt": 837,
@@ -39085,44 +39085,6 @@
         "H_Datum": "20.12.2022",
         "Datum_Bett": "21.12.2022"
       }
-    },
-    {
-      "attributes": {
-        "Datum": "23.12.2022",
-        "Fallzahl": 277600,
-        "ObjectId": 1022,
-        "Sterbefall": 1826,
-        "Genesungsfall": 272233,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 7322,
-        "Zuwachs_Fallzahl": 633,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
-        "Zuwachs_Genesung": -550,
-        "BelegteBetten": null,
-        "Inzidenz": 276.410790617479,
-        "Datum_neu": 1671753600000,
-        "F\u00e4lle_Meldedatum": 59,
-        "Zeitraum": "16.12.2022 - 22.12.2022",
-        "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 173.6,
-        "Fallzahl_aktiv": 3541,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
-        "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1183,
-        "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
-        "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
-        "Inzi_SN_RKI": null,
-        "Mutation": null,
-        "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.52,
-        "H_Zeitraum": "14.12.2022 - 20.12.2022",
-        "H_Datum": "20.12.2022",
-        "Datum_Bett": "22.12.2022"
-      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
