### PR TITLE
New data set: 2023-01-18T110103Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-17T110203Z.json
+pjson/2023-01-18T110103Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-17T110203Z.json pjson/2023-01-18T110103Z.json```:
```
--- pjson/2023-01-17T110203Z.json	2023-01-17 11:02:04.262327222 +0000
+++ pjson/2023-01-18T110103Z.json	2023-01-18 11:01:04.214021839 +0000
@@ -37822,7 +37822,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -38874,7 +38874,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671235200000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -38988,7 +38988,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671494400000,
-        "F\u00e4lle_Meldedatum": 235,
+        "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -39064,7 +39064,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671667200000,
-        "F\u00e4lle_Meldedatum": 160,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -39102,7 +39102,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671753600000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -39444,7 +39444,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672531200000,
-        "F\u00e4lle_Meldedatum": 22,
+        "F\u00e4lle_Meldedatum": 21,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -39482,7 +39482,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672617600000,
-        "F\u00e4lle_Meldedatum": 163,
+        "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
         "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
@@ -39520,7 +39520,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672704000000,
-        "F\u00e4lle_Meldedatum": 141,
+        "F\u00e4lle_Meldedatum": 140,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -39784,15 +39784,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 173,
         "BelegteBetten": null,
-        "Inzidenz": 97.5250547792665,
+        "Inzidenz": null,
         "Datum_neu": 1673308800000,
         "F\u00e4lle_Meldedatum": 84,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
-        "Inzidenz_RKI": 83.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 806,
-        "Krh_I_belegt": 82,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39802,7 +39802,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.63,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "09.01.2023"
@@ -39840,7 +39840,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.57,
+        "H_Inzidenz": 7.59,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2023"
@@ -39878,7 +39878,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.48,
+        "H_Inzidenz": 6.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.01.2023"
@@ -39916,7 +39916,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.81,
+        "H_Inzidenz": 6.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.01.2023"
@@ -39925,7 +39925,7 @@
     {
       "attributes": {
         "Datum": "14.01.2023",
-        "Fallzahl": 279012,
+        "Fallzahl": 279004,
         "ObjectId": 1044,
         "Sterbefall": null,
         "Genesungsfall": 276060,
@@ -39954,7 +39954,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.95,
+        "H_Inzidenz": 5.66,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2023"
@@ -39963,7 +39963,7 @@
     {
       "attributes": {
         "Datum": "15.01.2023",
-        "Fallzahl": 279025,
+        "Fallzahl": 279016,
         "ObjectId": 1045,
         "Sterbefall": null,
         "Genesungsfall": 276089,
@@ -39976,7 +39976,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.4246201372176,
         "Datum_neu": 1673740800000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51,
@@ -39992,7 +39992,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.67,
+        "H_Inzidenz": 5.54,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2023"
@@ -40003,26 +40003,26 @@
         "Datum": "16.01.2023",
         "Fallzahl": 279026,
         "ObjectId": 1046,
-        "Sterbefall": 1875,
+        "Sterbefall": null,
         "Genesungsfall": 276236,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7517,
-        "Zuwachs_Fallzahl": 72,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 147,
         "BelegteBetten": null,
         "Inzidenz": 61.2450159847696,
         "Datum_neu": 1673827200000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 48.8,
-        "Fallzahl_aktiv": 915,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 710,
         "Krh_I_belegt": 61,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -75,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40030,7 +40030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.6,
+        "H_Inzidenz": 5.57,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2023"
@@ -40043,7 +40043,7 @@
         "ObjectId": 1047,
         "Sterbefall": 1875,
         "Genesungsfall": 276368,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7526,
         "Zuwachs_Fallzahl": 75,
         "Zuwachs_Sterbefall": 0,
@@ -40052,8 +40052,8 @@
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
         "Datum_neu": 1673913600000,
-        "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "10.01.2023 - 16.01.2023",
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 46.8,
         "Fallzahl_aktiv": 858,
@@ -40068,11 +40068,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.79,
-        "H_Zeitraum": "10.01.2023 - 16.01.2023",
-        "H_Datum": "10.01.2023",
+        "H_Inzidenz": 4.28,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "18.01.2023",
+        "Fallzahl": 279157,
+        "ObjectId": 1048,
+        "Sterbefall": 1876,
+        "Genesungsfall": 276494,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7526,
+        "Zuwachs_Fallzahl": 56,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 126,
+        "BelegteBetten": null,
+        "Inzidenz": 55.6772872588814,
+        "Datum_neu": 1674000000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "11.01.2023 - 17.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 45.7,
+        "Fallzahl_aktiv": 787,
+        "Krh_N_belegt": 477,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -71,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.19,
+        "H_Zeitraum": "11.01.2023 - 17.01.2023",
+        "H_Datum": "17.01.2023",
+        "Datum_Bett": "17.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
