### PR TITLE
New data set: 2023-02-21T111104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-02-14T110203Z.json
+pjson/2023-02-21T111104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-02-14T110203Z.json pjson/2023-02-21T111104Z.json```:
```
--- pjson/2023-02-14T110203Z.json	2023-02-14 11:02:04.361624289 +0000
+++ pjson/2023-02-21T111104Z.json	2023-02-21 11:11:04.510261001 +0000
@@ -36102,7 +36102,7 @@
         "Datum_neu": 1664928000000,
         "F\u00e4lle_Meldedatum": 920,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 14,
+        "Hosp_Meldedatum": 13,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -40092,7 +40092,7 @@
         "Datum_neu": 1674000000000,
         "F\u00e4lle_Meldedatum": 53,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 11,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -40698,7 +40698,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1675382400000,
-        "F\u00e4lle_Meldedatum": 37,
+        "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -40801,26 +40801,26 @@
         "Datum": "06.02.2023",
         "Fallzahl": 280056,
         "ObjectId": 1067,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277483,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7594,
-        "Zuwachs_Fallzahl": 64,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 66,
         "BelegteBetten": null,
-        "Inzidenz": 57.1141204784655,
+        "Inzidenz": null,
         "Datum_neu": 1675641600000,
         "F\u00e4lle_Meldedatum": 67,
-        "Zeitraum": "30.01.2023 - 05.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 45,
-        "Fallzahl_aktiv": 686,
-        "Krh_N_belegt": 322,
-        "Krh_I_belegt": 32,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40839,26 +40839,26 @@
         "Datum": "07.02.2023",
         "Fallzahl": 280070,
         "ObjectId": 1068,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277536,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7595,
-        "Zuwachs_Fallzahl": 14,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
-        "Zuwachs_Genesung": 53,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
-        "Inzidenz": 56.7549121735695,
+        "Inzidenz": null,
         "Datum_neu": 1675728000000,
         "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "31.01.2023 - 06.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 45.6,
-        "Fallzahl_aktiv": 647,
-        "Krh_N_belegt": 322,
-        "Krh_I_belegt": 32,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -39,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40866,75 +40866,75 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.28,
-        "H_Zeitraum": "31.01.2023 - 06.02.2023",
-        "H_Datum": "31.01.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.02.2023"
       }
     },
     {
       "attributes": {
         "Datum": "08.02.2023",
-        "Fallzahl": 280175,
+        "Fallzahl": 280174,
         "ObjectId": 1069,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277611,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7597,
-        "Zuwachs_Fallzahl": 105,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
-        "Zuwachs_Genesung": 75,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 51.0075792952333,
+        "Inzidenz": null,
         "Datum_neu": 1675814400000,
         "F\u00e4lle_Meldedatum": 63,
-        "Zeitraum": "01.02.2023 - 07.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 43.4,
-        "Fallzahl_aktiv": 677,
-        "Krh_N_belegt": 334,
-        "Krh_I_belegt": 23,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 30,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.06,
-        "H_Zeitraum": "01.02.2023 - 07.02.2023",
-        "H_Datum": "07.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.02.2023"
       }
     },
     {
       "attributes": {
         "Datum": "09.02.2023",
-        "Fallzahl": 280220,
+        "Fallzahl": 280219,
         "ObjectId": 1070,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277667,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7598,
-        "Zuwachs_Fallzahl": 45,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 1,
-        "Zuwachs_Genesung": 56,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 54.0608498868494,
+        "Inzidenz": null,
         "Datum_neu": 1675900800000,
         "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "02.02.2023 - 08.02.2023",
-        "Hosp_Meldedatum": 1,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 43.8,
-        "Fallzahl_aktiv": 666,
-        "Krh_N_belegt": 334,
-        "Krh_I_belegt": 23,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40942,37 +40942,37 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.98,
-        "H_Zeitraum": "02.02.2023 - 08.02.2023",
-        "H_Datum": "07.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.02.2023"
       }
     },
     {
       "attributes": {
         "Datum": "10.02.2023",
-        "Fallzahl": 280268,
+        "Fallzahl": 280267,
         "ObjectId": 1071,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277728,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7602,
-        "Zuwachs_Fallzahl": 48,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
-        "Zuwachs_Genesung": 61,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 51.9056000574733,
+        "Inzidenz": null,
         "Datum_neu": 1675987200000,
         "F\u00e4lle_Meldedatum": 48,
-        "Zeitraum": "03.02.2023 - 09.02.2023",
-        "Hosp_Meldedatum": 4,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 44.3,
-        "Fallzahl_aktiv": 653,
-        "Krh_N_belegt": 334,
-        "Krh_I_belegt": 23,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -13,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -40980,9 +40980,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.11,
-        "H_Zeitraum": "03.02.2023 - 09.02.2023",
-        "H_Datum": "07.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.02.2023"
       }
     },
