### PR TITLE
New data set: 2023-01-17T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-16T113604Z.json
+pjson/2023-01-17T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-16T113604Z.json pjson/2023-01-17T110203Z.json```:
```
--- pjson/2023-01-16T113604Z.json	2023-01-16 11:36:05.331608117 +0000
+++ pjson/2023-01-17T110203Z.json	2023-01-17 11:02:04.262327222 +0000
@@ -39746,15 +39746,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
-        "Inzidenz": 111.354574517763,
+        "Inzidenz": null,
         "Datum_neu": 1673222400000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 91.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39764,7 +39764,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 9.92,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "08.01.2023"
@@ -39802,7 +39802,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.43,
+        "H_Inzidenz": 8.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.01.2023"
@@ -39824,7 +39824,7 @@
         "BelegteBetten": null,
         "Inzidenz": 87.6468263946263,
         "Datum_neu": 1673395200000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 56,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.8,
@@ -39840,7 +39840,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.37,
+        "H_Inzidenz": 7.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2023"
@@ -39851,13 +39851,13 @@
         "Datum": "12.01.2023",
         "Fallzahl": 278902,
         "ObjectId": 1042,
-        "Sterbefall": 1869,
+        "Sterbefall": null,
         "Genesungsfall": 275895,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7501,
-        "Zuwachs_Fallzahl": 51,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 16,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 117,
         "BelegteBetten": null,
         "Inzidenz": 75.7929523330579,
@@ -39866,11 +39866,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 65.9,
-        "Fallzahl_aktiv": 1138,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 710,
         "Krh_I_belegt": 61,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -66,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39878,7 +39878,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.26,
+        "H_Inzidenz": 6.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.01.2023"
@@ -39889,26 +39889,26 @@
         "Datum": "13.01.2023",
         "Fallzahl": 278954,
         "ObjectId": 1043,
-        "Sterbefall": 1875,
+        "Sterbefall": null,
         "Genesungsfall": 276008,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7507,
-        "Zuwachs_Fallzahl": 52,
-        "Zuwachs_Sterbefall": 6,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
         "Inzidenz": 72.3804734365459,
         "Datum_neu": 1673568000000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 6,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 64.1,
-        "Fallzahl_aktiv": 1071,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 710,
         "Krh_I_belegt": 61,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -67,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -39916,7 +39916,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.39,
+        "H_Inzidenz": 5.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.01.2023"
@@ -39925,7 +39925,7 @@
     {
       "attributes": {
         "Datum": "14.01.2023",
-        "Fallzahl": 279011,
+        "Fallzahl": 279012,
         "ObjectId": 1044,
         "Sterbefall": null,
         "Genesungsfall": 276060,
@@ -39936,10 +39936,10 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
-        "Inzidenz": 64.6574948812817,
+        "Inzidenz": 64.2982865763857,
         "Datum_neu": 1673654400000,
-        "F\u00e4lle_Meldedatum": 14,
-        "Zeitraum": "07.01.2023 - 13.01.2023",
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 56.9,
         "Fallzahl_aktiv": null,
@@ -39954,8 +39954,8 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.38,
-        "H_Zeitraum": "07.01.2023 - 13.01.2023",
+        "H_Inzidenz": 4.95,
+        "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2023"
       }
@@ -39963,7 +39963,7 @@
     {
       "attributes": {
         "Datum": "15.01.2023",
-        "Fallzahl": 279024,
+        "Fallzahl": 279025,
         "ObjectId": 1045,
         "Sterbefall": null,
         "Genesungsfall": 276089,
@@ -39974,10 +39974,10 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 61.2450159847696,
+        "Inzidenz": 61.4246201372176,
         "Datum_neu": 1673740800000,
         "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "08.01.2023 - 14.01.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51,
         "Fallzahl_aktiv": null,
@@ -39992,8 +39992,8 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.01,
-        "H_Zeitraum": "08.01.2023 - 14.01.2023",
+        "H_Inzidenz": 4.67,
+        "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2023"
       }
@@ -40005,7 +40005,7 @@
         "ObjectId": 1046,
         "Sterbefall": 1875,
         "Genesungsfall": 276236,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7517,
         "Zuwachs_Fallzahl": 72,
         "Zuwachs_Sterbefall": 0,
@@ -40014,9 +40014,9 @@
         "BelegteBetten": null,
         "Inzidenz": 61.2450159847696,
         "Datum_neu": 1673827200000,
-        "F\u00e4lle_Meldedatum": 2,
-        "Zeitraum": "09.01.2023 - 15.01.2023",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 48.8,
         "Fallzahl_aktiv": 915,
         "Krh_N_belegt": 710,
@@ -40030,11 +40030,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.76,
-        "H_Zeitraum": "09.01.2023 - 15.01.2023",
-        "H_Datum": "10.01.2026",
+        "H_Inzidenz": 4.6,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "17.01.2023",
+        "Fallzahl": 279101,
+        "ObjectId": 1047,
+        "Sterbefall": 1875,
+        "Genesungsfall": 276368,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7526,
+        "Zuwachs_Fallzahl": 75,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 132,
+        "BelegteBetten": null,
+        "Inzidenz": 58.3713495456015,
+        "Datum_neu": 1673913600000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "10.01.2023 - 16.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 46.8,
+        "Fallzahl_aktiv": 858,
+        "Krh_N_belegt": 710,
+        "Krh_I_belegt": 61,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -57,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.79,
+        "H_Zeitraum": "10.01.2023 - 16.01.2023",
+        "H_Datum": "10.01.2023",
+        "Datum_Bett": "16.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
