### PR TITLE
New data set: 2023-01-06T105203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-04T105004Z.json
+pjson/2023-01-06T105203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-05T105503Z.json pjson/2023-01-06T105203Z.json```:
```
--- pjson/2023-01-05T105503Z.json	2023-01-05 10:55:04.334967899 +0000
+++ pjson/2023-01-06T105203Z.json	2023-01-06 10:52:04.068805442 +0000
@@ -34010,7 +34010,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660176000000,
-        "F\u00e4lle_Meldedatum": 307,
+        "F\u00e4lle_Meldedatum": 306,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -34200,7 +34200,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660608000000,
-        "F\u00e4lle_Meldedatum": 417,
+        "F\u00e4lle_Meldedatum": 416,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -39252,7 +39252,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 313,
         "BelegteBetten": null,
-        "Inzidenz": 150.508279751428,
+        "Inzidenz": null,
         "Datum_neu": 1672099200000,
         "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
@@ -39330,13 +39330,13 @@
         "BelegteBetten": null,
         "Inzidenz": 136.499155860484,
         "Datum_neu": 1672272000000,
-        "F\u00e4lle_Meldedatum": 107,
+        "F\u00e4lle_Meldedatum": 108,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 107.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 823,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39346,7 +39346,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.52,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.12.2022"
@@ -39370,7 +39370,7 @@
         "Datum_neu": 1672358400000,
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 13,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 110,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 823,
@@ -39384,7 +39384,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.19,
+        "H_Inzidenz": 13.36,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.12.2022"
@@ -39406,7 +39406,7 @@
         "BelegteBetten": null,
         "Inzidenz": 119.975573835267,
         "Datum_neu": 1672444800000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 99.9,
@@ -39422,7 +39422,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.6,
+        "H_Inzidenz": 12.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.12.2022"
@@ -39460,7 +39460,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.48,
+        "H_Inzidenz": 12.79,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.12.2022"
@@ -39498,7 +39498,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.16,
+        "H_Inzidenz": 12.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.01.2023"
@@ -39536,7 +39536,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.12,
+        "H_Inzidenz": 14.94,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2023"
@@ -39547,26 +39547,26 @@
         "Datum": "04.01.2023",
         "Fallzahl": 278383,
         "ObjectId": 1034,
-        "Sterbefall": 1864,
-        "Genesungsfall": 275009,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7439,
-        "Zuwachs_Fallzahl": 164,
-        "Zuwachs_Sterbefall": 4,
-        "Zuwachs_Krankenhauseinweisung": 20,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 263,
         "BelegteBetten": null,
         "Inzidenz": 133.805093573763,
         "Datum_neu": 1672790400000,
-        "F\u00e4lle_Meldedatum": 115,
-        "Zeitraum": "28.12.2022 - 03.01.2023",
+        "F\u00e4lle_Meldedatum": 122,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 109.8,
-        "Fallzahl_aktiv": 1510,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -103,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39574,9 +39574,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.62,
-        "H_Zeitraum": "28.12.2022 - 03.01.2023",
-        "H_Datum": "03.01.2023",
+        "H_Inzidenz": 11.77,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.01.2023"
       }
     },
@@ -39587,7 +39587,7 @@
         "ObjectId": 1035,
         "Sterbefall": 1866,
         "Genesungsfall": 275168,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7456,
         "Zuwachs_Fallzahl": 99,
         "Zuwachs_Sterbefall": 2,
@@ -39596,9 +39596,9 @@
         "BelegteBetten": null,
         "Inzidenz": 127.159739933187,
         "Datum_neu": 1672876800000,
-        "F\u00e4lle_Meldedatum": 18,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": "29.12.2022 - 04.01.2023",
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 111.3,
         "Fallzahl_aktiv": 1448,
         "Krh_N_belegt": 806,
@@ -39612,11 +39612,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.62,
+        "H_Inzidenz": 10.24,
         "H_Zeitraum": "29.12.2022 - 04.01.2023",
         "H_Datum": "03.01.2023",
         "Datum_Bett": "04.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "06.01.2023",
+        "Fallzahl": 278552,
+        "ObjectId": 1036,
+        "Sterbefall": 1866,
+        "Genesungsfall": 275307,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7457,
+        "Zuwachs_Fallzahl": 70,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 139,
+        "BelegteBetten": null,
+        "Inzidenz": 121.412407054851,
+        "Datum_neu": 1672963200000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "30.12.2022 - 05.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 111.3,
+        "Fallzahl_aktiv": 1379,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -69,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.64,
+        "H_Zeitraum": "30.12.2022 - 05.01.2023",
+        "H_Datum": "03.01.2023",
+        "Datum_Bett": "05.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
