### PR TITLE
New data set: 2023-01-31T104204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-30T105004Z.json
+pjson/2023-01-31T104204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-30T105004Z.json pjson/2023-01-31T104204Z.json```:
```
--- pjson/2023-01-30T105004Z.json	2023-01-30 10:50:04.614666860 +0000
+++ pjson/2023-01-31T104204Z.json	2023-01-31 10:42:04.587429946 +0000
@@ -38798,7 +38798,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1671062400000,
-        "F\u00e4lle_Meldedatum": 216,
+        "F\u00e4lle_Meldedatum": 217,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -40014,7 +40014,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1673827200000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 59,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
@@ -40164,7 +40164,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 89,
         "BelegteBetten": null,
-        "Inzidenz": 55.8568914113294,
+        "Inzidenz": null,
         "Datum_neu": 1674172800000,
         "F\u00e4lle_Meldedatum": 46,
         "Zeitraum": null,
@@ -40202,7 +40202,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 34,
         "BelegteBetten": null,
-        "Inzidenz": 57.5,
+        "Inzidenz": null,
         "Datum_neu": 1674259200000,
         "F\u00e4lle_Meldedatum": 19,
         "Zeitraum": null,
@@ -40240,15 +40240,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 33,
         "BelegteBetten": null,
-        "Inzidenz": 57.7,
+        "Inzidenz": null,
         "Datum_neu": 1674345600000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 47.5,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 477,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40258,7 +40258,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.82,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "21.01.2023"
@@ -40283,10 +40283,10 @@
         "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 45.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 477,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40296,7 +40296,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.6,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "22.01.2023"
@@ -40318,7 +40318,7 @@
         "BelegteBetten": null,
         "Inzidenz": 58.5509536980495,
         "Datum_neu": 1674518400000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 45,
@@ -40334,7 +40334,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.01,
+        "H_Inzidenz": 4.16,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2023"
@@ -40356,7 +40356,7 @@
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1674604800000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 71,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 47.7,
@@ -40372,7 +40372,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.64,
+        "H_Inzidenz": 3.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2023"
@@ -40383,13 +40383,13 @@
         "Datum": "26.01.2023",
         "Fallzahl": 279555,
         "ObjectId": 1056,
-        "Sterbefall": 1884,
-        "Genesungsfall": 276979,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7557,
-        "Zuwachs_Fallzahl": 82,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
         "Inzidenz": 61.4246201372176,
@@ -40398,19 +40398,19 @@
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 50.2,
-        "Fallzahl_aktiv": 692,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 22,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.76,
+        "H_Inzidenz": 4.08,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2023"
@@ -40421,36 +40421,36 @@
         "Datum": "27.01.2023",
         "Fallzahl": 279636,
         "ObjectId": 1057,
-        "Sterbefall": 1886,
-        "Genesungsfall": 277029,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7560,
-        "Zuwachs_Fallzahl": 81,
-        "Zuwachs_Sterbefall": 2,
-        "Zuwachs_Krankenhauseinweisung": 3,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
         "Inzidenz": 60.7062035274256,
         "Datum_neu": 1674777600000,
         "F\u00e4lle_Meldedatum": 53,
-        "Zeitraum": "20.01.2023 - 26.01.2023",
-        "Hosp_Meldedatum": 2,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": 52.6,
-        "Fallzahl_aktiv": 721,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 29,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.19,
-        "H_Zeitraum": "20.01.2023 - 26.01.2023",
-        "H_Datum": "24.01.2023",
+        "H_Inzidenz": 3.66,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.01.2023"
       }
     },
@@ -40459,36 +40459,36 @@
         "Datum": "28.01.2023",
         "Fallzahl": 279667,
         "ObjectId": 1058,
-        "Sterbefall": 1886,
-        "Genesungsfall": 277030,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7561,
-        "Zuwachs_Fallzahl": 31,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
-        "Zuwachs_Genesung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
         "Inzidenz": 61.9634325945616,
         "Datum_neu": 1674864000000,
-        "F\u00e4lle_Meldedatum": 31,
-        "Zeitraum": "21.01.2023 - 27.01.2023",
+        "F\u00e4lle_Meldedatum": 34,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 54.6,
-        "Fallzahl_aktiv": 751,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 30,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.12,
-        "H_Zeitraum": "21.01.2023 - 27.01.2023",
-        "H_Datum": "24.01.2023",
+        "H_Inzidenz": 3.81,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.01.2023"
       }
     },
@@ -40497,34 +40497,34 @@
         "Datum": "29.01.2023",
         "Fallzahl": 279675,
         "ObjectId": 1059,
-        "Sterbefall": 1886,
-        "Genesungsfall": 277031,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7561,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
         "Inzidenz": 64.1186824239376,
         "Datum_neu": 1674950400000,
         "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "22.01.2023 - 28.01.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.1,
-        "Fallzahl_aktiv": 758,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 7,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.77,
+        "H_Inzidenz": 3.51,
         "H_Zeitraum": "22.01.2023 - 28.01.2023",
         "H_Datum": "24.01.2023",
         "Datum_Bett": "28.01.2023"
@@ -40537,24 +40537,24 @@
         "ObjectId": 1060,
         "Sterbefall": 1886,
         "Genesungsfall": 277127,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7564,
         "Zuwachs_Fallzahl": 45,
         "Zuwachs_Sterbefall": 0,
         "Zuwachs_Krankenhauseinweisung": 4,
-        "Zuwachs_Genesung": 98,
+        "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
         "Inzidenz": 63.9390782714896,
         "Datum_neu": 1675036800000,
-        "F\u00e4lle_Meldedatum": 6,
+        "F\u00e4lle_Meldedatum": 65,
         "Zeitraum": "23.01.2023 - 29.01.2023",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 49.7,
         "Fallzahl_aktiv": 668,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -53,
+        "Fallzahl_aktiv_Zuwachs": -10,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40562,11 +40562,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.7,
+        "H_Inzidenz": 3.44,
         "H_Zeitraum": "23.01.2023 - 29.01.2023",
         "H_Datum": "24.01.2023",
         "Datum_Bett": "29.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "31.01.2023",
+        "Fallzahl": 279760,
+        "ObjectId": 1061,
+        "Sterbefall": 1886,
+        "Genesungsfall": 277195,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7575,
+        "Zuwachs_Fallzahl": 79,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 68,
+        "BelegteBetten": null,
+        "Inzidenz": 62.5022450519056,
+        "Datum_neu": 1675123200000,
+        "F\u00e4lle_Meldedatum": 20,
+        "Zeitraum": "24.01.2023 - 30.01.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 51.9,
+        "Fallzahl_aktiv": 679,
+        "Krh_N_belegt": 402,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.87,
+        "H_Zeitraum": "24.01.2023 - 30.01.2023",
+        "H_Datum": "24.01.2023",
+        "Datum_Bett": "30.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
