### PR TITLE
New data set: 2023-01-11T104304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-10T104308Z.json
+pjson/2023-01-11T104304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-10T104308Z.json pjson/2023-01-11T104304Z.json```:
```
--- pjson/2023-01-10T104308Z.json	2023-01-10 10:43:09.240669473 +0000
+++ pjson/2023-01-11T104304Z.json	2023-01-11 10:43:04.613287426 +0000
@@ -39294,7 +39294,7 @@
         "Datum_neu": 1672185600000,
         "F\u00e4lle_Meldedatum": 162,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 20,
+        "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39330,7 +39330,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672272000000,
-        "F\u00e4lle_Meldedatum": 109,
+        "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -39480,7 +39480,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 253,
         "BelegteBetten": null,
-        "Inzidenz": 117.281511548547,
+        "Inzidenz": null,
         "Datum_neu": 1672617600000,
         "F\u00e4lle_Meldedatum": 163,
         "Zeitraum": null,
@@ -39523,10 +39523,10 @@
         "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 114.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 823,
-        "Krh_I_belegt": 79,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39536,7 +39536,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 15.24,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "02.01.2023"
@@ -39574,7 +39574,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.14,
+        "H_Inzidenz": 12.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2023"
@@ -39612,7 +39612,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.03,
+        "H_Inzidenz": 11.3,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2023"
@@ -39634,8 +39634,8 @@
         "BelegteBetten": null,
         "Inzidenz": 121.412407054851,
         "Datum_neu": 1672963200000,
-        "F\u00e4lle_Meldedatum": 87,
-        "Zeitraum": "30.12.2022 - 05.01.2023",
+        "F\u00e4lle_Meldedatum": 88,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 111.3,
         "Fallzahl_aktiv": null,
@@ -39650,7 +39650,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.04,
+        "H_Inzidenz": 10.44,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2023"
@@ -39672,8 +39672,8 @@
         "BelegteBetten": null,
         "Inzidenz": 117.461115700995,
         "Datum_neu": 1673049600000,
-        "F\u00e4lle_Meldedatum": 32,
-        "Zeitraum": "31.12.2022 - 06.01.2023",
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 103.9,
         "Fallzahl_aktiv": null,
@@ -39688,7 +39688,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.15,
+        "H_Inzidenz": 9.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.01.2023"
@@ -39711,7 +39711,7 @@
         "Inzidenz": 113.509824347139,
         "Datum_neu": 1673136000000,
         "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "01.01.2023 - 07.01.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 95.1,
         "Fallzahl_aktiv": null,
@@ -39726,7 +39726,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.71,
+        "H_Inzidenz": 9.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.01.2023"
@@ -39737,34 +39737,34 @@
         "Datum": "09.01.2023",
         "Fallzahl": 278677,
         "ObjectId": 1039,
-        "Sterbefall": 1869,
-        "Genesungsfall": 275432,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7469,
-        "Zuwachs_Fallzahl": 125,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
         "Inzidenz": 111.354574517763,
         "Datum_neu": 1673222400000,
-        "F\u00e4lle_Meldedatum": 77,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": "02.01.2023 - 08.01.2023",
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 91.1,
-        "Fallzahl_aktiv": 1376,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 96,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.24,
+        "H_Inzidenz": 9.23,
         "H_Zeitraum": "02.01.2023 - 08.01.2023",
         "H_Datum": "03.01.2023",
         "Datum_Bett": "08.01.2023"
@@ -39777,7 +39777,7 @@
         "ObjectId": 1040,
         "Sterbefall": 1869,
         "Genesungsfall": 275605,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7481,
         "Zuwachs_Fallzahl": 97,
         "Zuwachs_Sterbefall": 0,
@@ -39786,9 +39786,9 @@
         "BelegteBetten": null,
         "Inzidenz": 97.5250547792665,
         "Datum_neu": 1673308800000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": "03.01.2023 - 09.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 83.9,
         "Fallzahl_aktiv": 1300,
         "Krh_N_belegt": 806,
@@ -39802,11 +39802,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.32,
+        "H_Inzidenz": 6.83,
         "H_Zeitraum": "03.01.2023 - 09.01.2023",
         "H_Datum": "03.01.2023",
         "Datum_Bett": "09.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "11.01.2023",
+        "Fallzahl": 278851,
+        "ObjectId": 1041,
+        "Sterbefall": 1869,
+        "Genesungsfall": 275778,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7485,
+        "Zuwachs_Fallzahl": 77,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 173,
+        "BelegteBetten": null,
+        "Inzidenz": 87.6468263946263,
+        "Datum_neu": 1673395200000,
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": "04.01.2023 - 10.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 75.8,
+        "Fallzahl_aktiv": 1204,
+        "Krh_N_belegt": 710,
+        "Krh_I_belegt": 61,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -96,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.7,
+        "H_Zeitraum": "04.01.2023 - 10.01.2023",
+        "H_Datum": "10.01.2023",
+        "Datum_Bett": "10.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
