### PR TITLE
New data set: 2023-03-14T105303Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-03-07T110104Z.json
+pjson/2023-03-14T105303Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-03-07T110104Z.json pjson/2023-03-14T105303Z.json```:
```
--- pjson/2023-03-07T110104Z.json	2023-03-07 11:01:05.173948857 +0000
+++ pjson/2023-03-14T105303Z.json	2023-03-14 10:53:04.191854290 +0000
@@ -38848,7 +38848,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40282,7 +40282,7 @@
         "Datum_neu": 1674432000000,
         "F\u00e4lle_Meldedatum": 73,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -41458,7 +41458,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1677110400000,
-        "F\u00e4lle_Meldedatum": 65,
+        "F\u00e4lle_Meldedatum": 62,
         "Zeitraum": null,
         "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
@@ -41523,26 +41523,26 @@
         "Datum": "25.02.2023",
         "Fallzahl": 280940,
         "ObjectId": 1086,
-        "Sterbefall": 1888,
-        "Genesungsfall": 278399,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7689,
-        "Zuwachs_Fallzahl": 12,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 18,
         "BelegteBetten": null,
-        "Inzidenz": 58.9101620029455,
+        "Inzidenz": null,
         "Datum_neu": 1677283200000,
         "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "18.02.2023 - 24.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 653,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -6,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41561,28 +41561,28 @@
         "Datum": "26.02.2023",
         "Fallzahl": 280953,
         "ObjectId": 1087,
-        "Sterbefall": 1888,
-        "Genesungsfall": 278411,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7689,
-        "Zuwachs_Fallzahl": 13,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 12,
         "BelegteBetten": null,
-        "Inzidenz": 57.1141204784655,
+        "Inzidenz": null,
         "Datum_neu": 1677369600000,
         "F\u00e4lle_Meldedatum": 13,
-        "Zeitraum": "19.02.2023 - 25.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": null,
-        "Fallzahl_aktiv": 654,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
         "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
@@ -41599,26 +41599,26 @@
         "Datum": "27.02.2023",
         "Fallzahl": 280998,
         "ObjectId": 1088,
-        "Sterbefall": 1888,
-        "Genesungsfall": 278463,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7693,
-        "Zuwachs_Fallzahl": 45,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 52,
         "BelegteBetten": null,
-        "Inzidenz": 57.6529329358095,
+        "Inzidenz": null,
         "Datum_neu": 1677456000000,
         "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "20.02.2023 - 26.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 11,
-        "Inzidenz_RKI": 44.3,
-        "Fallzahl_aktiv": 647,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -7,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41626,9 +41626,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 8.51,
-        "H_Zeitraum": "20.02.2023 - 26.02.2023",
-        "H_Datum": "21.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "26.02.2023"
       }
     },
@@ -41637,26 +41637,26 @@
         "Datum": "28.02.2023",
         "Fallzahl": 281037,
         "ObjectId": 1089,
-        "Sterbefall": 1888,
-        "Genesungsfall": 278533,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7693,
-        "Zuwachs_Fallzahl": 39,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 70,
         "BelegteBetten": null,
-        "Inzidenz": 53.8812457344014,
+        "Inzidenz": null,
         "Datum_neu": 1677542400000,
         "F\u00e4lle_Meldedatum": 80,
-        "Zeitraum": "21.02.2023 - 27.02.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 1,
-        "Inzidenz_RKI": 44.8,
-        "Fallzahl_aktiv": 616,
-        "Krh_N_belegt": 401,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -31,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41664,9 +41664,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.52,
-        "H_Zeitraum": "21.02.2023 - 27.02.2023",
-        "H_Datum": "21.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "27.02.2023"
       }
     },
@@ -41675,36 +41675,36 @@
         "Datum": "01.03.2023",
         "Fallzahl": 281102,
         "ObjectId": 1090,
-        "Sterbefall": 1893,
-        "Genesungsfall": 278592,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7704,
-        "Zuwachs_Fallzahl": 65,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 11,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 59,
         "BelegteBetten": null,
-        "Inzidenz": 54.5996623441934,
+        "Inzidenz": null,
         "Datum_neu": 1677628800000,
