### PR TITLE
New data set: 2023-02-07T110704Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-02-02T105304Z.json
+pjson/2023-02-07T110704Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-02-02T105304Z.json pjson/2023-02-07T110704Z.json```:
```
--- pjson/2023-02-02T105304Z.json	2023-02-02 10:53:04.487076900 +0000
+++ pjson/2023-02-07T110704Z.json	2023-02-07 11:07:04.683983012 +0000
@@ -34998,7 +34998,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662422400000,
-        "F\u00e4lle_Meldedatum": 299,
+        "F\u00e4lle_Meldedatum": 300,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -39532,7 +39532,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40280,7 +40280,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1674432000000,
-        "F\u00e4lle_Meldedatum": 72,
+        "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
         "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": null,
@@ -40318,7 +40318,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1674518400000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": null,
@@ -40354,7 +40354,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 57.8325370882575,
+        "Inzidenz": null,
         "Datum_neu": 1674604800000,
         "F\u00e4lle_Meldedatum": 69,
         "Zeitraum": null,
@@ -40392,15 +40392,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 60,
         "BelegteBetten": null,
-        "Inzidenz": 61.4246201372176,
+        "Inzidenz": null,
         "Datum_neu": 1674691200000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 50.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 402,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40410,7 +40410,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.13,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "25.01.2023"
@@ -40430,15 +40430,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 50,
         "BelegteBetten": null,
-        "Inzidenz": 60.7062035274256,
+        "Inzidenz": null,
         "Datum_neu": 1674777600000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 52.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 402,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40448,7 +40448,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.03,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "26.01.2023"
@@ -40473,10 +40473,10 @@
         "F\u00e4lle_Meldedatum": 34,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 54.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 402,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40486,7 +40486,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.4,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "27.01.2023"
@@ -40511,10 +40511,10 @@
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 51.1,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 402,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40524,7 +40524,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.28,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "28.01.2023"
@@ -40562,7 +40562,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.25,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "29.01.2023"
@@ -40584,7 +40584,7 @@
         "BelegteBetten": null,
         "Inzidenz": 62.5022450519056,
         "Datum_neu": 1675123200000,
-        "F\u00e4lle_Meldedatum": 86,
+        "F\u00e4lle_Meldedatum": 87,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 51.9,
@@ -40600,7 +40600,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.58,
+        "H_Inzidenz": 4.85,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.01.2023"
@@ -40622,9 +40622,9 @@
         "BelegteBetten": null,
         "Inzidenz": 66.2739322533137,
         "Datum_neu": 1675209600000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 44,
         "Zeitraum": "25.01.2023 - 31.01.2023",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 3,
         "Inzidenz_RKI": 53.8,
         "Fallzahl_aktiv": 693,
         "Krh_N_belegt": 322,
@@ -40638,7 +40638,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.28,
+        "H_Inzidenz": 4.95,
         "H_Zeitraum": "25.01.2023 - 31.01.2023",
         "H_Datum": "31.01.2023",
         "Datum_Bett": "31.01.2023"
@@ -40651,7 +40651,7 @@
         "ObjectId": 1063,
         "Sterbefall": 1886,
         "Genesungsfall": 277316,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7581,
         "Zuwachs_Fallzahl": 46,
         "Zuwachs_Sterbefall": 0,
@@ -40660,9 +40660,9 @@
         "BelegteBetten": null,
         "Inzidenz": 60.7062035274256,
         "Datum_neu": 1675296000000,
-        "F\u00e4lle_Meldedatum": 17,
+        "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": "26.01.2023 - 01.02.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 54.6,
         "Fallzahl_aktiv": 677,
         "Krh_N_belegt": 322,
@@ -40676,11 +40676,201 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.49,
+        "H_Inzidenz": 4.55,
         "H_Zeitraum": "26.01.2023 - 01.02.2023",
         "H_Datum": "31.01.2023",
         "Datum_Bett": "01.02.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "03.02.2023",
+        "Fallzahl": 279961,
+        "ObjectId": 1064,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277369,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7588,
+        "Zuwachs_Fallzahl": 82,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 7,
+        "Zuwachs_Genesung": 53,
+        "BelegteBetten": null,
+        "Inzidenz": 62.1430367470096,
+        "Datum_neu": 1675382400000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "27.01.2023 - 02.02.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 54,
+        "Fallzahl_aktiv": 705,
+        "Krh_N_belegt": 322,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 28,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.16,
+        "H_Zeitraum": "27.01.2023 - 02.02.2023",
+        "H_Datum": "31.01.2023",
+        "Datum_Bett": "02.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.02.2023",
+        "Fallzahl": 279982,
+        "ObjectId": 1065,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277396,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7588,
+        "Zuwachs_Fallzahl": 21,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 27,
+        "BelegteBetten": null,
+        "Inzidenz": 59.2693703078415,
+        "Datum_neu": 1675468800000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "28.01.2023 - 03.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 52.8,
+        "Fallzahl_aktiv": 699,
+        "Krh_N_belegt": 322,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -6,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.51,
+        "H_Zeitraum": "28.01.2023 - 03.02.2023",
+        "H_Datum": "31.01.2023",
+        "Datum_Bett": "03.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.02.2023",
+        "Fallzahl": 279992,
+        "ObjectId": 1066,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277417,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7589,
+        "Zuwachs_Fallzahl": 10,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 21,
+        "BelegteBetten": null,
+        "Inzidenz": 56.9345163260175,
+        "Datum_neu": 1675555200000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "29.01.2023 - 04.02.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 46.6,
+        "Fallzahl_aktiv": 688,
+        "Krh_N_belegt": 322,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.26,
+        "H_Zeitraum": "29.01.2023 - 04.02.2023",
+        "H_Datum": "31.01.2023",
+        "Datum_Bett": "04.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.02.2023",
+        "Fallzahl": 280056,
+        "ObjectId": 1067,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277483,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7594,
+        "Zuwachs_Fallzahl": 64,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 66,
+        "BelegteBetten": null,
+        "Inzidenz": 57.1141204784655,
+        "Datum_neu": 1675641600000,
+        "F\u00e4lle_Meldedatum": 64,
+        "Zeitraum": "30.01.2023 - 05.02.2023",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 45,
+        "Fallzahl_aktiv": 686,
+        "Krh_N_belegt": 322,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.24,
+        "H_Zeitraum": "30.01.2023 - 05.02.2023",
+        "H_Datum": "31.01.2023",
+        "Datum_Bett": "05.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.02.2023",
+        "Fallzahl": 280070,
+        "ObjectId": 1068,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277535,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7594,
+        "Zuwachs_Fallzahl": 191,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 219,
+        "BelegteBetten": null,
+        "Inzidenz": 56.7549121735695,
+        "Datum_neu": 1675728000000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "31.01.2023 - 06.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 45.6,
+        "Fallzahl_aktiv": 648,
+        "Krh_N_belegt": 322,
+        "Krh_I_belegt": 32,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -29,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.08,
+        "H_Zeitraum": "31.01.2023 - 06.02.2023",
+        "H_Datum": "31.01.2023",
+        "Datum_Bett": "06.02.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
