### PR TITLE
New data set: 2023-01-10T104308Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-09T105504Z.json
+pjson/2023-01-10T104308Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-09T105504Z.json pjson/2023-01-10T104308Z.json```:
```
--- pjson/2023-01-09T105504Z.json	2023-01-09 10:55:04.650477933 +0000
+++ pjson/2023-01-10T104308Z.json	2023-01-10 10:43:09.240669473 +0000
@@ -38760,7 +38760,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670976000000,
-        "F\u00e4lle_Meldedatum": 195,
+        "F\u00e4lle_Meldedatum": 196,
         "Zeitraum": null,
         "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": null,
@@ -38988,7 +38988,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671494400000,
-        "F\u00e4lle_Meldedatum": 234,
+        "F\u00e4lle_Meldedatum": 235,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -39140,7 +39140,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671840000000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -39290,7 +39290,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 191,
         "BelegteBetten": null,
-        "Inzidenz": 143.862926110852,
+        "Inzidenz": null,
         "Datum_neu": 1672185600000,
         "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
@@ -39328,7 +39328,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 212,
         "BelegteBetten": null,
-        "Inzidenz": 136.499155860484,
+        "Inzidenz": null,
         "Datum_neu": 1672272000000,
         "F\u00e4lle_Meldedatum": 109,
         "Zeitraum": null,
@@ -39366,7 +39366,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 172,
         "BelegteBetten": null,
-        "Inzidenz": 127.518948238083,
+        "Inzidenz": null,
         "Datum_neu": 1672358400000,
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
@@ -39404,7 +39404,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 80,
         "BelegteBetten": null,
-        "Inzidenz": 119.975573835267,
+        "Inzidenz": null,
         "Datum_neu": 1672444800000,
         "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
@@ -39442,7 +39442,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 40,
         "BelegteBetten": null,
-        "Inzidenz": 118.179532310787,
+        "Inzidenz": null,
         "Datum_neu": 1672531200000,
         "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": null,
@@ -39485,10 +39485,10 @@
         "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
-        "Inzidenz_RKI": 85.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 823,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39498,7 +39498,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "01.01.2023"
@@ -39536,7 +39536,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 13.15,
+        "H_Inzidenz": 15.24,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2023"
@@ -39558,7 +39558,7 @@
         "BelegteBetten": null,
         "Inzidenz": 133.805093573763,
         "Datum_neu": 1672790400000,
-        "F\u00e4lle_Meldedatum": 121,
+        "F\u00e4lle_Meldedatum": 122,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 109.8,
@@ -39574,7 +39574,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.25,
+        "H_Inzidenz": 12.14,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2023"
@@ -39596,7 +39596,7 @@
         "BelegteBetten": null,
         "Inzidenz": 127.159739933187,
         "Datum_neu": 1672876800000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 111.3,
@@ -39612,7 +39612,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.13,
+        "H_Inzidenz": 11.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2023"
@@ -39623,26 +39623,26 @@
         "Datum": "06.01.2023",
         "Fallzahl": 278552,
         "ObjectId": 1036,
-        "Sterbefall": 1866,
-        "Genesungsfall": 275307,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7457,
-        "Zuwachs_Fallzahl": 70,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 139,
         "BelegteBetten": null,
         "Inzidenz": 121.412407054851,
         "Datum_neu": 1672963200000,
-        "F\u00e4lle_Meldedatum": 85,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": "30.12.2022 - 05.01.2023",
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 111.3,
-        "Fallzahl_aktiv": 1379,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -69,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39650,9 +39650,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.97,
-        "H_Zeitraum": "30.12.2022 - 05.01.2023",
-        "H_Datum": "03.01.2023",
+        "H_Inzidenz": 10.04,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.01.2023"
       }
     },
@@ -39661,26 +39661,26 @@
         "Datum": "07.01.2023",
         "Fallzahl": 278656,
         "ObjectId": 1037,
-        "Sterbefall": 1866,
-        "Genesungsfall": 275308,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7469,
-        "Zuwachs_Fallzahl": 0,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 70,
         "BelegteBetten": null,
         "Inzidenz": 117.461115700995,
         "Datum_neu": 1673049600000,
-        "F\u00e4lle_Meldedatum": 27,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": "31.12.2022 - 06.01.2023",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 103.9,
-        "Fallzahl_aktiv": 1482,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39688,9 +39688,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.81,
-        "H_Zeitraum": "31.12.2022 - 06.01.2023",
-        "H_Datum": "03.01.2023",
+        "H_Inzidenz": 9.15,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.01.2023"
       }
     },
@@ -39699,26 +39699,26 @@
         "Datum": "08.01.2023",
         "Fallzahl": 278666,
         "ObjectId": 1038,
-        "Sterbefall": 1866,
-        "Genesungsfall": 275309,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7469,
-        "Zuwachs_Fallzahl": 0,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
         "Inzidenz": 113.509824347139,
         "Datum_neu": 1673136000000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": "01.01.2023 - 07.01.2023",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 95.1,
-        "Fallzahl_aktiv": 1491,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39726,9 +39726,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.47,
-        "H_Zeitraum": "01.01.2023 - 07.01.2023",
-        "H_Datum": "03.01.2023",
+        "H_Inzidenz": 8.71,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.01.2023"
       }
     },
@@ -39739,36 +39739,74 @@
         "ObjectId": 1039,
         "Sterbefall": 1869,
         "Genesungsfall": 275432,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7469,
         "Zuwachs_Fallzahl": 125,
         "Zuwachs_Sterbefall": 3,
         "Zuwachs_Krankenhauseinweisung": 12,
-        "Zuwachs_Genesung": 125,
+        "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
         "Inzidenz": 111.354574517763,
         "Datum_neu": 1673222400000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 77,
         "Zeitraum": "02.01.2023 - 08.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 91.1,
         "Fallzahl_aktiv": 1376,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -3,
+        "Fallzahl_aktiv_Zuwachs": 96,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.15,
+        "H_Inzidenz": 8.24,
         "H_Zeitraum": "02.01.2023 - 08.01.2023",
         "H_Datum": "03.01.2023",
         "Datum_Bett": "08.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "10.01.2023",
+        "Fallzahl": 278774,
+        "ObjectId": 1040,
+        "Sterbefall": 1869,
+        "Genesungsfall": 275605,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7481,
+        "Zuwachs_Fallzahl": 97,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 12,
+        "Zuwachs_Genesung": 173,
+        "BelegteBetten": null,
+        "Inzidenz": 97.5250547792665,
+        "Datum_neu": 1673308800000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "03.01.2023 - 09.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 83.9,
+        "Fallzahl_aktiv": 1300,
+        "Krh_N_belegt": 806,
+        "Krh_I_belegt": 82,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -76,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.32,
+        "H_Zeitraum": "03.01.2023 - 09.01.2023",
+        "H_Datum": "03.01.2023",
+        "Datum_Bett": "09.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