@@ -40991,26 +40991,26 @@
         "Datum": "11.02.2023",
         "Fallzahl": 280280,
         "ObjectId": 1072,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277766,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7602,
-        "Zuwachs_Fallzahl": 12,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 38,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 53.8812457344014,
+        "Inzidenz": null,
         "Datum_neu": 1676073600000,
-        "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "04.02.2023 - 10.02.2023",
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 45.7,
-        "Fallzahl_aktiv": 627,
-        "Krh_N_belegt": 334,
-        "Krh_I_belegt": 23,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -26,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41018,9 +41018,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.01,
-        "H_Zeitraum": "04.02.2023 - 10.02.2023",
-        "H_Datum": "07.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.02.2023"
       }
     },
@@ -41029,26 +41029,26 @@
         "Datum": "12.02.2023",
         "Fallzahl": 280288,
         "ObjectId": 1073,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277785,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7602,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
-        "Zuwachs_Genesung": 19,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 52.2648083623693,
+        "Inzidenz": null,
         "Datum_neu": 1676160000000,
         "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "05.02.2023 - 11.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 42,
-        "Fallzahl_aktiv": 616,
-        "Krh_N_belegt": 334,
-        "Krh_I_belegt": 23,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41056,37 +41056,37 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.86,
-        "H_Zeitraum": "05.02.2023 - 11.02.2023",
-        "H_Datum": "07.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.02.2023"
       }
     },
     {
       "attributes": {
         "Datum": "13.02.2023",
-        "Fallzahl": 280343,
+        "Fallzahl": 280348,
         "ObjectId": 1074,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277840,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7605,
-        "Zuwachs_Fallzahl": 55,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 3,
-        "Zuwachs_Genesung": 55,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
+        "Zuwachs_Genesung": 0,
         "BelegteBetten": null,
-        "Inzidenz": 51.7259959050253,
+        "Inzidenz": null,
         "Datum_neu": 1676246400000,
-        "F\u00e4lle_Meldedatum": 55,
-        "Zeitraum": "06.02.2023 - 12.02.2023",
-        "Hosp_Meldedatum": 3,
+        "F\u00e4lle_Meldedatum": 60,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 40,
-        "Fallzahl_aktiv": 616,
-        "Krh_N_belegt": 334,
-        "Krh_I_belegt": 23,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 0,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41094,37 +41094,37 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.88,
-        "H_Zeitraum": "06.02.2023 - 12.02.2023",
-        "H_Datum": "07.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "12.02.2023"
       }
     },
     {
       "attributes": {
         "Datum": "14.02.2023",
-        "Fallzahl": 280357,
+        "Fallzahl": 280424,
         "ObjectId": 1075,
         "Sterbefall": 1887,
         "Genesungsfall": 277927,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 7606,
-        "Zuwachs_Fallzahl": 287,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7617,
+        "Zuwachs_Fallzahl": 354,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Krankenhauseinweisung": 22,
         "Zuwachs_Genesung": 391,
         "BelegteBetten": null,
-        "Inzidenz": 49.5707460756493,
+        "Inzidenz": 50.6483709903373,
         "Datum_neu": 1676332800000,
-        "F\u00e4lle_Meldedatum": 14,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": "07.02.2023 - 13.02.2023",
-        "Hosp_Meldedatum": 1,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": 38.7,
-        "Fallzahl_aktiv": 543,
+        "Fallzahl_aktiv": 610,
         "Krh_N_belegt": 334,
         "Krh_I_belegt": 23,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -104,
+        "Fallzahl_aktiv_Zuwachs": -37,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41137,6 +41137,272 @@
         "H_Datum": "07.02.2023",
         "Datum_Bett": "13.02.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.02.2023",
+        "Fallzahl": 280482,
+        "ObjectId": 1076,
+        "Sterbefall": 1887,
+        "Genesungsfall": 277976,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7622,
+        "Zuwachs_Fallzahl": 58,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 49,
+        "BelegteBetten": null,
+        "Inzidenz": 56.2160997162254,
+        "Datum_neu": 1676419200000,
+        "F\u00e4lle_Meldedatum": 58,
+        "Zeitraum": "08.02.2023 - 14.02.2023",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 43.9,
+        "Fallzahl_aktiv": 619,
+        "Krh_N_belegt": 335,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 9,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.08,
+        "H_Zeitraum": "08.02.2023-14.02.2023",
+        "H_Datum": "14.02.2023",
+        "Datum_Bett": "14.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.02.2023",
+        "Fallzahl": 280546,
+        "ObjectId": 1077,
+        "Sterbefall": 1887,
+        "Genesungsfall": 278032,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7631,
+        "Zuwachs_Fallzahl": 64,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 56,
+        "BelegteBetten": null,
+        "Inzidenz": 55.3180789539854,
+        "Datum_neu": 1676505600000,
+        "F\u00e4lle_Meldedatum": 64,
+        "Zeitraum": "09.02.2023 - 15.02.2023",
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 48.4,
+        "Fallzahl_aktiv": 627,
+        "Krh_N_belegt": 335,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 8,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.31,
+        "H_Zeitraum": "09.02.2023-15.02.2023",
+        "H_Datum": "14.02.2023",
+        "Datum_Bett": "15.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.02.2023",
+        "Fallzahl": 280600,
+        "ObjectId": 1078,
+        "Sterbefall": 1887,
+        "Genesungsfall": 278075,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7633,
+        "Zuwachs_Fallzahl": 54,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 43,
+        "BelegteBetten": null,
+        "Inzidenz": 58.7305578504975,
+        "Datum_neu": 1676592000000,
+        "F\u00e4lle_Meldedatum": 54,
+        "Zeitraum": "10.02.2023 - 16.02.2023",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 49,
+        "Fallzahl_aktiv": 638,
+        "Krh_N_belegt": 335,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 11,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.43,
+        "H_Zeitraum": "10.02.2023-16.02.2023",
+        "H_Datum": "14.02.2023",
+        "Datum_Bett": "16.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.02.2023",
+        "Fallzahl": 280621,
+        "ObjectId": 1079,
+        "Sterbefall": 1887,
+        "Genesungsfall": 278101,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7633,
+        "Zuwachs_Fallzahl": 21,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 26,
+        "BelegteBetten": null,
+        "Inzidenz": 59.8081827651855,
+        "Datum_neu": 1676678400000,
+        "F\u00e4lle_Meldedatum": 21,
+        "Zeitraum": "11.02.2023 - 17.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 52.2,
+        "Fallzahl_aktiv": 633,
+        "Krh_N_belegt": 335,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -5,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.16,
+        "H_Zeitraum": "11.02.2023-17.02.2023",
+        "H_Datum": "14.02.2023",
+        "Datum_Bett": "17.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.02.2023",
+        "Fallzahl": 280629,
+        "ObjectId": 1080,
+        "Sterbefall": 1887,
+        "Genesungsfall": 278113,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7633,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 12,
+        "BelegteBetten": null,
+        "Inzidenz": 61.2450159847696,
+        "Datum_neu": 1676764800000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "12.02.2023 - 18.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 49.9,
+        "Fallzahl_aktiv": 629,
+        "Krh_N_belegt": 335,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.84,
+        "H_Zeitraum": "12.02.2023-18.02.2023",
+        "H_Datum": "14.02.2023",
+        "Datum_Bett": "18.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.02.2023",
+        "Fallzahl": 280692,
+        "ObjectId": 1081,
+        "Sterbefall": 1887,
+        "Genesungsfall": 278174,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7648,
+        "Zuwachs_Fallzahl": 63,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 61,
+        "BelegteBetten": null,
+        "Inzidenz": 61.2450159847696,
+        "Datum_neu": 1676851200000,
+        "F\u00e4lle_Meldedatum": 63,
+        "Zeitraum": "13.02.2023 - 19.02.2023",
+        "Hosp_Meldedatum": 15,
+        "Inzidenz_RKI": 48.4,
+        "Fallzahl_aktiv": 631,
+        "Krh_N_belegt": 335,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.61,
+        "H_Zeitraum": "13.02.2023-19.02.2023",
+        "H_Datum": "14.02.2023",
+        "Datum_Bett": "19.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.02.2023",
+        "Fallzahl": 280701,
+        "ObjectId": 1082,
+        "Sterbefall": 1887,
+        "Genesungsfall": 278219,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7648,
+        "Zuwachs_Fallzahl": 277,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 31,
+        "Zuwachs_Genesung": 292,
+        "BelegteBetten": null,
+        "Inzidenz": 61.7838284421136,
+        "Datum_neu": 1676937600000,
+        "F\u00e4lle_Meldedatum": 9,
+        "Zeitraum": "14.02.2023 - 20.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 50.4,
+        "Fallzahl_aktiv": 595,
+        "Krh_N_belegt": 335,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -15,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.23,
+        "H_Zeitraum": "14.02.2023-20.02.2012",
+        "H_Datum": "14.02.2023",
+        "Datum_Bett": "20.02.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