-        "F\u00e4lle_Meldedatum": 22,
-        "Zeitraum": "22.02.2023 - 28.02.2023",
+        "F\u00e4lle_Meldedatum": 23,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 46.1,
-        "Fallzahl_aktiv": 617,
-        "Krh_N_belegt": 442,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 1,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 7.4,
-        "H_Zeitraum": "22.02.2023 - 28.02.2023",
-        "H_Datum": "28.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "28.02.2023"
       }
     },
@@ -41713,26 +41713,26 @@
         "Datum": "02.03.2023",
         "Fallzahl": 281133,
         "ObjectId": 1091,
-        "Sterbefall": 1893,
-        "Genesungsfall": 278650,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7708,
-        "Zuwachs_Fallzahl": 31,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 58,
         "BelegteBetten": null,
-        "Inzidenz": 50.8279751427853,
+        "Inzidenz": null,
         "Datum_neu": 1677715200000,
         "F\u00e4lle_Meldedatum": 31,
-        "Zeitraum": "23.02.2023 - 01.03.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 46.8,
-        "Fallzahl_aktiv": 590,
-        "Krh_N_belegt": 442,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -27,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41740,9 +41740,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 6.68,
-        "H_Zeitraum": "23.02.2023 - 01.03.2023",
-        "H_Datum": "28.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "01.03.2023"
       }
     },
@@ -41751,26 +41751,26 @@
         "Datum": "03.03.2023",
         "Fallzahl": 281168,
         "ObjectId": 1092,
-        "Sterbefall": 1893,
-        "Genesungsfall": 278706,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7713,
-        "Zuwachs_Fallzahl": 35,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 56,
         "BelegteBetten": null,
-        "Inzidenz": 44.7214339595531,
+        "Inzidenz": null,
         "Datum_neu": 1677801600000,
-        "F\u00e4lle_Meldedatum": 35,
-        "Zeitraum": "24.02.2023 - 02.03.2023",
+        "F\u00e4lle_Meldedatum": 36,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 38.5,
-        "Fallzahl_aktiv": 569,
-        "Krh_N_belegt": 442,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -21,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41778,9 +41778,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.69,
-        "H_Zeitraum": "24.02.2023 - 02.03.2023",
-        "H_Datum": "28.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "02.03.2023"
       }
     },
@@ -41789,26 +41789,26 @@
         "Datum": "04.03.2023",
         "Fallzahl": 281176,
         "ObjectId": 1093,
-        "Sterbefall": 1893,
-        "Genesungsfall": 278729,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7713,
-        "Zuwachs_Fallzahl": 8,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 23,
         "BelegteBetten": null,
-        "Inzidenz": 42.7457882826251,
+        "Inzidenz": null,
         "Datum_neu": 1677888000000,
         "F\u00e4lle_Meldedatum": 8,
-        "Zeitraum": "25.02.2023 - 03.03.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 36.2,
-        "Fallzahl_aktiv": 554,
-        "Krh_N_belegt": 442,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -15,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41816,9 +41816,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.65,
-        "H_Zeitraum": "25.02.2023 - 03.03.2023",
-        "H_Datum": "28.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "03.03.2023"
       }
     },
@@ -41827,26 +41827,26 @@
         "Datum": "05.03.2023",
         "Fallzahl": 281188,
         "ObjectId": 1094,
-        "Sterbefall": 1893,
-        "Genesungsfall": 278743,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7713,
-        "Zuwachs_Fallzahl": 12,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 14,
         "BelegteBetten": null,
-        "Inzidenz": 42.0273716728331,
+        "Inzidenz": null,
         "Datum_neu": 1677974400000,
         "F\u00e4lle_Meldedatum": 12,
         "Zeitraum": "26.02.2023 - 04.03.2023",
         "Hosp_Meldedatum": 0,
         "Inzidenz_RKI": 34,
-        "Fallzahl_aktiv": 552,
+        "Fallzahl_aktiv": null,
         "Krh_N_belegt": 442,
         "Krh_I_belegt": 36,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41854,7 +41854,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.33,
