### PR TITLE
New data set: 2023-01-09T105504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-06T105203Z.json
+pjson/2023-01-09T105504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-06T105203Z.json pjson/2023-01-09T105504Z.json```:
```
--- pjson/2023-01-06T105203Z.json	2023-01-06 10:52:04.068805442 +0000
+++ pjson/2023-01-09T105504Z.json	2023-01-09 10:55:04.650477933 +0000
@@ -38684,7 +38684,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670803200000,
-        "F\u00e4lle_Meldedatum": 202,
+        "F\u00e4lle_Meldedatum": 203,
         "Zeitraum": null,
         "Hosp_Meldedatum": 32,
         "Inzidenz_RKI": null,
@@ -38760,7 +38760,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670976000000,
-        "F\u00e4lle_Meldedatum": 194,
+        "F\u00e4lle_Meldedatum": 195,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -39038,7 +39038,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39076,7 +39076,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39180,7 +39180,7 @@
         "Datum_neu": 1671926400000,
         "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39294,7 +39294,7 @@
         "Datum_neu": 1672185600000,
         "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 19,
+        "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39330,7 +39330,7 @@
         "BelegteBetten": null,
         "Inzidenz": 136.499155860484,
         "Datum_neu": 1672272000000,
-        "F\u00e4lle_Meldedatum": 108,
+        "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -39371,10 +39371,10 @@
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 110,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 823,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39384,7 +39384,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.36,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.12.2022"
@@ -39409,10 +39409,10 @@
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 99.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 823,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39422,7 +39422,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.12.2022"
@@ -39447,10 +39447,10 @@
         "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 89.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 823,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39460,7 +39460,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.79,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "31.12.2022"
@@ -39498,7 +39498,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.61,
+        "H_Inzidenz": 10.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.01.2023"
@@ -39536,7 +39536,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 14.94,
+        "H_Inzidenz": 13.15,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2023"
@@ -39558,9 +39558,9 @@
         "BelegteBetten": null,
         "Inzidenz": 133.805093573763,
         "Datum_neu": 1672790400000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 109.8,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
@@ -39574,7 +39574,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.77,
+        "H_Inzidenz": 11.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2023"
@@ -39585,26 +39585,26 @@
         "Datum": "05.01.2023",
         "Fallzahl": 278482,
         "ObjectId": 1035,
-        "Sterbefall": 1866,
-        "Genesungsfall": 275168,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7456,
-        "Zuwachs_Fallzahl": 99,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 17,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 159,
         "BelegteBetten": null,
         "Inzidenz": 127.159739933187,
         "Datum_neu": 1672876800000,
-        "F\u00e4lle_Meldedatum": 69,
-        "Zeitraum": "29.12.2022 - 04.01.2023",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 73,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 111.3,
-        "Fallzahl_aktiv": 1448,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -62,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39612,9 +39612,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.24,
-        "H_Zeitraum": "29.12.2022 - 04.01.2023",
-        "H_Datum": "03.01.2023",
+        "H_Inzidenz": 10.13,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "04.01.2023"
       }
     },
@@ -39625,7 +39625,7 @@
         "ObjectId": 1036,
         "Sterbefall": 1866,
         "Genesungsfall": 275307,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7457,
         "Zuwachs_Fallzahl": 70,
         "Zuwachs_Sterbefall": 0,
@@ -39634,9 +39634,9 @@
         "BelegteBetten": null,
         "Inzidenz": 121.412407054851,
         "Datum_neu": 1672963200000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 85,
         "Zeitraum": "30.12.2022 - 05.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 111.3,
         "Fallzahl_aktiv": 1379,
         "Krh_N_belegt": 806,
@@ -39650,11 +39650,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.64,
+        "H_Inzidenz": 8.97,
         "H_Zeitraum": "30.12.2022 - 05.01.2023",
         "H_Datum": "03.01.2023",
         "Datum_Bett": "05.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "07.01.2023",
+        "Fallzahl": 278656,
+        "ObjectId": 1037,
+        "Sterbefall": 1866,
+        "Genesungsfall": 275308,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7469,
+        "Zuwachs_Fallzahl": 0,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 117.461115700995,
+        "Datum_neu": 1673049600000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": "31.12.2022 - 06.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 103.9,
+        "Fallzahl_aktiv": 1482,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.81,
+        "H_Zeitraum": "31.12.2022 - 06.01.2023",
+        "H_Datum": "03.01.2023",
+        "Datum_Bett": "06.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "08.01.2023",
+        "Fallzahl": 278666,
+        "ObjectId": 1038,
+        "Sterbefall": 1866,
+        "Genesungsfall": 275309,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7469,
+        "Zuwachs_Fallzahl": 0,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 113.509824347139,
+        "Datum_neu": 1673136000000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "01.01.2023 - 07.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 95.1,
+        "Fallzahl_aktiv": 1491,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -1,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.47,
+        "H_Zeitraum": "01.01.2023 - 07.01.2023",
+        "H_Datum": "03.01.2023",
+        "Datum_Bett": "07.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.01.2023",
+        "Fallzahl": 278677,
+        "ObjectId": 1039,
+        "Sterbefall": 1869,
+        "Genesungsfall": 275432,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7469,
+        "Zuwachs_Fallzahl": 125,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 125,
+        "BelegteBetten": null,
+        "Inzidenz": 111.354574517763,
+        "Datum_neu": 1673222400000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "02.01.2023 - 08.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 91.1,
+        "Fallzahl_aktiv": 1376,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.15,
+        "H_Zeitraum": "02.01.2023 - 08.01.2023",
+        "H_Datum": "03.01.2023",
+        "Datum_Bett": "08.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
