### PR TITLE
New data set: 2023-03-07T110104Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-02-28T121604Z.json
+pjson/2023-03-07T110104Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-02-28T121604Z.json pjson/2023-03-07T110104Z.json```:
```
--- pjson/2023-02-28T121604Z.json	2023-02-28 12:16:04.698526319 +0000
+++ pjson/2023-03-07T110104Z.json	2023-03-07 11:01:05.173948857 +0000
@@ -40596,7 +40596,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40786,7 +40786,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40976,7 +40976,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -41105,26 +41105,26 @@
         "Datum": "14.02.2023",
         "Fallzahl": 280424,
         "ObjectId": 1075,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277927,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7617,
-        "Zuwachs_Fallzahl": 354,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 22,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 391,
         "BelegteBetten": null,
-        "Inzidenz": 50.6483709903373,
+        "Inzidenz": null,
         "Datum_neu": 1676332800000,
         "F\u00e4lle_Meldedatum": 76,
-        "Zeitraum": "07.02.2023 - 13.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 610,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -37,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41143,28 +41143,28 @@
         "Datum": "15.02.2023",
         "Fallzahl": 280482,
         "ObjectId": 1076,
-        "Sterbefall": 1887,
-        "Genesungsfall": 277976,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7622,
-        "Zuwachs_Fallzahl": 58,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 49,
         "BelegteBetten": null,
-        "Inzidenz": 56.2160997162254,
+        "Inzidenz": null,
         "Datum_neu": 1676419200000,
         "F\u00e4lle_Meldedatum": 58,
-        "Zeitraum": "08.02.2023 - 14.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 619,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 9,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -41181,28 +41181,28 @@
         "Datum": "16.02.2023",
         "Fallzahl": 280546,
         "ObjectId": 1077,
-        "Sterbefall": 1887,
-        "Genesungsfall": 278032,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7631,
-        "Zuwachs_Fallzahl": 64,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
-        "Inzidenz": 55.3180789539854,
+        "Inzidenz": null,
         "Datum_neu": 1676505600000,
         "F\u00e4lle_Meldedatum": 64,
-        "Zeitraum": "09.02.2023 - 15.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 9,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 627,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 8,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
@@ -41219,28 +41219,28 @@
         "Datum": "17.02.2023",
         "Fallzahl": 280600,
         "ObjectId": 1078,
-        "Sterbefall": 1887,
-        "Genesungsfall": 278075,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7633,
-        "Zuwachs_Fallzahl": 54,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 58.7305578504975,
+        "Inzidenz": null,
         "Datum_neu": 1676592000000,
         "F\u00e4lle_Meldedatum": 55,
-        "Zeitraum": "10.02.2023 - 16.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 638,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 11,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
@@ -41257,26 +41257,26 @@
         "Datum": "18.02.2023",
         "Fallzahl": 280621,
         "ObjectId": 1079,
-        "Sterbefall": 1887,
-        "Genesungsfall": 278101,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7633,
-        "Zuwachs_Fallzahl": 21,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 26,
         "BelegteBetten": null,
-        "Inzidenz": 59.8081827651855,
+        "Inzidenz": null,
         "Datum_neu": 1676678400000,
         "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "11.02.2023 - 17.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 633,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -5,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41295,26 +41295,26 @@
         "Datum": "19.02.2023",
         "Fallzahl": 280629,
         "ObjectId": 1080,
-        "Sterbefall": 1887,
-        "Genesungsfall": 278113,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7633,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 12,
         "BelegteBetten": null,
-        "Inzidenz": 61.2450159847696,
+        "Inzidenz": null,
         "Datum_neu": 1676764800000,
         "F\u00e4lle_Meldedatum": 10,
-        "Zeitraum": "12.02.2023 - 18.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 629,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -4,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41333,36 +41333,36 @@
         "Datum": "20.02.2023",
         "Fallzahl": 280692,
         "ObjectId": 1081,
-        "Sterbefall": 1887,
-        "Genesungsfall": 278174,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7648,
-        "Zuwachs_Fallzahl": 63,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 61,
         "BelegteBetten": null,
