### PR TITLE
New data set: 2023-01-24T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-23T121304Z.json
+pjson/2023-01-24T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-23T121304Z.json pjson/2023-01-24T110504Z.json```:
```
--- pjson/2023-01-23T121304Z.json	2023-01-23 12:13:04.813716849 +0000
+++ pjson/2023-01-24T110504Z.json	2023-01-24 11:05:05.133381344 +0000
@@ -40012,15 +40012,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 147,
         "BelegteBetten": null,
-        "Inzidenz": 61.2450159847696,
+        "Inzidenz": null,
         "Datum_neu": 1673827200000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 48.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 710,
-        "Krh_I_belegt": 61,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40030,7 +40030,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.71,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "15.01.2023"
@@ -40041,26 +40041,26 @@
         "Datum": "17.01.2023",
         "Fallzahl": 279101,
         "ObjectId": 1047,
-        "Sterbefall": 1875,
-        "Genesungsfall": 276368,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7526,
-        "Zuwachs_Fallzahl": 75,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
         "Inzidenz": 58.3713495456015,
         "Datum_neu": 1673913600000,
-        "F\u00e4lle_Meldedatum": 70,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 46.8,
-        "Fallzahl_aktiv": 858,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 710,
         "Krh_I_belegt": 61,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -57,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40079,13 +40079,13 @@
         "Datum": "18.01.2023",
         "Fallzahl": 279157,
         "ObjectId": 1048,
-        "Sterbefall": 1876,
-        "Genesungsfall": 276494,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7526,
-        "Zuwachs_Fallzahl": 56,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
@@ -40094,11 +40094,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45.7,
-        "Fallzahl_aktiv": 787,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 477,
         "Krh_I_belegt": 42,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -71,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40117,13 +40117,13 @@
         "Datum": "19.01.2023",
         "Fallzahl": 279211,
         "ObjectId": 1049,
-        "Sterbefall": 1876,
-        "Genesungsfall": 276569,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7532,
-        "Zuwachs_Fallzahl": 54,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 75,
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
@@ -40132,11 +40132,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 46.5,
-        "Fallzahl_aktiv": 766,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 477,
         "Krh_I_belegt": 42,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -21,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40191,7 +40191,7 @@
     {
       "attributes": {
         "Datum": "21.01.2023",
-        "Fallzahl": 279317,
+        "Fallzahl": 279314,
         "ObjectId": 1051,
         "Sterbefall": null,
         "Genesungsfall": 276692,
@@ -40202,10 +40202,10 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 34,
         "BelegteBetten": null,
-        "Inzidenz": 57.4733287833615,
+        "Inzidenz": 57.5,
         "Datum_neu": 1674259200000,
-        "F\u00e4lle_Meldedatum": 19,
-        "Zeitraum": "14.01.2023 - 20.01.2023",
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 50.8,
         "Fallzahl_aktiv": null,
@@ -40221,7 +40221,7 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 3.88,
-        "H_Zeitraum": "14.01.2023 - 20.01.2023",
+        "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2023"
       }
@@ -40229,7 +40229,7 @@
     {
       "attributes": {
         "Datum": "22.01.2023",
-        "Fallzahl": 279323,
+        "Fallzahl": 279322,
         "ObjectId": 1052,
         "Sterbefall": null,
         "Genesungsfall": 276725,
@@ -40240,10 +40240,10 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
-        "Inzidenz": 57.6529329358095,
+        "Inzidenz": 57.7,
         "Datum_neu": 1674345600000,
-        "F\u00e4lle_Meldedatum": 6,
-        "Zeitraum": "15.01.2023 - 21.01.2023",
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.5,
         "Fallzahl_aktiv": null,
@@ -40259,7 +40259,7 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 3.61,
-        "H_Zeitraum": "15.01.2023 - 21.01.2023",
+        "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2023"
       }
@@ -40271,7 +40271,7 @@
         "ObjectId": 1053,
         "Sterbefall": 1884,
         "Genesungsfall": 276798,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7542,
         "Zuwachs_Fallzahl": 65,
         "Zuwachs_Sterbefall": 3,
@@ -40280,8 +40280,8 @@
         "BelegteBetten": null,
         "Inzidenz": 56.7549121735695,
         "Datum_neu": 1674432000000,
-        "F\u00e4lle_Meldedatum": 3,
-        "Zeitraum": "16.01.2023 - 22.01.2023",
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 45.4,
         "Fallzahl_aktiv": 644,
@@ -40297,9 +40297,47 @@
         "Mutation": null,
         "Zuwachs_Mutation": null,
         "H_Inzidenz": 3.31,
+        "H_Zeitraum": null,
+        "H_Datum": null,
+        "Datum_Bett": "22.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.01.2023",
+        "Fallzahl": 279416,
+        "ObjectId": 1054,
+        "Sterbefall": 1884,
+        "Genesungsfall": 276876,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7544,
+        "Zuwachs_Fallzahl": 90,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 78,
+        "BelegteBetten": null,
+        "Inzidenz": 58.5509536980495,
+        "Datum_neu": 1674518400000,
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": "17.01.2023 - 23.01.2023",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 45,
+        "Fallzahl_aktiv": 656,
+        "Krh_N_belegt": 477,
+        "Krh_I_belegt": 42,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.31,
         "H_Zeitraum": "16.01.2023 - 22.01.2023",
         "H_Datum": "17.01.2023",
-        "Datum_Bett": "22.01.2023"
+        "Datum_Bett": "23.01.2023"
       }
     }
   ]
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
