### PR TITLE
New data set: 2023-01-03T105804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-02T112604Z.json
+pjson/2023-01-03T105804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-02T112604Z.json pjson/2023-01-03T105804Z.json```:
```
--- pjson/2023-01-02T112604Z.json	2023-01-02 11:26:05.164772560 +0000
+++ pjson/2023-01-03T105804Z.json	2023-01-03 10:58:04.437405236 +0000
@@ -36188,7 +36188,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36226,7 +36226,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -36720,7 +36720,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37290,7 +37290,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -37404,7 +37404,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38002,7 +38002,7 @@
         "Datum_neu": 1669248000000,
         "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38088,7 +38088,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38316,7 +38316,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 5,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38608,7 +38608,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670630400000,
-        "F\u00e4lle_Meldedatum": 68,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38658,7 +38658,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38722,7 +38722,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670889600000,
-        "F\u00e4lle_Meldedatum": 325,
+        "F\u00e4lle_Meldedatum": 326,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -38772,7 +38772,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39114,7 +39114,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39219,10 +39219,10 @@
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 154.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39232,7 +39232,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.52,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.12.2022"
@@ -39254,7 +39254,7 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1672099200000,
-        "F\u00e4lle_Meldedatum": 190,
+        "F\u00e4lle_Meldedatum": 188,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 108,
@@ -39270,7 +39270,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.67,
+        "H_Inzidenz": 10.07,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.12.2022"
@@ -39292,7 +39292,7 @@
         "BelegteBetten": null,
         "Inzidenz": 143.862926110852,
         "Datum_neu": 1672185600000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 161,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
         "Inzidenz_RKI": 108.6,
@@ -39308,7 +39308,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.22,
+        "H_Inzidenz": 10.98,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.12.2022"
@@ -39319,26 +39319,26 @@
         "Datum": "29.12.2022",
         "Fallzahl": 277752,
         "ObjectId": 1028,
-        "Sterbefall": 1827,
-        "Genesungsfall": 274019,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7370,
-        "Zuwachs_Fallzahl": 163,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 222,
         "BelegteBetten": null,
         "Inzidenz": 136.499155860484,
         "Datum_neu": 1672272000000,
         "F\u00e4lle_Meldedatum": 107,
-        "Zeitraum": "22.12.2022 - 28.12.2022",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 107.5,
-        "Fallzahl_aktiv": 1906,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -59,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39346,9 +39346,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.35,
-        "H_Zeitraum": "22.12.2022 - 28.12.2022",
-        "H_Datum": "27.12.2022",
+        "H_Inzidenz": 10.46,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.12.2022"
       }
     },
@@ -39357,26 +39357,26 @@
         "Datum": "30.12.2022",
         "Fallzahl": 277864,
         "ObjectId": 1029,
-        "Sterbefall": 1827,
-        "Genesungsfall": 274191,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7395,
-        "Zuwachs_Fallzahl": 112,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 25,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 172,
         "BelegteBetten": null,
         "Inzidenz": 127.518948238083,
         "Datum_neu": 1672358400000,
-        "F\u00e4lle_Meldedatum": 102,
-        "Zeitraum": "23.12.2022 - 29.12.2022",
-        "Hosp_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 108,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 110,
-        "Fallzahl_aktiv": 1846,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -60,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39384,9 +39384,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.24,
-        "H_Zeitraum": "23.12.2022 - 29.12.2022",
-        "H_Datum": "27.12.2022",
+        "H_Inzidenz": 9.92,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.12.2022"
       }
     },
@@ -39396,7 +39396,7 @@
         "Fallzahl": 278015,
         "ObjectId": 1030,
         "Sterbefall": null,
-        "Genesungsfall": 274192,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39406,8 +39406,8 @@
         "BelegteBetten": null,
         "Inzidenz": 119.975573835267,
         "Datum_neu": 1672444800000,
-        "F\u00e4lle_Meldedatum": 46,
-        "Zeitraum": "24.12.2022 - 30.12.2022",
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 99.9,
         "Fallzahl_aktiv": null,
@@ -39422,9 +39422,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.98,
-        "H_Zeitraum": "24.12.2022 - 30.12.2022",
-        "H_Datum": "27.12.2022",
+        "H_Inzidenz": 9.18,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "30.12.2022"
       }
     },
@@ -39434,7 +39434,7 @@
         "Fallzahl": 278034,
         "ObjectId": 1031,
         "Sterbefall": null,
-        "Genesungsfall": 274193,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39444,8 +39444,8 @@
         "BelegteBetten": null,
         "Inzidenz": 118.179532310787,
         "Datum_neu": 1672531200000,
-        "F\u00e4lle_Meldedatum": 19,
-        "Zeitraum": "25.12.2022 - 31.12.2022",
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 89.9,
         "Fallzahl_aktiv": null,
@@ -39460,9 +39460,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.38,
-        "H_Zeitraum": "25.12.2022 - 31.12.2022",
-        "H_Datum": "27.12.2022",
+        "H_Inzidenz": 8.78,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "31.12.2022"
       }
     },
@@ -39473,7 +39473,7 @@
         "ObjectId": 1032,
         "Sterbefall": 1845,
         "Genesungsfall": 274531,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7411,
         "Zuwachs_Fallzahl": 201,
         "Zuwachs_Sterbefall": 18,
@@ -39482,9 +39482,9 @@
         "BelegteBetten": null,
         "Inzidenz": 117.281511548547,
         "Datum_neu": 1672617600000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 145,
         "Zeitraum": "26.12.2022 - 01.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 85.5,
         "Fallzahl_aktiv": 1689,
         "Krh_N_belegt": 823,
@@ -39498,11 +39498,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.79,
+        "H_Inzidenz": 8.36,
         "H_Zeitraum": "26.12.2022 - 01.01.2023",
         "H_Datum": "27.12.2022",
         "Datum_Bett": "01.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.01.2023",
+        "Fallzahl": 278219,
+        "ObjectId": 1033,
+        "Sterbefall": 1860,
+        "Genesungsfall": 274746,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7419,
+        "Zuwachs_Fallzahl": 154,
+        "Zuwachs_Sterbefall": 15,
+        "Zuwachs_Krankenhauseinweisung": 8,
+        "Zuwachs_Genesung": 215,
+        "BelegteBetten": null,
+        "Inzidenz": 140.091238909444,
+        "Datum_neu": 1672704000000,
+        "F\u00e4lle_Meldedatum": 29,
+        "Zeitraum": "27.12.2022 - 02.01.2023",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 114.2,
+        "Fallzahl_aktiv": 1613,
+        "Krh_N_belegt": 823,
+        "Krh_I_belegt": 79,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -76,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.04,
+        "H_Zeitraum": "27.12.2022 - 02.01.2023",
+        "H_Datum": "27.12.2022",
+        "Datum_Bett": "02.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