-        "Inzidenz": 61.2450159847696,
+        "Inzidenz": null,
         "Datum_neu": 1676851200000,
         "F\u00e4lle_Meldedatum": 66,
-        "Zeitraum": "13.02.2023 - 19.02.2023",
-        "Hosp_Meldedatum": 24,
-        "Inzidenz_RKI": 48.4,
-        "Fallzahl_aktiv": 631,
-        "Krh_N_belegt": 335,
-        "Krh_I_belegt": 28,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 23,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.1,
-        "H_Zeitraum": "13.02.2023-19.02.2023",
-        "H_Datum": "14.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "19.02.2023"
       }
     },
@@ -41371,26 +41371,26 @@
         "Datum": "21.02.2023",
         "Fallzahl": 280701,
         "ObjectId": 1082,
-        "Sterbefall": 1887,
-        "Genesungsfall": 278219,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7648,
-        "Zuwachs_Fallzahl": 9,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 45,
         "BelegteBetten": null,
-        "Inzidenz": 61.7838284421136,
+        "Inzidenz": null,
         "Datum_neu": 1676937600000,
-        "F\u00e4lle_Meldedatum": 76,
-        "Zeitraum": "14.02.2023 - 20.02.2023",
+        "F\u00e4lle_Meldedatum": 78,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 7,
-        "Inzidenz_RKI": 50.4,
-        "Fallzahl_aktiv": 595,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -36,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41398,9 +41398,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.77,
-        "H_Zeitraum": "14.02.2023-20.02.2012",
-        "H_Datum": "14.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "20.02.2023"
       }
     },
@@ -41409,36 +41409,36 @@
         "Datum": "22.02.2023",
         "Fallzahl": 280817,
         "ObjectId": 1083,
-        "Sterbefall": 1888,
-        "Genesungsfall": 278284,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7674,
-        "Zuwachs_Fallzahl": 116,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 26,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 65,
         "BelegteBetten": null,
-        "Inzidenz": 63.0410575092496,
+        "Inzidenz": null,
         "Datum_neu": 1677024000000,
         "F\u00e4lle_Meldedatum": 43,
-        "Zeitraum": "15.02.2023 - 21.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 49.9,
-        "Fallzahl_aktiv": 645,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 50,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.54,
-        "H_Zeitraum": "14.02.2023-20.02.2013",
-        "H_Datum": "21.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "21.02.2023"
       }
     },
@@ -41447,36 +41447,36 @@
         "Datum": "23.02.2023",
         "Fallzahl": 280882,
         "ObjectId": 1084,
-        "Sterbefall": 1888,
-        "Genesungsfall": 278339,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7683,
-        "Zuwachs_Fallzahl": 65,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 55,
         "BelegteBetten": null,
-        "Inzidenz": 60.3469952225296,
+        "Inzidenz": null,
         "Datum_neu": 1677110400000,
         "F\u00e4lle_Meldedatum": 65,
-        "Zeitraum": "16.02.2023 - 22.02.2023",
-        "Hosp_Meldedatum": 9,
-        "Inzidenz_RKI": 51.9,
-        "Fallzahl_aktiv": 655,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 8,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 10,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.69,
-        "H_Zeitraum": "14.02.2023-20.02.2014",
-        "H_Datum": "21.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "22.02.2023"
       }
     },
@@ -41485,36 +41485,36 @@
         "Datum": "24.02.2023",
         "Fallzahl": 280928,
         "ObjectId": 1085,
-        "Sterbefall": 1888,
-        "Genesungsfall": 278381,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7689,
-        "Zuwachs_Fallzahl": 46,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 6,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 42,
         "BelegteBetten": null,
-        "Inzidenz": 60.5265993749776,
+        "Inzidenz": null,
         "Datum_neu": 1677196800000,
         "F\u00e4lle_Meldedatum": 46,
-        "Zeitraum": "17.02.2023 - 23.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 6,
-        "Inzidenz_RKI": 49.3,
-        "Fallzahl_aktiv": 659,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 4,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.79,
-        "H_Zeitraum": "14.02.2023-20.02.2015",
-        "H_Datum": "21.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "23.02.2023"
       }
     },
