### PR TITLE
New data set: 2023-01-12T105403Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-11T104304Z.json
+pjson/2023-01-12T105403Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-11T104304Z.json pjson/2023-01-12T105403Z.json```:
```
--- pjson/2023-01-11T104304Z.json	2023-01-11 10:43:04.613287426 +0000
+++ pjson/2023-01-12T105403Z.json	2023-01-12 10:54:04.420502454 +0000
@@ -39370,7 +39370,7 @@
         "Datum_neu": 1672358400000,
         "F\u00e4lle_Meldedatum": 110,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 12,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39518,7 +39518,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 215,
         "BelegteBetten": null,
-        "Inzidenz": 140.091238909444,
+        "Inzidenz": null,
         "Datum_neu": 1672704000000,
         "F\u00e4lle_Meldedatum": 141,
         "Zeitraum": null,
@@ -39556,15 +39556,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 263,
         "BelegteBetten": null,
-        "Inzidenz": 133.805093573763,
+        "Inzidenz": null,
         "Datum_neu": 1672790400000,
-        "F\u00e4lle_Meldedatum": 122,
+        "F\u00e4lle_Meldedatum": 121,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 109.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39574,7 +39574,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 12.39,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "03.01.2023"
@@ -39612,7 +39612,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.3,
+        "H_Inzidenz": 11.45,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2023"
@@ -39634,7 +39634,7 @@
         "BelegteBetten": null,
         "Inzidenz": 121.412407054851,
         "Datum_neu": 1672963200000,
-        "F\u00e4lle_Meldedatum": 88,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 111.3,
@@ -39650,7 +39650,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.44,
+        "H_Inzidenz": 10.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2023"
@@ -39688,7 +39688,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.89,
+        "H_Inzidenz": 10.12,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.01.2023"
@@ -39726,7 +39726,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.6,
+        "H_Inzidenz": 9.84,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.01.2023"
@@ -39748,8 +39748,8 @@
         "BelegteBetten": null,
         "Inzidenz": 111.354574517763,
         "Datum_neu": 1673222400000,
-        "F\u00e4lle_Meldedatum": 80,
-        "Zeitraum": "02.01.2023 - 08.01.2023",
+        "F\u00e4lle_Meldedatum": 81,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 91.1,
         "Fallzahl_aktiv": null,
@@ -39764,9 +39764,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.23,
-        "H_Zeitraum": "02.01.2023 - 08.01.2023",
-        "H_Datum": "03.01.2023",
+        "H_Inzidenz": 9.57,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.01.2023"
       }
     },
@@ -39775,26 +39775,26 @@
         "Datum": "10.01.2023",
         "Fallzahl": 278774,
         "ObjectId": 1040,
-        "Sterbefall": 1869,
-        "Genesungsfall": 275605,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7481,
-        "Zuwachs_Fallzahl": 97,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 12,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 173,
         "BelegteBetten": null,
         "Inzidenz": 97.5250547792665,
         "Datum_neu": 1673308800000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": "03.01.2023 - 09.01.2023",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 83.9,
-        "Fallzahl_aktiv": 1300,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
         "Krh_I_belegt": 82,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -76,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39802,7 +39802,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.83,
+        "H_Inzidenz": 7.74,
         "H_Zeitraum": "03.01.2023 - 09.01.2023",
         "H_Datum": "03.01.2023",
         "Datum_Bett": "09.01.2023"
@@ -39815,7 +39815,7 @@
         "ObjectId": 1041,
         "Sterbefall": 1869,
         "Genesungsfall": 275778,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7485,
         "Zuwachs_Fallzahl": 77,
         "Zuwachs_Sterbefall": 0,
@@ -39824,9 +39824,9 @@
         "BelegteBetten": null,
         "Inzidenz": 87.6468263946263,
         "Datum_neu": 1673395200000,
-        "F\u00e4lle_Meldedatum": 11,
+        "F\u00e4lle_Meldedatum": 51,
         "Zeitraum": "04.01.2023 - 10.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.8,
         "Fallzahl_aktiv": 1204,
         "Krh_N_belegt": 710,
@@ -39840,11 +39840,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.7,
+        "H_Inzidenz": 6.18,
         "H_Zeitraum": "04.01.2023 - 10.01.2023",
         "H_Datum": "10.01.2023",
         "Datum_Bett": "10.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "12.01.2023",
+        "Fallzahl": 278902,
+        "ObjectId": 1042,
+        "Sterbefall": 1869,
+        "Genesungsfall": 275895,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7501,
+        "Zuwachs_Fallzahl": 51,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 16,
+        "Zuwachs_Genesung": 117,
+        "BelegteBetten": null,
+        "Inzidenz": 75.7929523330579,
+        "Datum_neu": 1673481600000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "05.01.2023 - 11.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 65.9,
+        "Fallzahl_aktiv": 1138,
+        "Krh_N_belegt": 710,
+        "Krh_I_belegt": 31,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -66,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.77,
+        "H_Zeitraum": "05.01.2023 - 11.01.2023",
+        "H_Datum": "10.01.2023",
+        "Datum_Bett": "11.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
