### PR TITLE
New data set: 2023-01-25T113304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-24T110504Z.json
+pjson/2023-01-25T113304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-24T110504Z.json pjson/2023-01-25T113304Z.json```:
```
--- pjson/2023-01-24T110504Z.json	2023-01-24 11:05:05.133381344 +0000
+++ pjson/2023-01-25T113304Z.json	2023-01-25 11:33:04.704255332 +0000
@@ -39292,7 +39292,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672185600000,
-        "F\u00e4lle_Meldedatum": 162,
+        "F\u00e4lle_Meldedatum": 161,
         "Zeitraum": null,
         "Hosp_Meldedatum": 21,
         "Inzidenz_RKI": null,
@@ -39520,9 +39520,9 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672704000000,
-        "F\u00e4lle_Meldedatum": 140,
+        "F\u00e4lle_Meldedatum": 139,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -39824,7 +39824,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1673395200000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": null,
         "Hosp_Meldedatum": 12,
         "Inzidenz_RKI": null,
@@ -40016,7 +40016,7 @@
         "Datum_neu": 1673827200000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -40050,15 +40050,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 132,
         "BelegteBetten": null,
-        "Inzidenz": 58.3713495456015,
+        "Inzidenz": null,
         "Datum_neu": 1673913600000,
-        "F\u00e4lle_Meldedatum": 69,
+        "F\u00e4lle_Meldedatum": 68,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 46.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 710,
-        "Krh_I_belegt": 61,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40068,7 +40068,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "16.01.2023"
@@ -40090,7 +40090,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1674000000000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45.7,
@@ -40106,7 +40106,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.9,
+        "H_Inzidenz": 4.95,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.01.2023"
@@ -40128,7 +40128,7 @@
         "BelegteBetten": null,
         "Inzidenz": 54.2404540392974,
         "Datum_neu": 1674086400000,
-        "F\u00e4lle_Meldedatum": 61,
+        "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 46.5,
@@ -40144,7 +40144,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.9,
+        "H_Inzidenz": 5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.01.2023"
@@ -40155,13 +40155,13 @@
         "Datum": "20.01.2023",
         "Fallzahl": 279261,
         "ObjectId": 1050,
-        "Sterbefall": 1881,
-        "Genesungsfall": 276658,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7536,
-        "Zuwachs_Fallzahl": 50,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 89,
         "BelegteBetten": null,
         "Inzidenz": 55.8568914113294,
@@ -40170,11 +40170,11 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 47.5,
-        "Fallzahl_aktiv": 722,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 477,
         "Krh_I_belegt": 42,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -44,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40182,7 +40182,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.5,
+        "H_Inzidenz": 4.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2023"
@@ -40194,7 +40194,7 @@
         "Fallzahl": 279314,
         "ObjectId": 1051,
         "Sterbefall": null,
-        "Genesungsfall": 276692,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -40204,7 +40204,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.5,
         "Datum_neu": 1674259200000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 50.8,
@@ -40220,7 +40220,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.88,
+        "H_Inzidenz": 4.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2023"
@@ -40229,10 +40229,10 @@
     {
       "attributes": {
         "Datum": "22.01.2023",
-        "Fallzahl": 279322,
+        "Fallzahl": 279323,
         "ObjectId": 1052,
         "Sterbefall": null,
-        "Genesungsfall": 276725,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
         "Hospitalisierung": null,
         "Zuwachs_Fallzahl": null,
@@ -40242,7 +40242,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.7,
         "Datum_neu": 1674345600000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.5,
@@ -40258,7 +40258,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.61,
+        "H_Inzidenz": 4.43,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2023"
@@ -40269,26 +40269,26 @@
         "Datum": "23.01.2023",
         "Fallzahl": 279326,
         "ObjectId": 1053,
-        "Sterbefall": 1884,
-        "Genesungsfall": 276798,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7542,
-        "Zuwachs_Fallzahl": 65,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 73,
         "BelegteBetten": null,
         "Inzidenz": 56.7549121735695,
         "Datum_neu": 1674432000000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 45.4,
-        "Fallzahl_aktiv": 644,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 477,
         "Krh_I_belegt": 42,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40296,7 +40296,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.31,
+        "H_Inzidenz": 4.2,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2023"
@@ -40309,7 +40309,7 @@
         "ObjectId": 1054,
         "Sterbefall": 1884,
         "Genesungsfall": 276876,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7544,
         "Zuwachs_Fallzahl": 90,
         "Zuwachs_Sterbefall": 0,
@@ -40318,9 +40318,9 @@
         "BelegteBetten": null,
         "Inzidenz": 58.5509536980495,
         "Datum_neu": 1674518400000,
-        "F\u00e4lle_Meldedatum": 23,
-        "Zeitraum": "17.01.2023 - 23.01.2023",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": 45,
         "Fallzahl_aktiv": 656,
         "Krh_N_belegt": 477,
@@ -40334,11 +40334,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.31,
-        "H_Zeitraum": "16.01.2023 - 22.01.2023",
-        "H_Datum": "17.01.2023",
+        "H_Inzidenz": 3.39,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "23.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "25.01.2023",
+        "Fallzahl": 279473,
+        "ObjectId": 1055,
+        "Sterbefall": 1884,
+        "Genesungsfall": 276919,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7554,
+        "Zuwachs_Fallzahl": 57,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 10,
+        "Zuwachs_Genesung": 43,
+        "BelegteBetten": null,
+        "Inzidenz": 57.8325370882575,
+        "Datum_neu": 1674604800000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "18.01.2023 - 24.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 47.7,
+        "Fallzahl_aktiv": 670,
+        "Krh_N_belegt": 402,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 14,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.33,
+        "H_Zeitraum": "18.01.2023 - 24.01.2023",
+        "H_Datum": "24.01.2023",
+        "Datum_Bett": "24.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
