### PR TITLE
New data set: 2023-01-23T121304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-20T110504Z.json
+pjson/2023-01-23T121304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-20T110504Z.json pjson/2023-01-23T121304Z.json```:
```
--- pjson/2023-01-20T110504Z.json	2023-01-20 11:05:04.675271041 +0000
+++ pjson/2023-01-23T121304Z.json	2023-01-23 12:13:04.813716849 +0000
@@ -39304,7 +39304,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39380,7 +39380,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 3,
+        "SterbeF_Sterbedatum": 4,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39482,7 +39482,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672617600000,
-        "F\u00e4lle_Meldedatum": 159,
+        "F\u00e4lle_Meldedatum": 158,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -39596,7 +39596,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672876800000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -39722,7 +39722,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39824,7 +39824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1673395200000,
-        "F\u00e4lle_Meldedatum": 55,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -39898,15 +39898,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 113,
         "BelegteBetten": null,
-        "Inzidenz": 72.3804734365459,
+        "Inzidenz": null,
         "Datum_neu": 1673568000000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 64.1,
+        "Hosp_Meldedatum": 10,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 710,
-        "Krh_I_belegt": 61,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39916,7 +39916,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.33,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "12.01.2023"
@@ -39936,15 +39936,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
-        "Inzidenz": 64.2982865763857,
+        "Inzidenz": null,
         "Datum_neu": 1673654400000,
         "F\u00e4lle_Meldedatum": 18,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 56.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 710,
-        "Krh_I_belegt": 61,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39954,7 +39954,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.81,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "13.01.2023"
@@ -39974,15 +39974,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 29,
         "BelegteBetten": null,
-        "Inzidenz": 61.4246201372176,
+        "Inzidenz": null,
         "Datum_neu": 1673740800000,
-        "F\u00e4lle_Meldedatum": 12,
+        "F\u00e4lle_Meldedatum": 11,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 51,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 710,
-        "Krh_I_belegt": 61,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -39992,7 +39992,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "14.01.2023"
@@ -40014,7 +40014,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.2450159847696,
         "Datum_neu": 1673827200000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 48.8,
@@ -40030,7 +40030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
+        "H_Inzidenz": 5.71,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2023"
@@ -40068,7 +40068,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.72,
+        "H_Inzidenz": 4.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.01.2023"
@@ -40106,7 +40106,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.48,
+        "H_Inzidenz": 4.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.01.2023"
@@ -40128,9 +40128,9 @@
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
         "Datum_neu": 1674086400000,
-        "F\u00e4lle_Meldedatum": 56,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 46.5,
         "Fallzahl_aktiv": 766,
         "Krh_N_belegt": 477,
@@ -40144,7 +40144,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.33,
+        "H_Inzidenz": 4.9,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.01.2023"
@@ -40157,7 +40157,7 @@
         "ObjectId": 1050,
         "Sterbefall": 1881,
         "Genesungsfall": 276658,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7536,
         "Zuwachs_Fallzahl": 50,
         "Zuwachs_Sterbefall": 5,
@@ -40166,9 +40166,9 @@
         "BelegteBetten": null,
         "Inzidenz": 55.8568914113294,
         "Datum_neu": 1674172800000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "13.01.2023 - 19.01.2023",
-        "Hosp_Meldedatum": 1,
+        "F\u00e4lle_Meldedatum": 47,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 47.5,
         "Fallzahl_aktiv": 722,
         "Krh_N_belegt": 477,
@@ -40182,11 +40182,125 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.59,
-        "H_Zeitraum": "13.01.2023 - 19.01.2023",
-        "H_Datum": "17.01.2023",
+        "H_Inzidenz": 4.5,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "21.01.2023",
+        "Fallzahl": 279317,
+        "ObjectId": 1051,
+        "Sterbefall": null,
+        "Genesungsfall": 276692,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 34,
+        "BelegteBetten": null,
+        "Inzidenz": 57.4733287833615,
+        "Datum_neu": 1674259200000,
+        "F\u00e4lle_Meldedatum": 19,
+        "Zeitraum": "14.01.2023 - 20.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 50.8,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 477,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.88,
+        "H_Zeitraum": "14.01.2023 - 20.01.2023",
+        "H_Datum": null,
+        "Datum_Bett": "20.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "22.01.2023",
+        "Fallzahl": 279323,
+        "ObjectId": 1052,
+        "Sterbefall": null,
+        "Genesungsfall": 276725,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 33,
+        "BelegteBetten": null,
+        "Inzidenz": 57.6529329358095,
+        "Datum_neu": 1674345600000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "15.01.2023 - 21.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 47.5,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": 477,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": null,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.61,
+        "H_Zeitraum": "15.01.2023 - 21.01.2023",
+        "H_Datum": null,
+        "Datum_Bett": "21.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.01.2023",
+        "Fallzahl": 279326,
+        "ObjectId": 1053,
+        "Sterbefall": 1884,
+        "Genesungsfall": 276798,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7542,
+        "Zuwachs_Fallzahl": 65,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 73,
+        "BelegteBetten": null,
+        "Inzidenz": 56.7549121735695,
+        "Datum_neu": 1674432000000,
+        "F\u00e4lle_Meldedatum": 3,
+        "Zeitraum": "16.01.2023 - 22.01.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 45.4,
+        "Fallzahl_aktiv": 644,
+        "Krh_N_belegt": 477,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.31,
+        "H_Zeitraum": "16.01.2023 - 22.01.2023",
+        "H_Datum": "17.01.2023",
+        "Datum_Bett": "22.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
