### PR TITLE
New data set: 2023-02-28T121604Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-02-21T111104Z.json
+pjson/2023-02-28T121604Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-02-21T111104Z.json pjson/2023-02-28T121604Z.json```:
```
--- pjson/2023-02-21T111104Z.json	2023-02-21 11:11:04.510261001 +0000
+++ pjson/2023-02-28T121604Z.json	2023-02-28 12:16:04.698526319 +0000
@@ -35036,7 +35036,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1662508800000,
-        "F\u00e4lle_Meldedatum": 264,
+        "F\u00e4lle_Meldedatum": 263,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -35264,7 +35264,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1663027200000,
-        "F\u00e4lle_Meldedatum": 389,
+        "F\u00e4lle_Meldedatum": 388,
         "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
@@ -40853,7 +40853,7 @@
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 45.6,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -40890,8 +40890,8 @@
         "Datum_neu": 1675814400000,
         "F\u00e4lle_Meldedatum": 63,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 43.4,
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -40929,7 +40929,7 @@
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 43.8,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -40967,7 +40967,7 @@
         "F\u00e4lle_Meldedatum": 48,
         "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 44.3,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -41005,7 +41005,7 @@
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 45.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -41043,7 +41043,7 @@
         "F\u00e4lle_Meldedatum": 8,
         "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 42,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -41078,10 +41078,10 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1676246400000,
-        "F\u00e4lle_Meldedatum": 60,
+        "F\u00e4lle_Meldedatum": 61,
         "Zeitraum": null,
         "Hosp_Meldedatum": 10,
-        "Inzidenz_RKI": 40,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
@@ -41119,10 +41119,10 @@
         "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": "07.02.2023 - 13.02.2023",
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 38.7,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 610,
-        "Krh_N_belegt": 334,
-        "Krh_I_belegt": 23,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -37,
         "Krh_I": null,
@@ -41132,9 +41132,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.94,
-        "H_Zeitraum": "07.02.2023 - 13.02.2023",
-        "H_Datum": "07.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "13.02.2023"
       }
     },
@@ -41157,10 +41157,10 @@
         "F\u00e4lle_Meldedatum": 58,
         "Zeitraum": "08.02.2023 - 14.02.2023",
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 43.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 619,
-        "Krh_N_belegt": 335,
-        "Krh_I_belegt": 28,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 9,
         "Krh_I": null,
@@ -41170,9 +41170,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.08,
-        "H_Zeitraum": "08.02.2023-14.02.2023",
-        "H_Datum": "14.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "14.02.2023"
       }
     },
@@ -41195,10 +41195,10 @@
         "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": "09.02.2023 - 15.02.2023",
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 48.4,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 627,
-        "Krh_N_belegt": 335,
-        "Krh_I_belegt": 28,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 8,
         "Krh_I": null,
@@ -41208,9 +41208,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.31,
-        "H_Zeitraum": "09.02.2023-15.02.2023",
-        "H_Datum": "14.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "15.02.2023"
       }
     },
@@ -41230,25 +41230,25 @@
         "BelegteBetten": null,
         "Inzidenz": 58.7305578504975,
         "Datum_neu": 1676592000000,
-        "F\u00e4lle_Meldedatum": 54,
+        "F\u00e4lle_Meldedatum": 55,
         "Zeitraum": "10.02.2023 - 16.02.2023",
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 49,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 638,
-        "Krh_N_belegt": 335,
-        "Krh_I_belegt": 28,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 11,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.43,
-        "H_Zeitraum": "10.02.2023-16.02.2023",
-        "H_Datum": "14.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "16.02.2023"
       }
     },
@@ -41268,13 +41268,13 @@
         "BelegteBetten": null,
         "Inzidenz": 59.8081827651855,
         "Datum_neu": 1676678400000,
-        "F\u00e4lle_Meldedatum": 21,
+        "F\u00e4lle_Meldedatum": 22,
         "Zeitraum": "11.02.2023 - 17.02.2023",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 52.2,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 633,
