### PR TITLE
New data set: 2023-02-14T110203Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-02-07T110704Z.json
+pjson/2023-02-14T110203Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-02-07T110704Z.json pjson/2023-02-14T110203Z.json```:
```
--- pjson/2023-02-07T110704Z.json	2023-02-07 11:07:04.683983012 +0000
+++ pjson/2023-02-14T110203Z.json	2023-02-14 11:02:04.361624289 +0000
@@ -39786,7 +39786,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1673308800000,
-        "F\u00e4lle_Meldedatum": 83,
+        "F\u00e4lle_Meldedatum": 82,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -40468,9 +40468,9 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
-        "Inzidenz": 61.9634325945616,
+        "Inzidenz": null,
         "Datum_neu": 1674864000000,
-        "F\u00e4lle_Meldedatum": 34,
+        "F\u00e4lle_Meldedatum": 33,
         "Zeitraum": null,
         "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": null,
@@ -40506,7 +40506,7 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 20,
         "BelegteBetten": null,
-        "Inzidenz": 64.1186824239376,
+        "Inzidenz": null,
         "Datum_neu": 1674950400000,
         "F\u00e4lle_Meldedatum": 9,
         "Zeitraum": null,
@@ -40544,15 +40544,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
-        "Inzidenz": 63.9390782714896,
+        "Inzidenz": null,
         "Datum_neu": 1675036800000,
         "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 49.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 402,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40582,15 +40582,15 @@
         "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 68,
         "BelegteBetten": null,
-        "Inzidenz": 62.5022450519056,
+        "Inzidenz": null,
         "Datum_neu": 1675123200000,
-        "F\u00e4lle_Meldedatum": 87,
+        "F\u00e4lle_Meldedatum": 90,
         "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 51.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 402,
-        "Krh_I_belegt": 32,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
@@ -40600,7 +40600,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.85,
+        "H_Inzidenz": null,
         "H_Zeitraum": null,
         "H_Datum": null,
         "Datum_Bett": "30.01.2023"
@@ -40611,36 +40611,36 @@
         "Datum": "01.02.2023",
         "Fallzahl": 279833,
         "ObjectId": 1062,
-        "Sterbefall": 1886,
-        "Genesungsfall": 277254,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7580,
-        "Zuwachs_Fallzahl": 73,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
-        "Inzidenz": 66.2739322533137,
+        "Inzidenz": null,
         "Datum_neu": 1675209600000,
-        "F\u00e4lle_Meldedatum": 44,
-        "Zeitraum": "25.01.2023 - 31.01.2023",
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 3,
-        "Inzidenz_RKI": 53.8,
-        "Fallzahl_aktiv": 693,
-        "Krh_N_belegt": 322,
-        "Krh_I_belegt": 32,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 14,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.95,
-        "H_Zeitraum": "25.01.2023 - 31.01.2023",
-        "H_Datum": "31.01.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "31.01.2023"
       }
     },
@@ -40649,26 +40649,26 @@
         "Datum": "02.02.2023",
         "Fallzahl": 279879,
         "ObjectId": 1063,
-        "Sterbefall": 1886,
-        "Genesungsfall": 277316,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7581,
-        "Zuwachs_Fallzahl": 46,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 62,
         "BelegteBetten": null,
-        "Inzidenz": 60.7062035274256,
+        "Inzidenz": null,
         "Datum_neu": 1675296000000,
-        "F\u00e4lle_Meldedatum": 53,
-        "Zeitraum": "26.01.2023 - 01.02.2023",
+        "F\u00e4lle_Meldedatum": 57,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 54.6,
-        "Fallzahl_aktiv": 677,
-        "Krh_N_belegt": 322,
-        "Krh_I_belegt": 32,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -16,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40676,9 +40676,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.55,
-        "H_Zeitraum": "26.01.2023 - 01.02.2023",
-        "H_Datum": "31.01.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.02.2023"
       }
     },
@@ -40687,36 +40687,36 @@
         "Datum": "03.02.2023",
         "Fallzahl": 279961,
         "ObjectId": 1064,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277369,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7588,
-        "Zuwachs_Fallzahl": 82,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 7,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
-        "Inzidenz": 62.1430367470096,
+        "Inzidenz": null,
         "Datum_neu": 1675382400000,
         "F\u00e4lle_Meldedatum": 37,