@@ -41537,22 +41537,22 @@
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": "18.02.2023 - 24.02.2023",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 49.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 653,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": -6,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.64,
-        "H_Zeitraum": "14.02.2023-20.02.2016",
-        "H_Datum": "21.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "24.02.2023"
       }
     },
@@ -41575,22 +41575,22 @@
         "F\u00e4lle_Meldedatum": 13,
         "Zeitraum": "19.02.2023 - 25.02.2023",
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 45.9,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": 654,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": 1,
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.52,
-        "H_Zeitraum": "14.02.2023-20.02.2017",
-        "H_Datum": "21.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "25.02.2023"
       }
     },
@@ -41612,7 +41612,7 @@
         "Datum_neu": 1677456000000,
         "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": "20.02.2023 - 26.02.2023",
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 11,
         "Inzidenz_RKI": 44.3,
         "Fallzahl_aktiv": 647,
         "Krh_N_belegt": 401,
@@ -41626,8 +41626,8 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.93,
-        "H_Zeitraum": "14.02.2023-20.02.2018",
+        "H_Inzidenz": 8.51,
+        "H_Zeitraum": "20.02.2023 - 26.02.2023",
         "H_Datum": "21.02.2023",
         "Datum_Bett": "26.02.2023"
       }
@@ -41639,36 +41639,302 @@
         "ObjectId": 1089,
         "Sterbefall": 1888,
         "Genesungsfall": 278533,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7693,
-        "Zuwachs_Fallzahl": 336,
-        "Zuwachs_Sterbefall": 1,
-        "Zuwachs_Krankenhauseinweisung": 45,
-        "Zuwachs_Genesung": 314,
+        "Zuwachs_Fallzahl": 39,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 70,
         "BelegteBetten": null,
         "Inzidenz": 53.8812457344014,
         "Datum_neu": 1677542400000,
-        "F\u00e4lle_Meldedatum": 39,
+        "F\u00e4lle_Meldedatum": 80,
         "Zeitraum": "21.02.2023 - 27.02.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 1,
         "Inzidenz_RKI": 44.8,
         "Fallzahl_aktiv": 616,
         "Krh_N_belegt": 401,
         "Krh_I_belegt": 36,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 21,
+        "Fallzahl_aktiv_Zuwachs": -31,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.82,
-        "H_Zeitraum": "14.02.2023-20.02.2019",
+        "H_Inzidenz": 7.52,
+        "H_Zeitraum": "21.02.2023 - 27.02.2023",
         "H_Datum": "21.02.2023",
         "Datum_Bett": "27.02.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "01.03.2023",