-        "Krh_N_belegt": 335,
-        "Krh_I_belegt": 28,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -5,
         "Krh_I": null,
@@ -41284,9 +41284,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.16,
-        "H_Zeitraum": "11.02.2023-17.02.2023",
-        "H_Datum": "14.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "17.02.2023"
       }
     },
@@ -41306,13 +41306,13 @@
         "BelegteBetten": null,
         "Inzidenz": 61.2450159847696,
         "Datum_neu": 1676764800000,
-        "F\u00e4lle_Meldedatum": 8,
+        "F\u00e4lle_Meldedatum": 10,
         "Zeitraum": "12.02.2023 - 18.02.2023",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 49.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 629,
-        "Krh_N_belegt": 335,
-        "Krh_I_belegt": 28,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -4,
         "Krh_I": null,
@@ -41322,9 +41322,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.84,
-        "H_Zeitraum": "12.02.2023-18.02.2023",
-        "H_Datum": "14.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "18.02.2023"
       }
     },
@@ -41344,9 +41344,9 @@
         "BelegteBetten": null,
         "Inzidenz": 61.2450159847696,
         "Datum_neu": 1676851200000,
-        "F\u00e4lle_Meldedatum": 63,
+        "F\u00e4lle_Meldedatum": 66,
         "Zeitraum": "13.02.2023 - 19.02.2023",
-        "Hosp_Meldedatum": 15,
+        "Hosp_Meldedatum": 24,
         "Inzidenz_RKI": 48.4,
         "Fallzahl_aktiv": 631,
         "Krh_N_belegt": 335,
@@ -41360,7 +41360,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.61,
+        "H_Inzidenz": 7.1,
         "H_Zeitraum": "13.02.2023-19.02.2023",
         "H_Datum": "14.02.2023",
         "Datum_Bett": "19.02.2023"
@@ -41373,24 +41373,24 @@
         "ObjectId": 1082,
         "Sterbefall": 1887,
         "Genesungsfall": 278219,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7648,
-        "Zuwachs_Fallzahl": 277,
+        "Zuwachs_Fallzahl": 9,
         "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 31,
-        "Zuwachs_Genesung": 292,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 45,
         "BelegteBetten": null,
         "Inzidenz": 61.7838284421136,
         "Datum_neu": 1676937600000,
-        "F\u00e4lle_Meldedatum": 9,
+        "F\u00e4lle_Meldedatum": 76,
         "Zeitraum": "14.02.2023 - 20.02.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 7,
         "Inzidenz_RKI": 50.4,
         "Fallzahl_aktiv": 595,
-        "Krh_N_belegt": 335,
-        "Krh_I_belegt": 28,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -15,
+        "Fallzahl_aktiv_Zuwachs": -36,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41398,11 +41398,277 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.23,
+        "H_Inzidenz": 7.77,
         "H_Zeitraum": "14.02.2023-20.02.2012",
         "H_Datum": "14.02.2023",
         "Datum_Bett": "20.02.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "22.02.2023",
