### PR TITLE
New data set: 2022-12-28T104703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-23T124204Z.json
+pjson/2022-12-28T104703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-27T110404Z.json pjson/2022-12-28T104703Z.json```:
```
--- pjson/2022-12-27T110404Z.json	2022-12-27 11:04:04.548704733 +0000
+++ pjson/2022-12-28T104703Z.json	2022-12-28 10:47:03.868217880 +0000
@@ -38570,7 +38570,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670544000000,
-        "F\u00e4lle_Meldedatum": 247,
+        "F\u00e4lle_Meldedatum": 248,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -38684,7 +38684,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670803200000,
-        "F\u00e4lle_Meldedatum": 201,
+        "F\u00e4lle_Meldedatum": 202,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -38991,10 +38991,10 @@
         "F\u00e4lle_Meldedatum": 233,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 169.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 865,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39004,7 +39004,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.5,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.12.2022"
@@ -39042,7 +39042,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.44,
+        "H_Inzidenz": 14.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.12.2022"
@@ -39053,26 +39053,26 @@
         "Datum": "22.12.2022",
         "Fallzahl": 276967,
         "ObjectId": 1021,
-        "Sterbefall": 1826,
-        "Genesungsfall": 272783,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7317,
-        "Zuwachs_Fallzahl": 200,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 217,
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1671667200000,
-        "F\u00e4lle_Meldedatum": 156,
-        "Zeitraum": "15.12.2022 - 21.12.2022",
+        "F\u00e4lle_Meldedatum": 158,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 185.5,
-        "Fallzahl_aktiv": 2358,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 837,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -17,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39080,9 +39080,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.11,
-        "H_Zeitraum": "15.12.2022 - 21.12.2022",
-        "H_Datum": "20.12.2022",
+        "H_Inzidenz": 13.38,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.12.2022"
       }
     },
@@ -39092,7 +39092,7 @@
         "Fallzahl": 277287,
         "ObjectId": 1022,
         "Sterbefall": null,
-        "Genesungsfall": 273026,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39102,9 +39102,9 @@
         "BelegteBetten": null,
         "Inzidenz": 200.438234131973,
         "Datum_neu": 1671753600000,
-        "F\u00e4lle_Meldedatum": 152,
-        "Zeitraum": "16.12.2022 - 22.12.2022",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 154,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 173.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 837,
@@ -39118,9 +39118,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.1,
-        "H_Zeitraum": "16.12.2022 - 22.12.2022",
-        "H_Datum": "20.12.2022",
+        "H_Inzidenz": 12.69,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.12.2022"
       }
     },
@@ -39130,7 +39130,7 @@
         "Fallzahl": 277327,
         "ObjectId": 1023,
         "Sterbefall": null,
-        "Genesungsfall": 273094,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39140,8 +39140,8 @@
         "BelegteBetten": null,
         "Inzidenz": 186.788318545925,
         "Datum_neu": 1671840000000,
-        "F\u00e4lle_Meldedatum": 40,
-        "Zeitraum": "17.12.2022 - 23.12.2022",
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 170.7,
         "Fallzahl_aktiv": null,
@@ -39156,9 +39156,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.1,
-        "H_Zeitraum": "17.12.2022 - 23.12.2022",
-        "H_Datum": "20.12.2022",
+        "H_Inzidenz": 11.28,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "23.12.2022"
       }
     },
@@ -39168,7 +39168,7 @@
         "Fallzahl": 277344,
         "ObjectId": 1024,
         "Sterbefall": null,
-        "Genesungsfall": 273123,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39178,8 +39178,8 @@
         "BelegteBetten": null,
         "Inzidenz": 192.176443119365,
         "Datum_neu": 1671926400000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "18.12.2022 - 24.12.2022",
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 158.3,
         "Fallzahl_aktiv": null,
@@ -39194,9 +39194,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.1,
-        "H_Zeitraum": "18.12.2022 - 24.12.2022",
-        "H_Datum": "20.12.2022",
+        "H_Inzidenz": 9.79,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.12.2022"
       }
     },
@@ -39206,7 +39206,7 @@
         "Fallzahl": 277365,
         "ObjectId": 1025,
         "Sterbefall": null,
-        "Genesungsfall": 273293,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39216,7 +39216,7 @@
         "BelegteBetten": null,
         "Inzidenz": 206.365171162757,
         "Datum_neu": 1672012800000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": "19.12.2022 - 25.12.2022",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 154.7,
@@ -39232,7 +39232,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.1,
+        "H_Inzidenz": 9,
         "H_Zeitraum": "19.12.2022 - 25.12.2022",
         "H_Datum": "20.12.2022",
         "Datum_Bett": "25.12.2022"
@@ -39245,7 +39245,7 @@
         "ObjectId": 1026,
         "Sterbefall": 1827,
         "Genesungsfall": 273606,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7342,
         "Zuwachs_Fallzahl": 407,
         "Zuwachs_Sterbefall": 1,
@@ -39254,9 +39254,9 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1672099200000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 171,
         "Zeitraum": "20.12.2022 - 26.12.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": 108,
         "Fallzahl_aktiv": 1941,
         "Krh_N_belegt": 837,
@@ -39270,11 +39270,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.1,
+        "H_Inzidenz": 8.46,
         "H_Zeitraum": "20.12.2022 - 26.12.2022",
         "H_Datum": "20.12.2022",
         "Datum_Bett": "26.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.12.2022",
+        "Fallzahl": 277589,
+        "ObjectId": 1027,
+        "Sterbefall": 1827,
+        "Genesungsfall": 273797,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7359,
+        "Zuwachs_Fallzahl": 215,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 191,
+        "BelegteBetten": null,
+        "Inzidenz": 143.862926110852,
+        "Datum_neu": 1672185600000,
+        "F\u00e4lle_Meldedatum": 26,
+        "Zeitraum": "21.12.2022 - 27.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 108.6,
+        "Fallzahl_aktiv": 1965,
+        "Krh_N_belegt": 823,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 24,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.27,
+        "H_Zeitraum": "21.12.2022 - 27.12.2022",
+        "H_Datum": "27.12.2022",
+        "Datum_Bett": "27.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
