### PR TITLE
New data set: 2023-01-27T110903Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-26T112804Z.json
+pjson/2023-01-27T110903Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-26T112804Z.json pjson/2023-01-27T110903Z.json```:
```
--- pjson/2023-01-26T112804Z.json	2023-01-26 11:28:04.671568576 +0000
+++ pjson/2023-01-27T110903Z.json	2023-01-27 11:09:04.364235892 +0000
@@ -39722,7 +39722,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39798,7 +39798,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40088,7 +40088,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 126,
         "BelegteBetten": null,
-        "Inzidenz": 55.6772872588814,
+        "Inzidenz": null,
         "Datum_neu": 1674000000000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
@@ -40126,15 +40126,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 75,
         "BelegteBetten": null,
-        "Inzidenz": 54.2404540392974,
+        "Inzidenz": null,
         "Datum_neu": 1674086400000,
         "F\u00e4lle_Meldedatum": 60,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 46.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 477,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40144,7 +40144,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.02,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "18.01.2023"
@@ -40166,7 +40166,7 @@
         "BelegteBetten": null,
         "Inzidenz": 55.8568914113294,
         "Datum_neu": 1674172800000,
-        "F\u00e4lle_Meldedatum": 47,
+        "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 47.5,
@@ -40182,7 +40182,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.85,
+        "H_Inzidenz": 4.87,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2023"
@@ -40220,7 +40220,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.63,
+        "H_Inzidenz": 4.7,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2023"
@@ -40242,7 +40242,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.7,
         "Datum_neu": 1674345600000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.5,
@@ -40258,7 +40258,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.61,
+        "H_Inzidenz": 4.77,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2023"
@@ -40296,7 +40296,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.5,
+        "H_Inzidenz": 4.58,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2023"
@@ -40318,7 +40318,7 @@
         "BelegteBetten": null,
         "Inzidenz": 58.5509536980495,
         "Datum_neu": 1674518400000,
-        "F\u00e4lle_Meldedatum": 62,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45,
@@ -40334,7 +40334,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.86,
+        "H_Inzidenz": 3.96,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2023"
@@ -40345,34 +40345,34 @@
         "Datum": "25.01.2023",
         "Fallzahl": 279473,
         "ObjectId": 1055,
-        "Sterbefall": 1884,
-        "Genesungsfall": 276919,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7554,
-        "Zuwachs_Fallzahl": 57,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 10,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1674604800000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.7,
-        "Fallzahl_aktiv": 670,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 14,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.14,
+        "H_Inzidenz": 3.46,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2023"
@@ -40385,7 +40385,7 @@
         "ObjectId": 1056,
         "Sterbefall": 1884,
         "Genesungsfall": 276979,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7557,
         "Zuwachs_Fallzahl": 82,
         "Zuwachs_Sterbefall": 0,
@@ -40394,8 +40394,8 @@
         "BelegteBetten": null,
         "Inzidenz": 61.4246201372176,
         "Datum_neu": 1674691200000,
-        "F\u00e4lle_Meldedatum": 27,
-        "Zeitraum": "19.01.2023 - 25.01.2023",
+        "F\u00e4lle_Meldedatum": 53,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 50.2,
         "Fallzahl_aktiv": 692,
@@ -40410,11 +40410,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.7,
-        "H_Zeitraum": "19.01.2023 - 25.01.2023",
-        "H_Datum": "24.01.2023",
+        "H_Inzidenz": 3.41,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "27.01.2023",
+        "Fallzahl": 279597,
+        "ObjectId": 1057,
+        "Sterbefall": 1886,
+        "Genesungsfall": 277029,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7557,
+        "Zuwachs_Fallzahl": 42,
+        "Zuwachs_Sterbefall": 2,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 50,
+        "BelegteBetten": null,
+        "Inzidenz": 60.1673910700815,
+        "Datum_neu": 1674777600000,
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": "20.01.2023 - 26.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 52.6,
+        "Fallzahl_aktiv": 682,
+        "Krh_N_belegt": 402,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -10,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.75,
+        "H_Zeitraum": "20.01.2023 - 26.01.2023",
+        "H_Datum": "24.01.2023",
+        "Datum_Bett": "26.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
