### PR TITLE
New data set: 2023-02-02T105304Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-02-01T103204Z.json
+pjson/2023-02-02T105304Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-02-01T103204Z.json pjson/2023-02-02T105304Z.json```:
```
--- pjson/2023-02-01T103204Z.json	2023-02-01 10:32:04.968986325 +0000
+++ pjson/2023-02-02T105304Z.json	2023-02-02 10:53:04.487076900 +0000
@@ -39710,7 +39710,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1673136000000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
@@ -40166,7 +40166,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1674172800000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
@@ -40278,9 +40278,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 73,
         "BelegteBetten": null,
-        "Inzidenz": 56.7549121735695,
+        "Inzidenz": null,
         "Datum_neu": 1674432000000,
-        "F\u00e4lle_Meldedatum": 73,
+        "F\u00e4lle_Meldedatum": 72,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -40316,9 +40316,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 78,
         "BelegteBetten": null,
-        "Inzidenz": 58.5509536980495,
+        "Inzidenz": null,
         "Datum_neu": 1674518400000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -40356,13 +40356,13 @@
         "BelegteBetten": null,
         "Inzidenz": 57.8325370882575,
         "Datum_neu": 1674604800000,
-        "F\u00e4lle_Meldedatum": 71,
+        "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 47.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 402,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40372,7 +40372,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.86,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "24.01.2023"
@@ -40394,7 +40394,7 @@
         "BelegteBetten": null,
         "Inzidenz": 61.4246201372176,
         "Datum_neu": 1674691200000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 50.2,
@@ -40410,7 +40410,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.06,
+        "H_Inzidenz": 4.13,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2023"
@@ -40448,7 +40448,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.88,
+        "H_Inzidenz": 4.03,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.01.2023"
@@ -40486,7 +40486,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.11,
+        "H_Inzidenz": 4.4,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2023"
@@ -40524,7 +40524,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.91,
+        "H_Inzidenz": 4.28,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.01.2023"
@@ -40562,7 +40562,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.86,
+        "H_Inzidenz": 4.25,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.01.2023"
@@ -40573,36 +40573,36 @@
         "Datum": "31.01.2023",
         "Fallzahl": 279760,
         "ObjectId": 1061,
-        "Sterbefall": 1886,
-        "Genesungsfall": 277195,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7575,
-        "Zuwachs_Fallzahl": 79,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
         "Inzidenz": 62.5022450519056,
         "Datum_neu": 1675123200000,
-        "F\u00e4lle_Meldedatum": 82,
-        "Zeitraum": "24.01.2023 - 30.01.2023",
-        "Hosp_Meldedatum": 2,
+        "F\u00e4lle_Meldedatum": 86,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 51.9,
-        "Fallzahl_aktiv": 679,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 402,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.96,
-        "H_Zeitraum": "24.01.2023 - 30.01.2023",
-        "H_Datum": "24.01.2023",
+        "H_Inzidenz": 4.58,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "30.01.2023"
       }
     },
@@ -40613,7 +40613,7 @@
         "ObjectId": 1062,
         "Sterbefall": 1886,
         "Genesungsfall": 277254,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7580,
         "Zuwachs_Fallzahl": 73,
         "Zuwachs_Sterbefall": 0,
@@ -40622,7 +40622,7 @@
         "BelegteBetten": null,
         "Inzidenz": 66.2739322533137,
         "Datum_neu": 1675209600000,
-        "F\u00e4lle_Meldedatum": 7,
+        "F\u00e4lle_Meldedatum": 37,
         "Zeitraum": "25.01.2023 - 31.01.2023",
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 53.8,
@@ -40638,11 +40638,49 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.22,
+        "H_Inzidenz": 4.28,
         "H_Zeitraum": "25.01.2023 - 31.01.2023",
         "H_Datum": "31.01.2023",
         "Datum_Bett": "31.01.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "02.02.2023",
+        "Fallzahl": 279879,
+        "ObjectId": 1063,
+        "Sterbefall": 1886,
+        "Genesungsfall": 277316,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7581,
+        "Zuwachs_Fallzahl": 46,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 62,
+        "BelegteBetten": null,
+        "Inzidenz": 60.7062035274256,
+        "Datum_neu": 1675296000000,
+        "F\u00e4lle_Meldedatum": 17,
+        "Zeitraum": "26.01.2023 - 01.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 54.6,
+        "Fallzahl_aktiv": 677,
+        "Krh_N_belegt": 322,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -16,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.49,
+        "H_Zeitraum": "26.01.2023 - 01.02.2023",
+        "H_Datum": "31.01.2023",
+        "Datum_Bett": "01.02.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
