### PR TITLE
New data set: 2023-01-05T105503Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-04T105004Z.json
+pjson/2023-01-05T105503Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-04T105004Z.json pjson/2023-01-05T105503Z.json```:
```
--- pjson/2023-01-04T105004Z.json	2023-01-04 10:50:04.513267733 +0000
+++ pjson/2023-01-05T105503Z.json	2023-01-05 10:55:04.334967899 +0000
@@ -30362,7 +30362,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1651881600000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -30970,7 +30970,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1653264000000,
-        "F\u00e4lle_Meldedatum": 265,
+        "F\u00e4lle_Meldedatum": 262,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -33478,7 +33478,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1658966400000,
-        "F\u00e4lle_Meldedatum": 374,
+        "F\u00e4lle_Meldedatum": 372,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -38758,7 +38758,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 229,
         "BelegteBetten": null,
-        "Inzidenz": 136.319551708035,
+        "Inzidenz": null,
         "Datum_neu": 1670976000000,
         "F\u00e4lle_Meldedatum": 194,
         "Zeitraum": null,
@@ -38796,7 +38796,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 208,
         "BelegteBetten": null,
-        "Inzidenz": 148.712238226948,
+        "Inzidenz": null,
         "Datum_neu": 1671062400000,
         "F\u00e4lle_Meldedatum": 216,
         "Zeitraum": null,
@@ -38834,7 +38834,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 189,
         "BelegteBetten": null,
-        "Inzidenz": 180.502173210245,
+        "Inzidenz": null,
         "Datum_neu": 1671148800000,
         "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
@@ -38872,7 +38872,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 96,
         "BelegteBetten": null,
-        "Inzidenz": 151.406300513668,
+        "Inzidenz": null,
         "Datum_neu": 1671235200000,
         "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
@@ -38910,7 +38910,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 35,
         "BelegteBetten": null,
-        "Inzidenz": 150.508279751428,
+        "Inzidenz": null,
         "Datum_neu": 1671321600000,
         "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
@@ -38948,7 +38948,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 280,
         "BelegteBetten": null,
-        "Inzidenz": 192.715255576709,
+        "Inzidenz": null,
         "Datum_neu": 1671408000000,
         "F\u00e4lle_Meldedatum": 260,
         "Zeitraum": null,
@@ -38986,7 +38986,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 281,
         "BelegteBetten": null,
-        "Inzidenz": 216.423003699846,
+        "Inzidenz": null,
         "Datum_neu": 1671494400000,
         "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
@@ -39022,11 +39022,11 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 237,
+        "Zuwachs_Genesung": 230,
         "BelegteBetten": null,
-        "Inzidenz": 204.389525485829,
+        "Inzidenz": null,
         "Datum_neu": 1671580800000,
-        "F\u00e4lle_Meldedatum": 219,
+        "F\u00e4lle_Meldedatum": 220,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -39060,9 +39060,9 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 217,
+        "Zuwachs_Genesung": 205,
         "BelegteBetten": null,
-        "Inzidenz": 211.034879126405,
+        "Inzidenz": null,
         "Datum_neu": 1671667200000,
         "F\u00e4lle_Meldedatum": 160,
         "Zeitraum": null,
@@ -39098,9 +39098,9 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 241,
+        "Zuwachs_Genesung": 237,
         "BelegteBetten": null,
-        "Inzidenz": 200.438234131973,
+        "Inzidenz": null,
         "Datum_neu": 1671753600000,
         "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
@@ -39138,7 +39138,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
-        "Inzidenz": 186.788318545925,
+        "Inzidenz": null,
         "Datum_neu": 1671840000000,
         "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
@@ -39176,7 +39176,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 192.176443119365,
+        "Inzidenz": null,
         "Datum_neu": 1671926400000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
@@ -39214,7 +39214,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 170,
         "BelegteBetten": null,