-        "Zeitraum": "27.01.2023 - 02.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 54,
-        "Fallzahl_aktiv": 705,
-        "Krh_N_belegt": 322,
-        "Krh_I_belegt": 32,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 28,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.16,
-        "H_Zeitraum": "27.01.2023 - 02.02.2023",
-        "H_Datum": "31.01.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.02.2023"
       }
     },
@@ -40725,26 +40725,26 @@
         "Datum": "04.02.2023",
         "Fallzahl": 279982,
         "ObjectId": 1065,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277396,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7588,
-        "Zuwachs_Fallzahl": 21,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 27,
         "BelegteBetten": null,
-        "Inzidenz": 59.2693703078415,
+        "Inzidenz": null,
         "Datum_neu": 1675468800000,
         "F\u00e4lle_Meldedatum": 21,
-        "Zeitraum": "28.01.2023 - 03.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 52.8,
-        "Fallzahl_aktiv": 699,
-        "Krh_N_belegt": 322,
-        "Krh_I_belegt": 32,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -6,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40752,9 +40752,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.51,
-        "H_Zeitraum": "28.01.2023 - 03.02.2023",
-        "H_Datum": "31.01.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.02.2023"
       }
     },
@@ -40763,26 +40763,26 @@
         "Datum": "05.02.2023",
         "Fallzahl": 279992,
         "ObjectId": 1066,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277417,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7589,
-        "Zuwachs_Fallzahl": 10,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 21,
         "BelegteBetten": null,
-        "Inzidenz": 56.9345163260175,
+        "Inzidenz": null,
         "Datum_neu": 1675555200000,
-        "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "29.01.2023 - 04.02.2023",
+        "F\u00e4lle_Meldedatum": 11,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 46.6,
-        "Fallzahl_aktiv": 688,
-        "Krh_N_belegt": 322,
-        "Krh_I_belegt": 32,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40790,9 +40790,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.26,
-        "H_Zeitraum": "29.01.2023 - 04.02.2023",
-        "H_Datum": "31.01.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "04.02.2023"
       }
     },
@@ -40812,9 +40812,9 @@
         "BelegteBetten": null,
         "Inzidenz": 57.1141204784655,
         "Datum_neu": 1675641600000,
-        "F\u00e4lle_Meldedatum": 64,
+        "F\u00e4lle_Meldedatum": 67,
         "Zeitraum": "30.01.2023 - 05.02.2023",
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 45,
         "Fallzahl_aktiv": 686,
         "Krh_N_belegt": 322,
@@ -40828,9 +40828,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.24,
-        "H_Zeitraum": "30.01.2023 - 05.02.2023",
-        "H_Datum": "31.01.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.02.2023"
       }
     },
@@ -40840,25 +40840,25 @@
         "Fallzahl": 280070,
         "ObjectId": 1068,
         "Sterbefall": 1887,
-        "Genesungsfall": 277535,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 7594,
-        "Zuwachs_Fallzahl": 191,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 13,
-        "Zuwachs_Genesung": 219,
+        "Genesungsfall": 277536,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7595,
+        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 53,
         "BelegteBetten": null,
         "Inzidenz": 56.7549121735695,
         "Datum_neu": 1675728000000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": "31.01.2023 - 06.02.2023",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 45.6,
-        "Fallzahl_aktiv": 648,
+        "Fallzahl_aktiv": 647,
         "Krh_N_belegt": 322,
         "Krh_I_belegt": 32,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -29,
+        "Fallzahl_aktiv_Zuwachs": -39,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40866,11 +40866,277 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.08,
+        "H_Inzidenz": 4.28,
         "H_Zeitraum": "31.01.2023 - 06.02.2023",
         "H_Datum": "31.01.2023",
         "Datum_Bett": "06.02.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.02.2023",