+        "H_Inzidenz": 5.96,
         "H_Zeitraum": "26.02.2023 - 04.03.2023",
         "H_Datum": "28.02.2023",
         "Datum_Bett": "04.03.2023"
@@ -41878,7 +41878,7 @@
         "Datum_neu": 1678060800000,
         "F\u00e4lle_Meldedatum": 41,
         "Zeitraum": "27.02.2023 - 05.03.2023",
-        "Hosp_Meldedatum": 9,
+        "Hosp_Meldedatum": 18,
         "Inzidenz_RKI": 31.7,
         "Fallzahl_aktiv": 550,
         "Krh_N_belegt": 442,
@@ -41892,7 +41892,7 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 4.2,
+        "H_Inzidenz": 5.99,
         "H_Zeitraum": "27.02.2023 - 05.03.2023",
         "H_Datum": "28.02.2023",
         "Datum_Bett": "05.03.2023"
@@ -41905,24 +41905,24 @@
         "ObjectId": 1096,
         "Sterbefall": 1893,
         "Genesungsfall": 278858,
-        "Anzeige_Indikator": "x",
+        "Anzeige_Indikator": null,
         "Hospitalisierung": 7726,
-        "Zuwachs_Fallzahl": 202,
-        "Zuwachs_Sterbefall": 5,
-        "Zuwachs_Krankenhauseinweisung": 33,
-        "Zuwachs_Genesung": 325,
+        "Zuwachs_Fallzahl": 10,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 4,
+        "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
         "Inzidenz": 41.129350910593,
         "Datum_neu": 1678147200000,
-        "F\u00e4lle_Meldedatum": 10,
+        "F\u00e4lle_Meldedatum": 45,
         "Zeitraum": "28.02.2023 - 06.03.2023",
-        "Hosp_Meldedatum": 4,
+        "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": 33.5,
         "Fallzahl_aktiv": 488,
         "Krh_N_belegt": 442,
         "Krh_I_belegt": 36,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -128,
+        "Fallzahl_aktiv_Zuwachs": -62,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41930,11 +41930,277 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 2.84,
+        "H_Inzidenz": 5.81,
         "H_Zeitraum": "28.02.2023 - 06.03.2023",
         "H_Datum": "28.02.2023",
         "Datum_Bett": "06.03.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "08.03.2023",
