### PR TITLE
New data set: 2023-01-30T105004Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-27T110903Z.json
+pjson/2023-01-30T105004Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-27T110903Z.json pjson/2023-01-30T105004Z.json```:
```
--- pjson/2023-01-27T110903Z.json	2023-01-27 11:09:04.364235892 +0000
+++ pjson/2023-01-30T105004Z.json	2023-01-30 10:50:04.614666860 +0000
@@ -39482,7 +39482,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672617600000,
-        "F\u00e4lle_Meldedatum": 157,
+        "F\u00e4lle_Meldedatum": 156,
         "Zeitraum": null,
         "Hosp_Meldedatum": 16,
         "Inzidenz_RKI": null,
@@ -40169,10 +40169,10 @@
         "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 47.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 477,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40182,7 +40182,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.87,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "19.01.2023"
@@ -40207,10 +40207,10 @@
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 50.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 477,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40220,7 +40220,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.7,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "20.01.2023"
@@ -40242,7 +40242,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.7,
         "Datum_neu": 1674345600000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.5,
@@ -40258,7 +40258,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.77,
+        "H_Inzidenz": 4.82,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2023"
@@ -40280,7 +40280,7 @@
         "BelegteBetten": null,
         "Inzidenz": 56.7549121735695,
         "Datum_neu": 1674432000000,
-        "F\u00e4lle_Meldedatum": 74,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 45.4,
@@ -40296,7 +40296,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 4.6,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2023"
@@ -40318,7 +40318,7 @@
         "BelegteBetten": null,
         "Inzidenz": 58.5509536980495,
         "Datum_neu": 1674518400000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45,
@@ -40334,7 +40334,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.96,
+        "H_Inzidenz": 4.01,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2023"
@@ -40356,7 +40356,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1674604800000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.7,
@@ -40372,7 +40372,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.46,
+        "H_Inzidenz": 3.64,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2023"
@@ -40394,9 +40394,9 @@
         "BelegteBetten": null,
         "Inzidenz": 61.4246201372176,
         "Datum_neu": 1674691200000,
-        "F\u00e4lle_Meldedatum": 53,
+        "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 50.2,
         "Fallzahl_aktiv": 692,
         "Krh_N_belegt": 402,
@@ -40410,7 +40410,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.41,
+        "H_Inzidenz": 3.76,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2023"
@@ -40419,40 +40419,154 @@
     {
       "attributes": {
         "Datum": "27.01.2023",
-        "Fallzahl": 279597,
+        "Fallzahl": 279636,
         "ObjectId": 1057,
         "Sterbefall": 1886,
         "Genesungsfall": 277029,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 7557,
-        "Zuwachs_Fallzahl": 42,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7560,
+        "Zuwachs_Fallzahl": 81,
         "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
         "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
-        "Inzidenz": 60.1673910700815,
+        "Inzidenz": 60.7062035274256,
         "Datum_neu": 1674777600000,
-        "F\u00e4lle_Meldedatum": 16,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": "20.01.2023 - 26.01.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 52.6,
-        "Fallzahl_aktiv": 682,
+        "Fallzahl_aktiv": 721,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -10,
+        "Fallzahl_aktiv_Zuwachs": 29,
         "Krh_I": null,
-        "Vorz_akt_Faelle": null,
+        "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.75,
+        "H_Inzidenz": 3.19,
         "H_Zeitraum": "20.01.2023 - 26.01.2023",
         "H_Datum": "24.01.2023",
         "Datum_Bett": "26.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "28.01.2023",
+        "Fallzahl": 279667,
+        "ObjectId": 1058,
+        "Sterbefall": 1886,
+        "Genesungsfall": 277030,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7561,
+        "Zuwachs_Fallzahl": 31,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 61.9634325945616,
+        "Datum_neu": 1674864000000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "21.01.2023 - 27.01.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 54.6,
+        "Fallzahl_aktiv": 751,
+        "Krh_N_belegt": 402,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 30,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.12,
+        "H_Zeitraum": "21.01.2023 - 27.01.2023",
+        "H_Datum": "24.01.2023",
+        "Datum_Bett": "27.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "29.01.2023",
+        "Fallzahl": 279675,
+        "ObjectId": 1059,
+        "Sterbefall": 1886,
+        "Genesungsfall": 277031,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7561,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 1,
+        "BelegteBetten": null,
+        "Inzidenz": 64.1186824239376,
+        "Datum_neu": 1674950400000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "22.01.2023 - 28.01.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 51.1,
+        "Fallzahl_aktiv": 758,
+        "Krh_N_belegt": 402,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 7,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.77,
+        "H_Zeitraum": "22.01.2023 - 28.01.2023",
+        "H_Datum": "24.01.2023",
+        "Datum_Bett": "28.01.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "30.01.2023",
+        "Fallzahl": 279681,
+        "ObjectId": 1060,
+        "Sterbefall": 1886,
+        "Genesungsfall": 277127,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7564,
+        "Zuwachs_Fallzahl": 45,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 98,
+        "BelegteBetten": null,
+        "Inzidenz": 63.9390782714896,
+        "Datum_neu": 1675036800000,
+        "F\u00e4lle_Meldedatum": 6,
+        "Zeitraum": "23.01.2023 - 29.01.2023",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 49.7,
+        "Fallzahl_aktiv": 668,
+        "Krh_N_belegt": 402,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -53,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.7,
+        "H_Zeitraum": "23.01.2023 - 29.01.2023",
+        "H_Datum": "24.01.2023",
+        "Datum_Bett": "29.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
