### PR TITLE
New data set: 2023-01-20T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-19T110703Z.json
+pjson/2023-01-20T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-19T110703Z.json pjson/2023-01-20T110504Z.json```:
```
--- pjson/2023-01-19T110703Z.json	2023-01-19 11:07:04.156902034 +0000
+++ pjson/2023-01-20T110504Z.json	2023-01-20 11:05:04.675271041 +0000
@@ -38418,7 +38418,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1670198400000,
-        "F\u00e4lle_Meldedatum": 293,
+        "F\u00e4lle_Meldedatum": 294,
         "Zeitraum": null,
         "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
@@ -39152,7 +39152,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39342,7 +39342,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39570,7 +39570,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39608,7 +39608,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39634,7 +39634,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672963200000,
-        "F\u00e4lle_Meldedatum": 90,
+        "F\u00e4lle_Meldedatum": 89,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -39684,7 +39684,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39786,7 +39786,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1673308800000,
-        "F\u00e4lle_Meldedatum": 84,
+        "F\u00e4lle_Meldedatum": 83,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -39822,15 +39822,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 173,
         "BelegteBetten": null,
-        "Inzidenz": 87.6468263946263,
+        "Inzidenz": null,
         "Datum_neu": 1673395200000,
         "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
-        "Inzidenz_RKI": 75.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 710,
-        "Krh_I_belegt": 61,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39840,7 +39840,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "10.01.2023"
@@ -39860,15 +39860,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 117,
         "BelegteBetten": null,
-        "Inzidenz": 75.7929523330579,
+        "Inzidenz": null,
         "Datum_neu": 1673481600000,
-        "F\u00e4lle_Meldedatum": 50,
+        "F\u00e4lle_Meldedatum": 49,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 65.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 710,
-        "Krh_I_belegt": 61,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39878,7 +39878,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "11.01.2023"
@@ -39916,7 +39916,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.28,
+        "H_Inzidenz": 6.33,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.01.2023"
@@ -39954,7 +39954,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.76,
+        "H_Inzidenz": 5.81,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2023"
@@ -39992,7 +39992,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.64,
+        "H_Inzidenz": 5.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2023"
@@ -40014,7 +40014,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.2450159847696,
         "Datum_neu": 1673827200000,
-        "F\u00e4lle_Meldedatum": 59,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 48.8,
@@ -40030,7 +40030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.64,
+        "H_Inzidenz": 5.69,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2023"
@@ -40041,13 +40041,13 @@
         "Datum": "17.01.2023",
         "Fallzahl": 279101,
         "ObjectId": 1047,
-        "Sterbefall": null,
-        "Genesungsfall": null,
+        "Sterbefall": 1875,
+        "Genesungsfall": 276368,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": null,
-        "Zuwachs_Fallzahl": null,
-        "Zuwachs_Sterbefall": null,
-        "Zuwachs_Krankenhauseinweisung": null,
+        "Hospitalisierung": 7526,
+        "Zuwachs_Fallzahl": 75,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
@@ -40056,11 +40056,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 46.8,
-        "Fallzahl_aktiv": null,
+        "Fallzahl_aktiv": 858,
         "Krh_N_belegt": 710,
         "Krh_I_belegt": 61,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": null,
+        "Fallzahl_aktiv_Zuwachs": -57,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40068,7 +40068,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.67,
+        "H_Inzidenz": 4.72,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.01.2023"
@@ -40090,7 +40090,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1674000000000,
-        "F\u00e4lle_Meldedatum": 52,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45.7,
@@ -40106,7 +40106,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.25,
+        "H_Inzidenz": 4.48,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.01.2023"
@@ -40119,7 +40119,7 @@
         "ObjectId": 1049,
         "Sterbefall": 1876,
         "Genesungsfall": 276569,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7532,
         "Zuwachs_Fallzahl": 54,
         "Zuwachs_Sterbefall": 0,
@@ -40128,9 +40128,9 @@
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
         "Datum_neu": 1674086400000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "12.01.2023 - 18.01.2023",
-        "Hosp_Meldedatum": 0,
+        "F\u00e4lle_Meldedatum": 56,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 46.5,
         "Fallzahl_aktiv": 766,
         "Krh_N_belegt": 477,
@@ -40144,11 +40144,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.86,
-        "H_Zeitraum": "12.01.2023 - 18.01.2023",
-        "H_Datum": "17.01.2023",
+        "H_Inzidenz": 4.33,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "18.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "20.01.2023",
+        "Fallzahl": 279261,
+        "ObjectId": 1050,
+        "Sterbefall": 1881,
+        "Genesungsfall": 276658,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7536,
+        "Zuwachs_Fallzahl": 50,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 89,
+        "BelegteBetten": null,
+        "Inzidenz": 55.8568914113294,
+        "Datum_neu": 1674172800000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "13.01.2023 - 19.01.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 47.5,
+        "Fallzahl_aktiv": 722,
+        "Krh_N_belegt": 477,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -44,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.59,
+        "H_Zeitraum": "13.01.2023 - 19.01.2023",
+        "H_Datum": "17.01.2023",
+        "Datum_Bett": "19.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
