### PR TITLE
New data set: 2023-01-04T105004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-03T105804Z.json
+pjson/2023-01-04T105004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-03T105804Z.json pjson/2023-01-04T105004Z.json```:
```
--- pjson/2023-01-03T105804Z.json	2023-01-03 10:58:04.437405236 +0000
+++ pjson/2023-01-04T105004Z.json	2023-01-04 10:50:04.513267733 +0000
@@ -38306,7 +38306,7 @@
         "Datum_neu": 1669939200000,
         "F\u00e4lle_Meldedatum": 205,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 16,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38354,7 +38354,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38392,7 +38392,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39066,7 +39066,7 @@
         "Datum_neu": 1671667200000,
         "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39114,7 +39114,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39228,7 +39228,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39254,13 +39254,13 @@
         "BelegteBetten": null,
         "Inzidenz": 150.508279751428,
         "Datum_neu": 1672099200000,
-        "F\u00e4lle_Meldedatum": 188,
+        "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 108,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 837,
-        "Krh_I_belegt": 68,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39270,7 +39270,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.07,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.12.2022"
@@ -39308,7 +39308,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.98,
+        "H_Inzidenz": 12.56,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.12.2022"
@@ -39346,7 +39346,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.46,
+        "H_Inzidenz": 12.52,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.12.2022"
@@ -39368,9 +39368,9 @@
         "BelegteBetten": null,
         "Inzidenz": 127.518948238083,
         "Datum_neu": 1672358400000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 110,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
@@ -39384,7 +39384,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.92,
+        "H_Inzidenz": 12.19,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.12.2022"
@@ -39402,11 +39402,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1,
+        "Zuwachs_Genesung": 80,
         "BelegteBetten": null,
         "Inzidenz": 119.975573835267,
         "Datum_neu": 1672444800000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 99.9,
@@ -39422,7 +39422,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.18,
+        "H_Inzidenz": 11.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.12.2022"
@@ -39440,7 +39440,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 1,
+        "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
         "Inzidenz": 118.179532310787,
         "Datum_neu": 1672531200000,
@@ -39460,7 +39460,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.78,
+        "H_Inzidenz": 11.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.12.2022"
@@ -39471,26 +39471,26 @@
         "Datum": "02.01.2023",
         "Fallzahl": 278065,
         "ObjectId": 1032,
-        "Sterbefall": 1845,
-        "Genesungsfall": 274531,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7411,
-        "Zuwachs_Fallzahl": 201,
-        "Zuwachs_Sterbefall": 18,
-        "Zuwachs_Krankenhauseinweisung": 16,
-        "Zuwachs_Genesung": 340,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 253,
         "BelegteBetten": null,
         "Inzidenz": 117.281511548547,
         "Datum_neu": 1672617600000,
-        "F\u00e4lle_Meldedatum": 145,
+        "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": "26.12.2022 - 01.01.2023",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 85.5,
-        "Fallzahl_aktiv": 1689,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -157,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39498,9 +39498,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.36,
-        "H_Zeitraum": "26.12.2022 - 01.01.2023",
-        "H_Datum": "27.12.2022",
+        "H_Inzidenz": 11.16,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.01.2023"
       }
     },
@@ -39511,7 +39511,7 @@
         "ObjectId": 1033,
         "Sterbefall": 1860,
         "Genesungsfall": 274746,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7419,
         "Zuwachs_Fallzahl": 154,
         "Zuwachs_Sterbefall": 15,
@@ -39520,9 +39520,9 @@
         "BelegteBetten": null,
         "Inzidenz": 140.091238909444,
         "Datum_neu": 1672704000000,
-        "F\u00e4lle_Meldedatum": 29,
+        "F\u00e4lle_Meldedatum": 133,
         "Zeitraum": "27.12.2022 - 02.01.2023",
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 114.2,
         "Fallzahl_aktiv": 1613,
         "Krh_N_belegt": 823,
@@ -39536,11 +39536,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.04,
+        "H_Inzidenz": 12.12,
         "H_Zeitraum": "27.12.2022 - 02.01.2023",
         "H_Datum": "27.12.2022",
         "Datum_Bett": "02.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "04.01.2023",
+        "Fallzahl": 278383,
+        "ObjectId": 1034,
+        "Sterbefall": 1864,
+        "Genesungsfall": 275009,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7439,
+        "Zuwachs_Fallzahl": 164,
+        "Zuwachs_Sterbefall": 4,
+        "Zuwachs_Krankenhauseinweisung": 20,
+        "Zuwachs_Genesung": 263,
+        "BelegteBetten": null,
+        "Inzidenz": 133.805093573763,
+        "Datum_neu": 1672790400000,
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": "28.12.2022 - 03.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 109.8,
+        "Fallzahl_aktiv": 1510,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -103,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.62,
+        "H_Zeitraum": "28.12.2022 - 03.01.2023",
+        "H_Datum": "03.01.2023",
+        "Datum_Bett": "03.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
