### PR TITLE
New data set: 2023-01-02T112604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2022-12-30T104404Z.json
+pjson/2023-01-02T112604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2022-12-30T104404Z.json pjson/2023-01-02T112604Z.json```:
```
--- pjson/2022-12-30T104404Z.json	2022-12-30 10:44:04.491782155 +0000
+++ pjson/2023-01-02T112604Z.json	2023-01-02 11:26:05.164772560 +0000
@@ -35466,7 +35466,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36074,7 +36074,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36340,7 +36340,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36862,7 +36862,7 @@
         "Datum_neu": 1666656000000,
         "F\u00e4lle_Meldedatum": 540,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -36872,7 +36872,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36948,7 +36948,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36986,7 +36986,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37822,7 +37822,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37898,7 +37898,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38202,7 +38202,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38506,7 +38506,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38544,7 +38544,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38582,7 +38582,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38772,7 +38772,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38848,7 +38848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38988,7 +38988,7 @@
         "BelegteBetten": null,
         "Inzidenz": 216.423003699846,
         "Datum_neu": 1671494400000,
-        "F\u00e4lle_Meldedatum": 233,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -39064,7 +39064,7 @@
         "BelegteBetten": null,
         "Inzidenz": 211.034879126405,
         "Datum_neu": 1671667200000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -39105,10 +39105,10 @@
         "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
-        "Inzidenz_RKI": 173.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39118,7 +39118,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.61,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.12.2022"
@@ -39143,10 +39143,10 @@
         "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 170.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39156,7 +39156,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.12.2022"
@@ -39180,11 +39180,11 @@
         "Datum_neu": 1671926400000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 158.3,
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39194,7 +39194,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.75,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.12.2022"
@@ -39232,7 +39232,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.6,
+        "H_Inzidenz": 12.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.12.2022"
@@ -39254,7 +39254,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1672099200000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 190,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 108,
@@ -39270,7 +39270,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.73,
+        "H_Inzidenz": 9.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.12.2022"
@@ -39292,9 +39292,9 @@
         "BelegteBetten": null,
         "Inzidenz": 143.862926110852,
         "Datum_neu": 1672185600000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 108.6,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
@@ -39308,7 +39308,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.81,
+        "H_Inzidenz": 10.22,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.12.2022"
@@ -39330,9 +39330,9 @@
         "BelegteBetten": null,
         "Inzidenz": 136.499155860484,
         "Datum_neu": 1672272000000,
-        "F\u00e4lle_Meldedatum": 96,
+        "F\u00e4lle_Meldedatum": 107,
         "Zeitraum": "22.12.2022 - 28.12.2022",
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 107.5,
         "Fallzahl_aktiv": 1906,
         "Krh_N_belegt": 823,
@@ -39346,7 +39346,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.62,
+        "H_Inzidenz": 9.35,
         "H_Zeitraum": "22.12.2022 - 28.12.2022",
         "H_Datum": "27.12.2022",
         "Datum_Bett": "28.12.2022"
@@ -39359,7 +39359,7 @@
         "ObjectId": 1029,
         "Sterbefall": 1827,
         "Genesungsfall": 274191,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7395,
         "Zuwachs_Fallzahl": 112,
         "Zuwachs_Sterbefall": 0,
@@ -39368,9 +39368,9 @@
         "BelegteBetten": null,
         "Inzidenz": 127.518948238083,
         "Datum_neu": 1672358400000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 102,
         "Zeitraum": "23.12.2022 - 29.12.2022",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 110,
         "Fallzahl_aktiv": 1846,
         "Krh_N_belegt": 823,
@@ -39384,11 +39384,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.18,
+        "H_Inzidenz": 8.24,
         "H_Zeitraum": "23.12.2022 - 29.12.2022",
         "H_Datum": "27.12.2022",
         "Datum_Bett": "29.12.2022"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "31.12.2022",
+        "Fallzahl": 278015,
+        "ObjectId": 1030,
+        "Sterbefall": null,
+        "Genesungsfall": 274192,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 119.975573835267,
+        "Datum_neu": 1672444800000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "24.12.2022 - 30.12.2022",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 99.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 823,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.98,
+        "H_Zeitraum": "24.12.2022 - 30.12.2022",
+        "H_Datum": "27.12.2022",
+        "Datum_Bett": "30.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "01.01.2023",
+        "Fallzahl": 278034,
+        "ObjectId": 1031,
+        "Sterbefall": null,
+        "Genesungsfall": 274193,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 118.179532310787,
+        "Datum_neu": 1672531200000,
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": "25.12.2022 - 31.12.2022",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 89.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 823,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.38,
+        "H_Zeitraum": "25.12.2022 - 31.12.2022",
+        "H_Datum": "27.12.2022",
+        "Datum_Bett": "31.12.2022"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.01.2023",
+        "Fallzahl": 278065,
+        "ObjectId": 1032,
+        "Sterbefall": 1845,
+        "Genesungsfall": 274531,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7411,
+        "Zuwachs_Fallzahl": 201,
+        "Zuwachs_Sterbefall": 18,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 340,
+        "BelegteBetten": null,
+        "Inzidenz": 117.281511548547,
+        "Datum_neu": 1672617600000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "26.12.2022 - 01.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 85.5,
+        "Fallzahl_aktiv": 1689,
+        "Krh_N_belegt": 823,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -157,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.79,
+        "H_Zeitraum": "26.12.2022 - 01.01.2023",
+        "H_Datum": "27.12.2022",
+        "Datum_Bett": "01.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
