### PR TITLE
New data set: 2023-01-13T110704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-12T105403Z.json
+pjson/2023-01-13T110704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-12T105403Z.json pjson/2023-01-13T110704Z.json```:
```
--- pjson/2023-01-12T105403Z.json	2023-01-12 10:54:04.420502454 +0000
+++ pjson/2023-01-13T110704Z.json	2023-01-13 11:07:04.747635382 +0000
@@ -33934,7 +33934,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1660003200000,
-        "F\u00e4lle_Meldedatum": 460,
+        "F\u00e4lle_Meldedatum": 461,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
@@ -35910,7 +35910,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1664496000000,
-        "F\u00e4lle_Meldedatum": 477,
+        "F\u00e4lle_Meldedatum": 478,
         "Zeitraum": null,
         "Hosp_Meldedatum": 14,
         "Inzidenz_RKI": null,
@@ -39152,7 +39152,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39266,7 +39266,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39380,7 +39380,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39532,7 +39532,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39599,10 +39599,10 @@
         "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 111.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39612,7 +39612,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 11.45,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "04.01.2023"
@@ -39650,7 +39650,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.59,
+        "H_Inzidenz": 10.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2023"
@@ -39688,7 +39688,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.12,
+        "H_Inzidenz": 10.39,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.01.2023"
@@ -39726,7 +39726,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.84,
+        "H_Inzidenz": 10.17,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.01.2023"
@@ -39748,7 +39748,7 @@
         "BelegteBetten": null,
         "Inzidenz": 111.354574517763,
         "Datum_neu": 1673222400000,
-        "F\u00e4lle_Meldedatum": 81,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 91.1,
@@ -39764,7 +39764,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.57,
+        "H_Inzidenz": 9.89,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.01.2023"
@@ -39787,7 +39787,7 @@
         "Inzidenz": 97.5250547792665,
         "Datum_neu": 1673308800000,
         "F\u00e4lle_Meldedatum": 84,
-        "Zeitraum": "03.01.2023 - 09.01.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": 83.9,
         "Fallzahl_aktiv": null,
@@ -39802,9 +39802,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.74,
-        "H_Zeitraum": "03.01.2023 - 09.01.2023",
-        "H_Datum": "03.01.2023",
+        "H_Inzidenz": 8.21,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.01.2023"
       }
     },
@@ -39813,26 +39813,26 @@
         "Datum": "11.01.2023",
         "Fallzahl": 278851,
         "ObjectId": 1041,
-        "Sterbefall": 1869,
-        "Genesungsfall": 275778,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7485,
-        "Zuwachs_Fallzahl": 77,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 173,
         "BelegteBetten": null,
         "Inzidenz": 87.6468263946263,
         "Datum_neu": 1673395200000,
-        "F\u00e4lle_Meldedatum": 51,
-        "Zeitraum": "04.01.2023 - 10.01.2023",
+        "F\u00e4lle_Meldedatum": 53,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.8,
-        "Fallzahl_aktiv": 1204,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 710,
         "Krh_I_belegt": 61,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -96,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39840,9 +39840,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.18,
-        "H_Zeitraum": "04.01.2023 - 10.01.2023",
-        "H_Datum": "10.01.2023",
+        "H_Inzidenz": 6.88,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.01.2023"
       }
     },
@@ -39853,7 +39853,7 @@
         "ObjectId": 1042,
         "Sterbefall": 1869,
         "Genesungsfall": 275895,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7501,
         "Zuwachs_Fallzahl": 51,
         "Zuwachs_Sterbefall": 0,
@@ -39862,13 +39862,13 @@
         "BelegteBetten": null,
         "Inzidenz": 75.7929523330579,
         "Datum_neu": 1673481600000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": "05.01.2023 - 11.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 65.9,
         "Fallzahl_aktiv": 1138,
         "Krh_N_belegt": 710,
-        "Krh_I_belegt": 31,
+        "Krh_I_belegt": 61,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -66,
         "Krh_I": null,
@@ -39878,11 +39878,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.77,
+        "H_Inzidenz": 5.61,
         "H_Zeitraum": "05.01.2023 - 11.01.2023",
         "H_Datum": "10.01.2023",
         "Datum_Bett": "11.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "13.01.2023",
+        "Fallzahl": 278954,
+        "ObjectId": 1043,
+        "Sterbefall": 1875,
+        "Genesungsfall": 276008,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7507,
+        "Zuwachs_Fallzahl": 52,
+        "Zuwachs_Sterbefall": 6,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 113,
+        "BelegteBetten": null,
+        "Inzidenz": 72.3804734365459,
+        "Datum_neu": 1673568000000,
+        "F\u00e4lle_Meldedatum": 4,
+        "Zeitraum": "06.01.2023 - 12.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 64.1,
+        "Fallzahl_aktiv": 1071,
+        "Krh_N_belegt": 710,
+        "Krh_I_belegt": 61,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -67,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.43,
+        "H_Zeitraum": "06.01.2023 - 12.01.2023",
+        "H_Datum": "10.01.2023",
+        "Datum_Bett": "12.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
