### PR TITLE
New data set: 2022-12-29T105003Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-28T104703Z.json
+pjson/2022-12-29T105003Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-28T104703Z.json pjson/2022-12-29T105003Z.json```:
```
--- pjson/2022-12-28T104703Z.json	2022-12-28 10:47:03.868217880 +0000
+++ pjson/2022-12-29T105003Z.json	2022-12-29 10:50:04.011483023 +0000
@@ -39029,10 +39029,10 @@
         "F\u00e4lle_Meldedatum": 219,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
-        "Inzidenz_RKI": 155.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39042,7 +39042,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.07,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.12.2022"
@@ -39080,7 +39080,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.38,
+        "H_Inzidenz": 13.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.12.2022"
@@ -39102,7 +39102,7 @@
         "BelegteBetten": null,
         "Inzidenz": 200.438234131973,
         "Datum_neu": 1671753600000,
-        "F\u00e4lle_Meldedatum": 154,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 173.6,
@@ -39118,7 +39118,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.69,
+        "H_Inzidenz": 12.47,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.12.2022"
@@ -39140,7 +39140,7 @@
         "BelegteBetten": null,
         "Inzidenz": 186.788318545925,
         "Datum_neu": 1671840000000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 170.7,
@@ -39156,7 +39156,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.28,
+        "H_Inzidenz": 11.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.12.2022"
@@ -39178,7 +39178,7 @@
         "BelegteBetten": null,
         "Inzidenz": 192.176443119365,
         "Datum_neu": 1671926400000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 158.3,
@@ -39194,7 +39194,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.79,
+        "H_Inzidenz": 11.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.12.2022"
@@ -39217,7 +39217,7 @@
         "Inzidenz": 206.365171162757,
         "Datum_neu": 1672012800000,
         "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "19.12.2022 - 25.12.2022",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 154.7,
         "Fallzahl_aktiv": null,
@@ -39232,9 +39232,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9,
-        "H_Zeitraum": "19.12.2022 - 25.12.2022",
-        "H_Datum": "20.12.2022",
+        "H_Inzidenz": 11.28,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.12.2022"
       }
     },
@@ -39243,36 +39243,36 @@
         "Datum": "27.12.2022",
         "Fallzahl": 277374,
         "ObjectId": 1026,
-        "Sterbefall": 1827,
-        "Genesungsfall": 273606,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7342,
-        "Zuwachs_Fallzahl": 407,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 25,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 313,
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1672099200000,
-        "F\u00e4lle_Meldedatum": 171,
-        "Zeitraum": "20.12.2022 - 26.12.2022",
-        "Hosp_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 186,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 108,
-        "Fallzahl_aktiv": 1941,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 837,
         "Krh_I_belegt": 68,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 93,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.46,
-        "H_Zeitraum": "20.12.2022 - 26.12.2022",
-        "H_Datum": "20.12.2022",
+        "H_Inzidenz": 8.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.12.2022"
       }
     },
@@ -39283,7 +39283,7 @@
         "ObjectId": 1027,
         "Sterbefall": 1827,
         "Genesungsfall": 273797,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7359,
         "Zuwachs_Fallzahl": 215,
         "Zuwachs_Sterbefall": 0,
@@ -39292,9 +39292,9 @@
         "BelegteBetten": null,
         "Inzidenz": 143.862926110852,
         "Datum_neu": 1672185600000,
-        "F\u00e4lle_Meldedatum": 26,
+        "F\u00e4lle_Meldedatum": 151,
         "Zeitraum": "21.12.2022 - 27.12.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 108.6,
         "Fallzahl_aktiv": 1965,
         "Krh_N_belegt": 823,
@@ -39308,11 +39308,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.27,
+        "H_Inzidenz": 7.69,
         "H_Zeitraum": "21.12.2022 - 27.12.2022",
         "H_Datum": "27.12.2022",
         "Datum_Bett": "27.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "29.12.2022",
+        "Fallzahl": 277752,
+        "ObjectId": 1028,
+        "Sterbefall": 1827,
+        "Genesungsfall": 274019,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7370,
+        "Zuwachs_Fallzahl": 163,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 222,
+        "BelegteBetten": null,
+        "Inzidenz": 136.499155860484,
+        "Datum_neu": 1672272000000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "22.12.2022 - 28.12.2022",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 107.5,
+        "Fallzahl_aktiv": 1906,
+        "Krh_N_belegt": 823,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -59,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.74,
+        "H_Zeitraum": "22.12.2022 - 28.12.2022",
+        "H_Datum": "27.12.2022",
+        "Datum_Bett": "28.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