+        "Fallzahl": 280175,
+        "ObjectId": 1069,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277611,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7597,
+        "Zuwachs_Fallzahl": 105,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 75,
+        "BelegteBetten": null,
+        "Inzidenz": 51.0075792952333,
+        "Datum_neu": 1675814400000,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": "01.02.2023 - 07.02.2023",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 43.4,
+        "Fallzahl_aktiv": 677,
+        "Krh_N_belegt": 334,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 30,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.06,
+        "H_Zeitraum": "01.02.2023 - 07.02.2023",
+        "H_Datum": "07.02.2023",
+        "Datum_Bett": "07.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.02.2023",
+        "Fallzahl": 280220,
+        "ObjectId": 1070,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277667,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7598,
+        "Zuwachs_Fallzahl": 45,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 1,
+        "Zuwachs_Genesung": 56,
+        "BelegteBetten": null,
+        "Inzidenz": 54.0608498868494,
+        "Datum_neu": 1675900800000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "02.02.2023 - 08.02.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 43.8,
+        "Fallzahl_aktiv": 666,
+        "Krh_N_belegt": 334,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.98,
+        "H_Zeitraum": "02.02.2023 - 08.02.2023",
+        "H_Datum": "07.02.2023",
+        "Datum_Bett": "08.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.02.2023",
+        "Fallzahl": 280268,
+        "ObjectId": 1071,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277728,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7602,
+        "Zuwachs_Fallzahl": 48,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 61,
+        "BelegteBetten": null,
+        "Inzidenz": 51.9056000574733,
+        "Datum_neu": 1675987200000,
+        "F\u00e4lle_Meldedatum": 48,
+        "Zeitraum": "03.02.2023 - 09.02.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 44.3,
+        "Fallzahl_aktiv": 653,
+        "Krh_N_belegt": 334,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -13,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.11,
+        "H_Zeitraum": "03.02.2023 - 09.02.2023",
+        "H_Datum": "07.02.2023",
+        "Datum_Bett": "09.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.02.2023",
+        "Fallzahl": 280280,
+        "ObjectId": 1072,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277766,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7602,
+        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 38,
+        "BelegteBetten": null,
+        "Inzidenz": 53.8812457344014,
+        "Datum_neu": 1676073600000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "04.02.2023 - 10.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 45.7,
+        "Fallzahl_aktiv": 627,
+        "Krh_N_belegt": 334,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -26,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.01,
+        "H_Zeitraum": "04.02.2023 - 10.02.2023",
+        "H_Datum": "07.02.2023",
+        "Datum_Bett": "10.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.02.2023",
+        "Fallzahl": 280288,
+        "ObjectId": 1073,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277785,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7602,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 19,
+        "BelegteBetten": null,
+        "Inzidenz": 52.2648083623693,
+        "Datum_neu": 1676160000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "05.02.2023 - 11.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 42,
+        "Fallzahl_aktiv": 616,
+        "Krh_N_belegt": 334,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.86,
+        "H_Zeitraum": "05.02.2023 - 11.02.2023",
+        "H_Datum": "07.02.2023",
+        "Datum_Bett": "11.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.02.2023",
+        "Fallzahl": 280343,
+        "ObjectId": 1074,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277840,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7605,
+        "Zuwachs_Fallzahl": 55,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 55,
+        "BelegteBetten": null,
+        "Inzidenz": 51.7259959050253,
+        "Datum_neu": 1676246400000,
+        "F\u00e4lle_Meldedatum": 55,
+        "Zeitraum": "06.02.2023 - 12.02.2023",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 40,
+        "Fallzahl_aktiv": 616,
+        "Krh_N_belegt": 334,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 0,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.88,
+        "H_Zeitraum": "06.02.2023 - 12.02.2023",
+        "H_Datum": "07.02.2023",
+        "Datum_Bett": "12.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.02.2023",
+        "Fallzahl": 280357,
+        "ObjectId": 1075,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277927,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7606,
+        "Zuwachs_Fallzahl": 287,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 391,
+        "BelegteBetten": null,
+        "Inzidenz": 49.5707460756493,
+        "Datum_neu": 1676332800000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "07.02.2023 - 13.02.2023",
+        "Hosp_Meldedatum": 1,
+        "Inzidenz_RKI": 38.7,
+        "Fallzahl_aktiv": 543,
+        "Krh_N_belegt": 334,
+        "Krh_I_belegt": 23,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -104,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.94,
+        "H_Zeitraum": "07.02.2023 - 13.02.2023",
+        "H_Datum": "07.02.2023",
+        "Datum_Bett": "13.02.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