+        "Fallzahl": 281307,
+        "ObjectId": 1097,
+        "Sterbefall": 1896,
+        "Genesungsfall": 278895,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7741,
+        "Zuwachs_Fallzahl": 68,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 15,
+        "Zuwachs_Genesung": 37,
+        "BelegteBetten": null,
+        "Inzidenz": 35.2024138798089,
+        "Datum_neu": 1678233600000,
+        "F\u00e4lle_Meldedatum": 34,
+        "Zeitraum": "01.03.2023 - 07.03.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 28.6,
+        "Fallzahl_aktiv": 516,
+        "Krh_N_belegt": 434,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 28,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.44,
+        "H_Zeitraum": "01.03.2023 - 07.03.2023",
+        "H_Datum": "07.03.2023",
+        "Datum_Bett": "07.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "09.03.2023",
+        "Fallzahl": 281340,
+        "ObjectId": 1098,
+        "Sterbefall": 1896,
+        "Genesungsfall": 278949,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7743,
+        "Zuwachs_Fallzahl": 33,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 2,
+        "Zuwachs_Genesung": 54,
+        "BelegteBetten": null,
+        "Inzidenz": 37.178059556737,
+        "Datum_neu": 1678320000000,
+        "F\u00e4lle_Meldedatum": 33,
+        "Zeitraum": "02.03.2023 - 08.03.2023",
+        "Hosp_Meldedatum": 2,
+        "Inzidenz_RKI": 31,
+        "Fallzahl_aktiv": 495,
+        "Krh_N_belegt": 434,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -21,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.74,
+        "H_Zeitraum": "02.03.2023 - 08.03.2023",
+        "H_Datum": "07.03.2023",
+        "Datum_Bett": "08.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "10.03.2023",
+        "Fallzahl": 281381,
+        "ObjectId": 1099,
+        "Sterbefall": 1896,
+        "Genesungsfall": 278992,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7748,
+        "Zuwachs_Fallzahl": 41,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 43,
+        "BelegteBetten": null,
+        "Inzidenz": 37.537267861633,
+        "Datum_neu": 1678406400000,
+        "F\u00e4lle_Meldedatum": 41,
+        "Zeitraum": "03.03.2023 - 09.03.2023",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 31.9,
+        "Fallzahl_aktiv": 493,
+        "Krh_N_belegt": 434,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -2,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.71,
+        "H_Zeitraum": "03.03.2023 - 09.03.2023",
+        "H_Datum": "07.03.2023",
+        "Datum_Bett": "09.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "11.03.2023",
+        "Fallzahl": 281396,
+        "ObjectId": 1100,
+        "Sterbefall": 1896,
+        "Genesungsfall": 279004,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7748,
+        "Zuwachs_Fallzahl": 15,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 12,
+        "BelegteBetten": null,
+        "Inzidenz": 38.435288623873,
+        "Datum_neu": 1678492800000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "04.03.2023 - 10.03.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 31.3,
+        "Fallzahl_aktiv": 496,
+        "Krh_N_belegt": 434,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 3,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.49,
+        "H_Zeitraum": "04.03.2023 - 10.03.2023",
+        "H_Datum": "07.03.2023",
+        "Datum_Bett": "10.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "12.03.2023",
+        "Fallzahl": 281411,
+        "ObjectId": 1101,
+        "Sterbefall": 1896,
+        "Genesungsfall": 279023,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7748,
+        "Zuwachs_Fallzahl": 15,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 19,
+        "BelegteBetten": null,
+        "Inzidenz": 39.692517691009,
+        "Datum_neu": 1678579200000,
+        "F\u00e4lle_Meldedatum": 15,
+        "Zeitraum": "05.03.2023 - 11.03.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 29.9,
+        "Fallzahl_aktiv": 492,
+        "Krh_N_belegt": 434,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -4,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.29,
+        "H_Zeitraum": "05.03.2023 - 11.03.2023",
+        "H_Datum": "07.03.2023",
+        "Datum_Bett": "11.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "13.03.2023",
+        "Fallzahl": 281457,
+        "ObjectId": 1102,
+        "Sterbefall": 1896,
+        "Genesungsfall": 279057,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7751,
+        "Zuwachs_Fallzahl": 46,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 3,
+        "Zuwachs_Genesung": 34,
+        "BelegteBetten": null,
+        "Inzidenz": 40.231330148353,
+        "Datum_neu": 1678665600000,
+        "F\u00e4lle_Meldedatum": 46,
+        "Zeitraum": "06.03.2023 - 12.03.2023",
+        "Hosp_Meldedatum": 3,
+        "Inzidenz_RKI": 27.7,
+        "Fallzahl_aktiv": 504,
+        "Krh_N_belegt": 434,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 12,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 5.1,
+        "H_Zeitraum": "06.03.2023 - 12.03.2023",
+        "H_Datum": "07.03.2023",
+        "Datum_Bett": "12.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "14.03.2023",
+        "Fallzahl": 281470,
+        "ObjectId": 1103,
+        "Sterbefall": 1896,
+        "Genesungsfall": 279136,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7751,
+        "Zuwachs_Fallzahl": 231,
+        "Zuwachs_Sterbefall": 3,
+        "Zuwachs_Krankenhauseinweisung": 25,
+        "Zuwachs_Genesung": 278,
+        "BelegteBetten": null,
+        "Inzidenz": 41.129350910593,
+        "Datum_neu": 1678752000000,
+        "F\u00e4lle_Meldedatum": 13,
+        "Zeitraum": "07.03.2023 - 13.03.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 32.4,
+        "Fallzahl_aktiv": 438,
+        "Krh_N_belegt": 434,
+        "Krh_I_belegt": 28,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -50,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 3.93,
+        "H_Zeitraum": "07.03.2023 - 13.03.2023",
+        "H_Datum": "07.03.2023",
+        "Datum_Bett": "13.03.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
