### PR TITLE
New data set: 2023-01-19T110703Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-18T110103Z.json
+pjson/2023-01-19T110703Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-18T110103Z.json pjson/2023-01-19T110703Z.json```:
```
--- pjson/2023-01-18T110103Z.json	2023-01-18 11:01:04.214021839 +0000
+++ pjson/2023-01-19T110703Z.json	2023-01-19 11:07:04.156902034 +0000
@@ -35036,7 +35036,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662508800000,
-        "F\u00e4lle_Meldedatum": 263,
+        "F\u00e4lle_Meldedatum": 264,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -35416,7 +35416,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663372800000,
-        "F\u00e4lle_Meldedatum": 97,
+        "F\u00e4lle_Meldedatum": 96,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -36594,7 +36594,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1666051200000,
-        "F\u00e4lle_Meldedatum": 722,
+        "F\u00e4lle_Meldedatum": 721,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -38838,7 +38838,7 @@
         "Datum_neu": 1671148800000,
         "F\u00e4lle_Meldedatum": 174,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -38990,7 +38990,7 @@
         "Datum_neu": 1671494400000,
         "F\u00e4lle_Meldedatum": 234,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39102,7 +39102,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671753600000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 20,
         "Inzidenz_RKI": null,
@@ -39256,7 +39256,7 @@
         "Datum_neu": 1672099200000,
         "F\u00e4lle_Meldedatum": 189,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 18,
+        "Hosp_Meldedatum": 17,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39406,7 +39406,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672444800000,
-        "F\u00e4lle_Meldedatum": 49,
+        "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -39484,7 +39484,7 @@
         "Datum_neu": 1672617600000,
         "F\u00e4lle_Meldedatum": 159,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 17,
+        "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39598,7 +39598,7 @@
         "Datum_neu": 1672876800000,
         "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 8,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39748,9 +39748,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1673222400000,
-        "F\u00e4lle_Meldedatum": 80,
+        "F\u00e4lle_Meldedatum": 81,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39824,7 +39824,7 @@
         "BelegteBetten": null,
         "Inzidenz": 87.6468263946263,
         "Datum_neu": 1673395200000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": 75.8,
@@ -39840,7 +39840,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.59,
+        "H_Inzidenz": 7.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2023"
@@ -39852,7 +39852,7 @@
         "Fallzahl": 278902,
         "ObjectId": 1042,
         "Sterbefall": null,
-        "Genesungsfall": 275895,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39862,9 +39862,9 @@
         "BelegteBetten": null,
         "Inzidenz": 75.7929523330579,
         "Datum_neu": 1673481600000,
-        "F\u00e4lle_Meldedatum": 51,
+        "F\u00e4lle_Meldedatum": 50,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 65.9,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 710,
@@ -39878,7 +39878,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.63,
+        "H_Inzidenz": 6.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.01.2023"
@@ -39890,7 +39890,7 @@
         "Fallzahl": 278954,
         "ObjectId": 1043,
         "Sterbefall": null,
-        "Genesungsfall": 276008,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39916,7 +39916,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.16,
+        "H_Inzidenz": 6.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.01.2023"
@@ -39928,7 +39928,7 @@
         "Fallzahl": 279004,
         "ObjectId": 1044,
         "Sterbefall": null,
-        "Genesungsfall": 276060,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39938,7 +39938,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.2982865763857,
         "Datum_neu": 1673654400000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 56.9,
@@ -39954,7 +39954,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.66,
+        "H_Inzidenz": 5.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2023"
@@ -39966,7 +39966,7 @@
         "Fallzahl": 279016,
         "ObjectId": 1045,
         "Sterbefall": null,
-        "Genesungsfall": 276089,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -39992,7 +39992,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.54,
+        "H_Inzidenz": 5.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2023"
@@ -40004,7 +40004,7 @@
         "Fallzahl": 279026,
         "ObjectId": 1046,
         "Sterbefall": null,
-        "Genesungsfall": 276236,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -40014,7 +40014,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.2450159847696,
         "Datum_neu": 1673827200000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 48.8,
@@ -40030,7 +40030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.57,
+        "H_Inzidenz": 5.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2023"
@@ -40041,26 +40041,26 @@
         "Datum": "17.01.2023",
         "Fallzahl": 279101,
         "ObjectId": 1047,
-        "Sterbefall": 1875,
-        "Genesungsfall": 276368,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7526,
-        "Zuwachs_Fallzahl": 75,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
         "Datum_neu": 1673913600000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 70,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 46.8,
-        "Fallzahl_aktiv": 858,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 710,
         "Krh_I_belegt": 61,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -57,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40068,7 +40068,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.28,
+        "H_Inzidenz": 4.67,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.01.2023"
@@ -40081,7 +40081,7 @@
         "ObjectId": 1048,
         "Sterbefall": 1876,
         "Genesungsfall": 276494,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7526,
         "Zuwachs_Fallzahl": 56,
         "Zuwachs_Sterbefall": 1,
@@ -40090,9 +40090,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1674000000000,
-        "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "11.01.2023 - 17.01.2023",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 52,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45.7,
         "Fallzahl_aktiv": 787,
         "Krh_N_belegt": 477,
@@ -40106,11 +40106,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.19,
-        "H_Zeitraum": "11.01.2023 - 17.01.2023",
-        "H_Datum": "17.01.2023",
+        "H_Inzidenz": 4.25,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "19.01.2023",
+        "Fallzahl": 279211,
+        "ObjectId": 1049,
+        "Sterbefall": 1876,
+        "Genesungsfall": 276569,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7532,
+        "Zuwachs_Fallzahl": 54,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 75,
+        "BelegteBetten": null,
+        "Inzidenz": 54.2404540392974,
+        "Datum_neu": 1674086400000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "12.01.2023 - 18.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 46.5,
+        "Fallzahl_aktiv": 766,
+        "Krh_N_belegt": 477,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -21,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.86,
+        "H_Zeitraum": "12.01.2023 - 18.01.2023",
+        "H_Datum": "17.01.2023",
+        "Datum_Bett": "18.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
