### PR TITLE
New data set: 2023-01-26T112804Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-24T110504Z.json
+pjson/2023-01-26T112804Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-25T113304Z.json pjson/2023-01-26T112804Z.json```:
```
--- pjson/2023-01-25T113304Z.json	2023-01-25 11:33:04.704255332 +0000
+++ pjson/2023-01-26T112804Z.json	2023-01-26 11:28:04.671568576 +0000
@@ -37620,7 +37620,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1668384000000,
-        "F\u00e4lle_Meldedatum": 260,
+        "F\u00e4lle_Meldedatum": 259,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -39178,7 +39178,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671926400000,
-        "F\u00e4lle_Meldedatum": 24,
+        "F\u00e4lle_Meldedatum": 25,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": null,
@@ -39482,7 +39482,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672617600000,
-        "F\u00e4lle_Meldedatum": 158,
+        "F\u00e4lle_Meldedatum": 157,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -40090,13 +40090,13 @@
         "BelegteBetten": null,
         "Inzidenz": 55.6772872588814,
         "Datum_neu": 1674000000000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 45.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 477,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40106,7 +40106,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.95,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "17.01.2023"
@@ -40144,7 +40144,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5,
+        "H_Inzidenz": 5.02,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.01.2023"
@@ -40182,7 +40182,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.82,
+        "H_Inzidenz": 4.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2023"
@@ -40220,7 +40220,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.4,
+        "H_Inzidenz": 4.63,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2023"
@@ -40258,7 +40258,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.43,
+        "H_Inzidenz": 3.61,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2023"
@@ -40280,7 +40280,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.7549121735695,
         "Datum_neu": 1674432000000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 74,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 45.4,
@@ -40296,7 +40296,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.2,
+        "H_Inzidenz": 4.5,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2023"
@@ -40307,34 +40307,34 @@
         "Datum": "24.01.2023",
         "Fallzahl": 279416,
         "ObjectId": 1054,
-        "Sterbefall": 1884,
-        "Genesungsfall": 276876,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7544,
-        "Zuwachs_Fallzahl": 90,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 78,
         "BelegteBetten": null,
         "Inzidenz": 58.5509536980495,
         "Datum_neu": 1674518400000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45,
-        "Fallzahl_aktiv": 656,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 477,
         "Krh_I_belegt": 42,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 12,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.39,
+        "H_Inzidenz": 3.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2023"
@@ -40347,7 +40347,7 @@
         "ObjectId": 1055,
         "Sterbefall": 1884,
         "Genesungsfall": 276919,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7554,
         "Zuwachs_Fallzahl": 57,
         "Zuwachs_Sterbefall": 0,
@@ -40356,8 +40356,8 @@
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1674604800000,
-        "F\u00e4lle_Meldedatum": 17,
-        "Zeitraum": "18.01.2023 - 24.01.2023",
+        "F\u00e4lle_Meldedatum": 71,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.7,
         "Fallzahl_aktiv": 670,
@@ -40372,11 +40372,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.33,
-        "H_Zeitraum": "18.01.2023 - 24.01.2023",
-        "H_Datum": "24.01.2023",
+        "H_Inzidenz": 3.14,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "26.01.2023",
+        "Fallzahl": 279555,
+        "ObjectId": 1056,
+        "Sterbefall": 1884,
+        "Genesungsfall": 276979,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7557,
+        "Zuwachs_Fallzahl": 82,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 60,
+        "BelegteBetten": null,
+        "Inzidenz": 61.4246201372176,
+        "Datum_neu": 1674691200000,
+        "F\u00e4lle_Meldedatum": 27,
+        "Zeitraum": "19.01.2023 - 25.01.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 50.2,
+        "Fallzahl_aktiv": 692,
+        "Krh_N_belegt": 402,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 22,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.7,
+        "H_Zeitraum": "19.01.2023 - 25.01.2023",
+        "H_Datum": "24.01.2023",
+        "Datum_Bett": "25.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
