### PR TITLE
New data set: 2022-12-30T104404Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-28T104703Z.json
+pjson/2022-12-30T104404Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-29T105003Z.json pjson/2022-12-30T104404Z.json```:
```
--- pjson/2022-12-29T105003Z.json	2022-12-29 10:50:04.011483023 +0000
+++ pjson/2022-12-30T104404Z.json	2022-12-30 10:44:04.491782155 +0000
@@ -38762,7 +38762,7 @@
         "Datum_neu": 1670976000000,
         "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39064,13 +39064,13 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1671667200000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 185.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39080,7 +39080,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.12.2022"
@@ -39104,7 +39104,7 @@
         "Datum_neu": 1671753600000,
         "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": 173.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 837,
@@ -39118,7 +39118,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.47,
+        "H_Inzidenz": 12.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.12.2022"
@@ -39140,7 +39140,7 @@
         "BelegteBetten": null,
         "Inzidenz": 186.788318545925,
         "Datum_neu": 1671840000000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 170.7,
@@ -39156,7 +39156,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.77,
+        "H_Inzidenz": 12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.12.2022"
@@ -39194,7 +39194,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.48,
+        "H_Inzidenz": 11.75,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.12.2022"
@@ -39218,7 +39218,7 @@
         "Datum_neu": 1672012800000,
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 154.7,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 837,
@@ -39232,7 +39232,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.28,
+        "H_Inzidenz": 11.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.12.2022"
@@ -39254,9 +39254,9 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1672099200000,
-        "F\u00e4lle_Meldedatum": 186,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 108,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 837,
@@ -39270,7 +39270,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.41,
+        "H_Inzidenz": 8.73,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.12.2022"
@@ -39281,36 +39281,36 @@
         "Datum": "28.12.2022",
         "Fallzahl": 277589,
         "ObjectId": 1027,
-        "Sterbefall": 1827,
-        "Genesungsfall": 273797,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7359,
-        "Zuwachs_Fallzahl": 215,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 191,
         "BelegteBetten": null,
         "Inzidenz": 143.862926110852,
         "Datum_neu": 1672185600000,
-        "F\u00e4lle_Meldedatum": 151,
-        "Zeitraum": "21.12.2022 - 27.12.2022",
-        "Hosp_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 160,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 108.6,
-        "Fallzahl_aktiv": 1965,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 24,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
-        "H_Zeitraum": "21.12.2022 - 27.12.2022",
-        "H_Datum": "27.12.2022",
+        "H_Inzidenz": 8.81,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.12.2022"
       }
     },
@@ -39321,7 +39321,7 @@
         "ObjectId": 1028,
         "Sterbefall": 1827,
         "Genesungsfall": 274019,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7370,
         "Zuwachs_Fallzahl": 163,
         "Zuwachs_Sterbefall": 0,
@@ -39330,9 +39330,9 @@
         "BelegteBetten": null,
         "Inzidenz": 136.499155860484,
         "Datum_neu": 1672272000000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": "22.12.2022 - 28.12.2022",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 107.5,
         "Fallzahl_aktiv": 1906,
         "Krh_N_belegt": 823,
@@ -39346,11 +39346,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
+        "H_Inzidenz": 7.62,
         "H_Zeitraum": "22.12.2022 - 28.12.2022",
         "H_Datum": "27.12.2022",
         "Datum_Bett": "28.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "30.12.2022",
+        "Fallzahl": 277864,
+        "ObjectId": 1029,
+        "Sterbefall": 1827,
+        "Genesungsfall": 274191,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7395,
+        "Zuwachs_Fallzahl": 112,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 25,
+        "Zuwachs_Genesung": 172,
+        "BelegteBetten": null,
+        "Inzidenz": 127.518948238083,
+        "Datum_neu": 1672358400000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "23.12.2022 - 29.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 110,
+        "Fallzahl_aktiv": 1846,
+        "Krh_N_belegt": 823,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -60,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.18,
+        "H_Zeitraum": "23.12.2022 - 29.12.2022",
+        "H_Datum": "27.12.2022",
+        "Datum_Bett": "29.12.2022"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