+        "Fallzahl": 280817,
+        "ObjectId": 1083,
+        "Sterbefall": 1888,
+        "Genesungsfall": 278284,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7674,
+        "Zuwachs_Fallzahl": 116,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 26,
+        "Zuwachs_Genesung": 65,
+        "BelegteBetten": null,
+        "Inzidenz": 63.0410575092496,
+        "Datum_neu": 1677024000000,
+        "F\u00e4lle_Meldedatum": 43,
+        "Zeitraum": "15.02.2023 - 21.02.2023",
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 49.9,
+        "Fallzahl_aktiv": 645,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 50,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.54,
+        "H_Zeitraum": "14.02.2023-20.02.2013",
+        "H_Datum": "21.02.2023",
+        "Datum_Bett": "21.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "23.02.2023",
+        "Fallzahl": 280882,
+        "ObjectId": 1084,
+        "Sterbefall": 1888,
+        "Genesungsfall": 278339,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7683,
+        "Zuwachs_Fallzahl": 65,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 55,
+        "BelegteBetten": null,
+        "Inzidenz": 60.3469952225296,
+        "Datum_neu": 1677110400000,
+        "F\u00e4lle_Meldedatum": 65,
+        "Zeitraum": "16.02.2023 - 22.02.2023",
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 51.9,
+        "Fallzahl_aktiv": 655,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 10,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.69,
+        "H_Zeitraum": "14.02.2023-20.02.2014",
+        "H_Datum": "21.02.2023",
+        "Datum_Bett": "22.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "24.02.2023",
+        "Fallzahl": 280928,
+        "ObjectId": 1085,
+        "Sterbefall": 1888,
+        "Genesungsfall": 278381,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7689,
+        "Zuwachs_Fallzahl": 46,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 42,
+        "BelegteBetten": null,
+        "Inzidenz": 60.5265993749776,
+        "Datum_neu": 1677196800000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "17.02.2023 - 23.02.2023",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 49.3,
+        "Fallzahl_aktiv": 659,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.79,
+        "H_Zeitraum": "14.02.2023-20.02.2015",
+        "H_Datum": "21.02.2023",
+        "Datum_Bett": "23.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "25.02.2023",
+        "Fallzahl": 280940,
+        "ObjectId": 1086,
+        "Sterbefall": 1888,
+        "Genesungsfall": 278399,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7689,
+        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 18,
+        "BelegteBetten": null,
+        "Inzidenz": 58.9101620029455,
+        "Datum_neu": 1677283200000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "18.02.2023 - 24.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 49.9,
+        "Fallzahl_aktiv": 653,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -6,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.64,
+        "H_Zeitraum": "14.02.2023-20.02.2016",
+        "H_Datum": "21.02.2023",
+        "Datum_Bett": "24.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "26.02.2023",
+        "Fallzahl": 280953,
+        "ObjectId": 1087,
+        "Sterbefall": 1888,
+        "Genesungsfall": 278411,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7689,
+        "Zuwachs_Fallzahl": 13,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 12,
+        "BelegteBetten": null,
+        "Inzidenz": 57.1141204784655,
+        "Datum_neu": 1677369600000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "19.02.2023 - 25.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 45.9,
+        "Fallzahl_aktiv": 654,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.52,
+        "H_Zeitraum": "14.02.2023-20.02.2017",
+        "H_Datum": "21.02.2023",
+        "Datum_Bett": "25.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "27.02.2023",
+        "Fallzahl": 280998,
+        "ObjectId": 1088,
+        "Sterbefall": 1888,
+        "Genesungsfall": 278463,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7693,
+        "Zuwachs_Fallzahl": 45,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 52,
+        "BelegteBetten": null,
+        "Inzidenz": 57.6529329358095,
+        "Datum_neu": 1677456000000,
+        "F\u00e4lle_Meldedatum": 45,
+        "Zeitraum": "20.02.2023 - 26.02.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 44.3,
+        "Fallzahl_aktiv": 647,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -7,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.93,
+        "H_Zeitraum": "14.02.2023-20.02.2018",
+        "H_Datum": "21.02.2023",
+        "Datum_Bett": "26.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "28.02.2023",
+        "Fallzahl": 281037,
+        "ObjectId": 1089,
+        "Sterbefall": 1888,
+        "Genesungsfall": 278533,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7693,
+        "Zuwachs_Fallzahl": 336,
+        "Zuwachs_Sterbefall": 1,
+        "Zuwachs_Krankenhauseinweisung": 45,
+        "Zuwachs_Genesung": 314,
+        "BelegteBetten": null,
+        "Inzidenz": 53.8812457344014,
+        "Datum_neu": 1677542400000,
+        "F\u00e4lle_Meldedatum": 39,
+        "Zeitraum": "21.02.2023 - 27.02.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 44.8,
+        "Fallzahl_aktiv": 616,
+        "Krh_N_belegt": 401,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 21,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.82,
+        "H_Zeitraum": "14.02.2023-20.02.2019",
+        "H_Datum": "21.02.2023",
+        "Datum_Bett": "27.02.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