-        "Inzidenz": 206.365171162757,
+        "Inzidenz": null,
         "Datum_neu": 1672012800000,
         "F\u00e4lle_Meldedatum": 27,
         "Zeitraum": null,
@@ -39292,13 +39292,13 @@
         "BelegteBetten": null,
         "Inzidenz": 143.862926110852,
         "Datum_neu": 1672185600000,
-        "F\u00e4lle_Meldedatum": 161,
+        "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
         "Hosp_Meldedatum": 19,
-        "Inzidenz_RKI": 108.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 823,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39308,7 +39308,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.56,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.12.2022"
@@ -39326,7 +39326,7 @@
         "Zuwachs_Fallzahl": null,
         "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": null,
-        "Zuwachs_Genesung": 222,
+        "Zuwachs_Genesung": 212,
         "BelegteBetten": null,
         "Inzidenz": 136.499155860484,
         "Datum_neu": 1672272000000,
@@ -39368,7 +39368,7 @@
         "BelegteBetten": null,
         "Inzidenz": 127.518948238083,
         "Datum_neu": 1672358400000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": 110,
@@ -39483,7 +39483,7 @@
         "Inzidenz": 117.281511548547,
         "Datum_neu": 1672617600000,
         "F\u00e4lle_Meldedatum": 163,
-        "Zeitraum": "26.12.2022 - 01.01.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": 85.5,
         "Fallzahl_aktiv": null,
@@ -39494,7 +39494,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39509,26 +39509,26 @@
         "Datum": "03.01.2023",
         "Fallzahl": 278219,
         "ObjectId": 1033,
-        "Sterbefall": 1860,
-        "Genesungsfall": 274746,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7419,
-        "Zuwachs_Fallzahl": 154,
-        "Zuwachs_Sterbefall": 15,
-        "Zuwachs_Krankenhauseinweisung": 8,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 215,
         "BelegteBetten": null,
         "Inzidenz": 140.091238909444,
         "Datum_neu": 1672704000000,
-        "F\u00e4lle_Meldedatum": 133,
-        "Zeitraum": "27.12.2022 - 02.01.2023",
-        "Hosp_Meldedatum": 5,
+        "F\u00e4lle_Meldedatum": 141,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 114.2,
-        "Fallzahl_aktiv": 1613,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
         "Krh_I_belegt": 79,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -76,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39537,8 +39537,8 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 12.12,
-        "H_Zeitraum": "27.12.2022 - 02.01.2023",
-        "H_Datum": "27.12.2022",
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.01.2023"
       }
     },
@@ -39549,7 +39549,7 @@
         "ObjectId": 1034,
         "Sterbefall": 1864,
         "Genesungsfall": 275009,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7439,
         "Zuwachs_Fallzahl": 164,
         "Zuwachs_Sterbefall": 4,
@@ -39558,9 +39558,9 @@
         "BelegteBetten": null,
         "Inzidenz": 133.805093573763,
         "Datum_neu": 1672790400000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 115,
         "Zeitraum": "28.12.2022 - 03.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 109.8,
         "Fallzahl_aktiv": 1510,
         "Krh_N_belegt": 806,
@@ -39579,6 +39579,44 @@
         "H_Datum": "03.01.2023",
         "Datum_Bett": "03.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "05.01.2023",
+        "Fallzahl": 278482,
+        "ObjectId": 1035,
+        "Sterbefall": 1866,
+        "Genesungsfall": 275168,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7456,
+        "Zuwachs_Fallzahl": 99,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 17,
+        "Zuwachs_Genesung": 159,
+        "BelegteBetten": null,
+        "Inzidenz": 127.159739933187,
+        "Datum_neu": 1672876800000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "29.12.2022 - 04.01.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 111.3,
+        "Fallzahl_aktiv": 1448,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -62,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.62,
+        "H_Zeitraum": "29.12.2022 - 04.01.2023",
+        "H_Datum": "03.01.2023",
+        "Datum_Bett": "04.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
