### PR TITLE
New data set: 2023-01-16T113604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-13T110704Z.json
+pjson/2023-01-16T113604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-13T110704Z.json pjson/2023-01-16T113604Z.json```:
```
--- pjson/2023-01-13T110704Z.json	2023-01-13 11:07:04.747635382 +0000
+++ pjson/2023-01-16T113604Z.json	2023-01-16 11:36:05.331608117 +0000
@@ -39594,7 +39594,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 159,
         "BelegteBetten": null,
-        "Inzidenz": 127.159739933187,
+        "Inzidenz": null,
         "Datum_neu": 1672876800000,
         "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
@@ -39632,15 +39632,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 139,
         "BelegteBetten": null,
-        "Inzidenz": 121.412407054851,
+        "Inzidenz": null,
         "Datum_neu": 1672963200000,
-        "F\u00e4lle_Meldedatum": 89,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 111.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39650,7 +39650,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.76,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "05.01.2023"
@@ -39670,15 +39670,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 70,
         "BelegteBetten": null,
-        "Inzidenz": 117.461115700995,
+        "Inzidenz": null,
         "Datum_neu": 1673049600000,
         "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 103.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39688,7 +39688,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.39,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "06.01.2023"
@@ -39708,15 +39708,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 113.509824347139,
+        "Inzidenz": null,
         "Datum_neu": 1673136000000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 95.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39726,7 +39726,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 10.17,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "07.01.2023"
@@ -39750,7 +39750,7 @@
         "Datum_neu": 1673222400000,
         "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 91.1,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 806,
@@ -39764,7 +39764,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.89,
+        "H_Inzidenz": 9.92,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.01.2023"
@@ -39802,7 +39802,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.21,
+        "H_Inzidenz": 8.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.01.2023"
@@ -39824,7 +39824,7 @@
         "BelegteBetten": null,
         "Inzidenz": 87.6468263946263,
         "Datum_neu": 1673395200000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.8,
@@ -39840,7 +39840,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.88,
+        "H_Inzidenz": 7.37,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2023"
@@ -39862,9 +39862,9 @@
         "BelegteBetten": null,
         "Inzidenz": 75.7929523330579,
         "Datum_neu": 1673481600000,
-        "F\u00e4lle_Meldedatum": 49,
-        "Zeitraum": "05.01.2023 - 11.01.2023",
-        "Hosp_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 51,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 65.9,
         "Fallzahl_aktiv": 1138,
         "Krh_N_belegt": 710,
@@ -39878,9 +39878,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.61,
-        "H_Zeitraum": "05.01.2023 - 11.01.2023",
-        "H_Datum": "10.01.2023",
+        "H_Inzidenz": 6.26,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.01.2023"
       }
     },
@@ -39891,7 +39891,7 @@
         "ObjectId": 1043,
         "Sterbefall": 1875,
         "Genesungsfall": 276008,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7507,
         "Zuwachs_Fallzahl": 52,
         "Zuwachs_Sterbefall": 6,
@@ -39900,9 +39900,9 @@
         "BelegteBetten": null,
         "Inzidenz": 72.3804734365459,
         "Datum_neu": 1673568000000,
-        "F\u00e4lle_Meldedatum": 4,
-        "Zeitraum": "06.01.2023 - 12.01.2023",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 64.1,
         "Fallzahl_aktiv": 1071,
         "Krh_N_belegt": 710,
@@ -39916,11 +39916,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.43,
-        "H_Zeitraum": "06.01.2023 - 12.01.2023",
-        "H_Datum": "10.01.2023",
+        "H_Inzidenz": 5.39,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "14.01.2023",
+        "Fallzahl": 279011,
+        "ObjectId": 1044,
+        "Sterbefall": null,
+        "Genesungsfall": 276060,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 52,
+        "BelegteBetten": null,
+        "Inzidenz": 64.6574948812817,
+        "Datum_neu": 1673654400000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "07.01.2023 - 13.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 56.9,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 710,
+        "Krh_I_belegt": 61,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.38,
+        "H_Zeitraum": "07.01.2023 - 13.01.2023",
+        "H_Datum": null,
+        "Datum_Bett": "13.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "15.01.2023",
+        "Fallzahl": 279024,
+        "ObjectId": 1045,
+        "Sterbefall": null,
+        "Genesungsfall": 276089,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 29,
+        "BelegteBetten": null,
+        "Inzidenz": 61.2450159847696,
+        "Datum_neu": 1673740800000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "08.01.2023 - 14.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 51,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 710,
+        "Krh_I_belegt": 61,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.01,
+        "H_Zeitraum": "08.01.2023 - 14.01.2023",
+        "H_Datum": null,
+        "Datum_Bett": "14.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.01.2023",
+        "Fallzahl": 279026,
+        "ObjectId": 1046,
+        "Sterbefall": 1875,
+        "Genesungsfall": 276236,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7517,
+        "Zuwachs_Fallzahl": 72,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 147,
+        "BelegteBetten": null,
+        "Inzidenz": 61.2450159847696,
+        "Datum_neu": 1673827200000,
+        "F\u00e4lle_Meldedatum": 2,
+        "Zeitraum": "09.01.2023 - 15.01.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 48.8,
+        "Fallzahl_aktiv": 915,
+        "Krh_N_belegt": 710,
+        "Krh_I_belegt": 61,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -75,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.76,
+        "H_Zeitraum": "09.01.2023 - 15.01.2023",
+        "H_Datum": "10.01.2026",
+        "Datum_Bett": "15.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