+        "Fallzahl": 281102,
+        "ObjectId": 1090,
+        "Sterbefall": 1893,
+        "Genesungsfall": 278592,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7704,
+        "Zuwachs_Fallzahl": 65,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 59,
+        "BelegteBetten": null,
+        "Inzidenz": 54.5996623441934,
+        "Datum_neu": 1677628800000,
+        "F\u00e4lle_Meldedatum": 22,
+        "Zeitraum": "22.02.2023 - 28.02.2023",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 46.1,
+        "Fallzahl_aktiv": 617,
+        "Krh_N_belegt": 442,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 1,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.4,
+        "H_Zeitraum": "22.02.2023 - 28.02.2023",
+        "H_Datum": "28.02.2023",
+        "Datum_Bett": "28.02.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "02.03.2023",
+        "Fallzahl": 281133,
+        "ObjectId": 1091,
+        "Sterbefall": 1893,
+        "Genesungsfall": 278650,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7708,
+        "Zuwachs_Fallzahl": 31,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 58,
+        "BelegteBetten": null,
+        "Inzidenz": 50.8279751427853,
+        "Datum_neu": 1677715200000,
+        "F\u00e4lle_Meldedatum": 31,
+        "Zeitraum": "23.02.2023 - 01.03.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 46.8,
+        "Fallzahl_aktiv": 590,
+        "Krh_N_belegt": 442,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -27,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.68,
+        "H_Zeitraum": "23.02.2023 - 01.03.2023",
+        "H_Datum": "28.02.2023",
+        "Datum_Bett": "01.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "03.03.2023",
+        "Fallzahl": 281168,
+        "ObjectId": 1092,
+        "Sterbefall": 1893,
+        "Genesungsfall": 278706,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7713,
+        "Zuwachs_Fallzahl": 35,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 56,
+        "BelegteBetten": null,
+        "Inzidenz": 44.7214339595531,
+        "Datum_neu": 1677801600000,
+        "F\u00e4lle_Meldedatum": 35,
+        "Zeitraum": "24.02.2023 - 02.03.2023",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 38.5,
+        "Fallzahl_aktiv": 569,
+        "Krh_N_belegt": 442,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -21,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.69,
+        "H_Zeitraum": "24.02.2023 - 02.03.2023",
+        "H_Datum": "28.02.2023",
+        "Datum_Bett": "02.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "04.03.2023",
+        "Fallzahl": 281176,
+        "ObjectId": 1093,
+        "Sterbefall": 1893,
+        "Genesungsfall": 278729,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7713,
+        "Zuwachs_Fallzahl": 8,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 23,
+        "BelegteBetten": null,
+        "Inzidenz": 42.7457882826251,
+        "Datum_neu": 1677888000000,
+        "F\u00e4lle_Meldedatum": 8,
+        "Zeitraum": "25.02.2023 - 03.03.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 36.2,
+        "Fallzahl_aktiv": 554,
+        "Krh_N_belegt": 442,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -15,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.65,
+        "H_Zeitraum": "25.02.2023 - 03.03.2023",
+        "H_Datum": "28.02.2023",
+        "Datum_Bett": "03.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "05.03.2023",
+        "Fallzahl": 281188,
+        "ObjectId": 1094,
+        "Sterbefall": 1893,
+        "Genesungsfall": 278743,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7713,
+        "Zuwachs_Fallzahl": 12,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 14,
+        "BelegteBetten": null,
+        "Inzidenz": 42.0273716728331,
+        "Datum_neu": 1677974400000,
+        "F\u00e4lle_Meldedatum": 12,
+        "Zeitraum": "26.02.2023 - 04.03.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 34,
+        "Fallzahl_aktiv": 552,
+        "Krh_N_belegt": 442,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.33,
+        "H_Zeitraum": "26.02.2023 - 04.03.2023",
+        "H_Datum": "28.02.2023",
+        "Datum_Bett": "04.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "06.03.2023",
+        "Fallzahl": 281229,
+        "ObjectId": 1095,
+        "Sterbefall": 1893,
+        "Genesungsfall": 278786,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7722,
+        "Zuwachs_Fallzahl": 41,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 9,
+        "Zuwachs_Genesung": 43,
+        "BelegteBetten": null,
+        "Inzidenz": 41.8477675203851,
+        "Datum_neu": 1678060800000,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": "27.02.2023 - 05.03.2023",
+        "Hosp_Meldedatum": 9,
+        "Inzidenz_RKI": 31.7,
+        "Fallzahl_aktiv": 550,
+        "Krh_N_belegt": 442,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 4.2,
+        "H_Zeitraum": "27.02.2023 - 05.03.2023",
+        "H_Datum": "28.02.2023",
+        "Datum_Bett": "05.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "07.03.2023",
+        "Fallzahl": 281239,
+        "ObjectId": 1096,
+        "Sterbefall": 1893,
+        "Genesungsfall": 278858,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7726,
+        "Zuwachs_Fallzahl": 202,
+        "Zuwachs_Sterbefall": 5,
+        "Zuwachs_Krankenhauseinweisung": 33,
+        "Zuwachs_Genesung": 325,
+        "BelegteBetten": null,
+        "Inzidenz": 41.129350910593,
+        "Datum_neu": 1678147200000,
+        "F\u00e4lle_Meldedatum": 10,
+        "Zeitraum": "28.02.2023 - 06.03.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 33.5,
+        "Fallzahl_aktiv": 488,
+        "Krh_N_belegt": 442,
+        "Krh_I_belegt": 36,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -128,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 2.84,
+        "H_Zeitraum": "28.02.2023 - 06.03.2023",
+        "H_Datum": "28.02.2023",
+        "Datum_Bett": "06.03.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
