### PR TITLE
New data set: 2023-02-01T103204Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-01-31T104204Z.json
+pjson/2023-02-01T103204Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-01-31T104204Z.json pjson/2023-02-01T103204Z.json```:
```
--- pjson/2023-01-31T104204Z.json	2023-01-31 10:42:04.587429946 +0000
+++ pjson/2023-02-01T103204Z.json	2023-02-01 10:32:04.968986325 +0000
@@ -39330,7 +39330,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1672272000000,
-        "F\u00e4lle_Meldedatum": 110,
+        "F\u00e4lle_Meldedatum": 111,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -40204,7 +40204,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1674259200000,
-        "F\u00e4lle_Meldedatum": 19,
+        "F\u00e4lle_Meldedatum": 20,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -40321,10 +40321,10 @@
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 45,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 477,
-        "Krh_I_belegt": 42,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40334,7 +40334,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.16,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "23.01.2023"
@@ -40372,7 +40372,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.88,
+        "H_Inzidenz": 3.86,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2023"
@@ -40396,7 +40396,7 @@
         "Datum_neu": 1674691200000,
         "F\u00e4lle_Meldedatum": 54,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 50.2,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
@@ -40410,7 +40410,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.08,
+        "H_Inzidenz": 4.06,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2023"
@@ -40448,7 +40448,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.66,
+        "H_Inzidenz": 3.88,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.01.2023"
@@ -40486,7 +40486,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.81,
+        "H_Inzidenz": 4.11,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2023"
@@ -40508,7 +40508,7 @@
         "BelegteBetten": null,
         "Inzidenz": 64.1186824239376,
         "Datum_neu": 1674950400000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 51.1,
@@ -40524,9 +40524,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.51,
-        "H_Zeitraum": "22.01.2023 - 28.01.2023",
-        "H_Datum": "24.01.2023",
+        "H_Inzidenz": 3.91,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.01.2023"
       }
     },
@@ -40535,26 +40535,26 @@
         "Datum": "30.01.2023",
         "Fallzahl": 279681,
         "ObjectId": 1060,
-        "Sterbefall": 1886,
-        "Genesungsfall": 277127,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7564,
-        "Zuwachs_Fallzahl": 45,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
         "Inzidenz": 63.9390782714896,
         "Datum_neu": 1675036800000,
-        "F\u00e4lle_Meldedatum": 65,
-        "Zeitraum": "23.01.2023 - 29.01.2023",
+        "F\u00e4lle_Meldedatum": 66,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 49.7,
-        "Fallzahl_aktiv": 668,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -10,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40562,9 +40562,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.44,
-        "H_Zeitraum": "23.01.2023 - 29.01.2023",
-        "H_Datum": "24.01.2023",
+        "H_Inzidenz": 3.86,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "29.01.2023"
       }
     },
@@ -40575,7 +40575,7 @@
         "ObjectId": 1061,
         "Sterbefall": 1886,
         "Genesungsfall": 277195,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7575,
         "Zuwachs_Fallzahl": 79,
         "Zuwachs_Sterbefall": 0,
@@ -40584,9 +40584,9 @@
         "BelegteBetten": null,
         "Inzidenz": 62.5022450519056,
         "Datum_neu": 1675123200000,
-        "F\u00e4lle_Meldedatum": 20,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": "24.01.2023 - 30.01.2023",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 51.9,
         "Fallzahl_aktiv": 679,
         "Krh_N_belegt": 402,
@@ -40600,11 +40600,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.87,
+        "H_Inzidenz": 3.96,
         "H_Zeitraum": "24.01.2023 - 30.01.2023",
         "H_Datum": "24.01.2023",
         "Datum_Bett": "30.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.02.2023",
+        "Fallzahl": 279833,
+        "ObjectId": 1062,
+        "Sterbefall": 1886,
+        "Genesungsfall": 277254,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7580,
+        "Zuwachs_Fallzahl": 73,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 59,
+        "BelegteBetten": null,
+        "Inzidenz": 66.2739322533137,
+        "Datum_neu": 1675209600000,
+        "F\u00e4lle_Meldedatum": 7,
+        "Zeitraum": "25.01.2023 - 31.01.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 53.8,
+        "Fallzahl_aktiv": 693,
+        "Krh_N_belegt": 322,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 14,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.22,
+        "H_Zeitraum": "25.01.2023 - 31.01.2023",
+        "H_Datum": "31.01.2023",
+        "Datum_Bett": "31.01.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
