### PR TITLE
New data set: 2023-03-21T110504Z

### DIFF
--- a/latest-json
+++ b/latest-json
@@ -1,1 +1,1 @@
-pjson/2023-03-14T105303Z.json
+pjson/2023-03-21T110504Z.json


### PR DESCRIPTION
Hi there! This pull request was *automatically* triggered by a **newly published data** set.

The following changes have been made:

```diff -u pjson/2023-03-14T105303Z.json pjson/2023-03-21T110504Z.json```:
```
--- pjson/2023-03-14T105303Z.json	2023-03-14 10:53:04.191854290 +0000
+++ pjson/2023-03-21T110504Z.json	2023-03-21 11:05:04.470664532 +0000
@@ -39684,7 +39684,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -39722,7 +39722,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 2,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40178,7 +40178,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40558,7 +40558,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -40748,7 +40748,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -41318,7 +41318,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -41384,7 +41384,7 @@
         "Datum_neu": 1676937600000,
         "F\u00e4lle_Meldedatum": 78,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 7,
+        "Hosp_Meldedatum": 8,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -41546,7 +41546,7 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 1,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
@@ -41686,7 +41686,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1677628800000,
-        "F\u00e4lle_Meldedatum": 23,
+        "F\u00e4lle_Meldedatum": 24,
         "Zeitraum": null,
         "Hosp_Meldedatum": 5,
         "Inzidenz_RKI": null,
@@ -41724,7 +41724,7 @@
         "BelegteBetten": null,
         "Inzidenz": null,
         "Datum_neu": 1677715200000,
-        "F\u00e4lle_Meldedatum": 31,
+        "F\u00e4lle_Meldedatum": 32,
         "Zeitraum": null,
         "Hosp_Meldedatum": 4,
         "Inzidenz_RKI": null,
@@ -41764,7 +41764,7 @@
         "Datum_neu": 1677801600000,
         "F\u00e4lle_Meldedatum": 36,
         "Zeitraum": null,
-        "Hosp_Meldedatum": 5,
+        "Hosp_Meldedatum": 6,
         "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
         "Krh_N_belegt": null,
@@ -41839,24 +41839,24 @@
         "Inzidenz": null,
         "Datum_neu": 1677974400000,
         "F\u00e4lle_Meldedatum": 12,
-        "Zeitraum": "26.02.2023 - 04.03.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 34,
+        "Inzidenz_RKI": null,
         "Fallzahl_aktiv": null,
-        "Krh_N_belegt": 442,
-        "Krh_I_belegt": 36,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
         "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 3,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.96,
-        "H_Zeitraum": "26.02.2023 - 04.03.2023",
-        "H_Datum": "28.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "04.03.2023"
       }
     },
@@ -41865,36 +41865,36 @@
         "Datum": "06.03.2023",
         "Fallzahl": 281229,
         "ObjectId": 1095,
-        "Sterbefall": 1893,
-        "Genesungsfall": 278786,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7722,
-        "Zuwachs_Fallzahl": 41,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 9,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 41.8477675203851,
+        "Inzidenz": null,
         "Datum_neu": 1678060800000,
         "F\u00e4lle_Meldedatum": 41,
-        "Zeitraum": "27.02.2023 - 05.03.2023",
-        "Hosp_Meldedatum": 18,
-        "Inzidenz_RKI": 31.7,
-        "Fallzahl_aktiv": 550,
-        "Krh_N_belegt": 442,
-        "Krh_I_belegt": 36,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 16,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.99,
-        "H_Zeitraum": "27.02.2023 - 05.03.2023",
-        "H_Datum": "28.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "05.03.2023"
       }
     },
@@ -41903,26 +41903,26 @@
         "Datum": "07.03.2023",
         "Fallzahl": 281239,
         "ObjectId": 1096,
-        "Sterbefall": 1893,
-        "Genesungsfall": 278858,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7726,
-        "Zuwachs_Fallzahl": 10,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 4,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 72,
         "BelegteBetten": null,
-        "Inzidenz": 41.129350910593,
+        "Inzidenz": null,
         "Datum_neu": 1678147200000,
         "F\u00e4lle_Meldedatum": 45,
-        "Zeitraum": "28.02.2023 - 06.03.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 33.5,
-        "Fallzahl_aktiv": 488,
-        "Krh_N_belegt": 442,
-        "Krh_I_belegt": 36,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -62,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -41930,9 +41930,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.81,
-        "H_Zeitraum": "28.02.2023 - 06.03.2023",
-        "H_Datum": "28.02.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "06.03.2023"
       }
     },
@@ -41941,36 +41941,36 @@
         "Datum": "08.03.2023",
         "Fallzahl": 281307,
         "ObjectId": 1097,
-        "Sterbefall": 1896,
-        "Genesungsfall": 278895,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7741,
-        "Zuwachs_Fallzahl": 68,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 15,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 37,
         "BelegteBetten": null,
-        "Inzidenz": 35.2024138798089,
+        "Inzidenz": null,
         "Datum_neu": 1678233600000,
         "F\u00e4lle_Meldedatum": 34,
-        "Zeitraum": "01.03.2023 - 07.03.2023",
-        "Hosp_Meldedatum": 4,
-        "Inzidenz_RKI": 28.6,
-        "Fallzahl_aktiv": 516,
-        "Krh_N_belegt": 434,
-        "Krh_I_belegt": 28,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 28,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.44,
-        "H_Zeitraum": "01.03.2023 - 07.03.2023",
-        "H_Datum": "07.03.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "07.03.2023"
       }
     },
@@ -41979,36 +41979,36 @@
         "Datum": "09.03.2023",
         "Fallzahl": 281340,
         "ObjectId": 1098,
-        "Sterbefall": 1896,
-        "Genesungsfall": 278949,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7743,
-        "Zuwachs_Fallzahl": 33,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 2,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 54,
         "BelegteBetten": null,
-        "Inzidenz": 37.178059556737,
+        "Inzidenz": null,
         "Datum_neu": 1678320000000,
         "F\u00e4lle_Meldedatum": 33,
-        "Zeitraum": "02.03.2023 - 08.03.2023",
+        "Zeitraum": null,
         "Hosp_Meldedatum": 2,
-        "Inzidenz_RKI": 31,
-        "Fallzahl_aktiv": 495,
-        "Krh_N_belegt": 434,
-        "Krh_I_belegt": 28,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -21,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 2,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.74,
-        "H_Zeitraum": "02.03.2023 - 08.03.2023",
-        "H_Datum": "07.03.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "08.03.2023"
       }
     },
@@ -42017,26 +42017,26 @@
         "Datum": "10.03.2023",
         "Fallzahl": 281381,
         "ObjectId": 1099,
-        "Sterbefall": 1896,
-        "Genesungsfall": 278992,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7748,
-        "Zuwachs_Fallzahl": 41,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 5,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 43,
         "BelegteBetten": null,
-        "Inzidenz": 37.537267861633,
+        "Inzidenz": null,
         "Datum_neu": 1678406400000,
         "F\u00e4lle_Meldedatum": 41,
-        "Zeitraum": "03.03.2023 - 09.03.2023",
-        "Hosp_Meldedatum": 5,
-        "Inzidenz_RKI": 31.9,
-        "Fallzahl_aktiv": 493,
-        "Krh_N_belegt": 434,
-        "Krh_I_belegt": 28,
+        "Zeitraum": null,
+        "Hosp_Meldedatum": 7,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -2,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -42044,9 +42044,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.71,
-        "H_Zeitraum": "03.03.2023 - 09.03.2023",
-        "H_Datum": "07.03.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "09.03.2023"
       }
     },
@@ -42055,36 +42055,36 @@
         "Datum": "11.03.2023",
         "Fallzahl": 281396,
         "ObjectId": 1100,
-        "Sterbefall": 1896,
-        "Genesungsfall": 279004,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7748,
-        "Zuwachs_Fallzahl": 15,
-        "Zuwachs_Sterbefall": 0,
-        "Zuwachs_Krankenhauseinweisung": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
+        "Zuwachs_Krankenhauseinweisung": null,
         "Zuwachs_Genesung": 12,
         "BelegteBetten": null,
-        "Inzidenz": 38.435288623873,
+        "Inzidenz": null,
         "Datum_neu": 1678492800000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "04.03.2023 - 10.03.2023",
+        "F\u00e4lle_Meldedatum": 16,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 31.3,
-        "Fallzahl_aktiv": 496,
-        "Krh_N_belegt": 434,
-        "Krh_I_belegt": 28,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": 3,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
-        "Vorz_akt_Faelle": "+",
+        "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
         "SterbeF_Sterbedatum": 0,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.49,
-        "H_Zeitraum": "04.03.2023 - 10.03.2023",
-        "H_Datum": "07.03.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "10.03.2023"
       }
     },
@@ -42093,26 +42093,26 @@
         "Datum": "12.03.2023",
         "Fallzahl": 281411,
         "ObjectId": 1101,
-        "Sterbefall": 1896,
-        "Genesungsfall": 279023,
+        "Sterbefall": null,
+        "Genesungsfall": null,
         "Anzeige_Indikator": null,
-        "Hospitalisierung": 7748,
-        "Zuwachs_Fallzahl": 15,
-        "Zuwachs_Sterbefall": 0,
+        "Hospitalisierung": null,
+        "Zuwachs_Fallzahl": null,
+        "Zuwachs_Sterbefall": null,
         "Zuwachs_Krankenhauseinweisung": 0,
         "Zuwachs_Genesung": 19,
         "BelegteBetten": null,
-        "Inzidenz": 39.692517691009,
+        "Inzidenz": null,
         "Datum_neu": 1678579200000,
-        "F\u00e4lle_Meldedatum": 15,
-        "Zeitraum": "05.03.2023 - 11.03.2023",
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": null,
         "Hosp_Meldedatum": 0,
-        "Inzidenz_RKI": 29.9,
-        "Fallzahl_aktiv": 492,
-        "Krh_N_belegt": 434,
-        "Krh_I_belegt": 28,
+        "Inzidenz_RKI": null,
+        "Fallzahl_aktiv": null,
+        "Krh_N_belegt": null,
+        "Krh_I_belegt": null,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -4,
+        "Fallzahl_aktiv_Zuwachs": null,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -42120,9 +42120,9 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.29,
-        "H_Zeitraum": "05.03.2023 - 11.03.2023",
-        "H_Datum": "07.03.2023",
+        "H_Inzidenz": null,
+        "H_Zeitraum": null,
+        "H_Datum": null,
         "Datum_Bett": "11.03.2023"
       }
     },
@@ -42132,7 +42132,7 @@
         "Fallzahl": 281457,
         "ObjectId": 1102,
         "Sterbefall": 1896,
-        "Genesungsfall": 279057,
+        "Genesungsfall": 279043,
         "Anzeige_Indikator": null,
         "Hospitalisierung": 7751,
         "Zuwachs_Fallzahl": 46,
@@ -42142,11 +42142,11 @@
         "BelegteBetten": null,
         "Inzidenz": 40.231330148353,
         "Datum_neu": 1678665600000,
-        "F\u00e4lle_Meldedatum": 46,
+        "F\u00e4lle_Meldedatum": 47,
         "Zeitraum": "06.03.2023 - 12.03.2023",
-        "Hosp_Meldedatum": 3,
+        "Hosp_Meldedatum": 10,
         "Inzidenz_RKI": 27.7,
-        "Fallzahl_aktiv": 504,
+        "Fallzahl_aktiv": 518,
         "Krh_N_belegt": 434,
         "Krh_I_belegt": 28,
         "Krh_I_frei": null,
@@ -42154,13 +42154,13 @@
         "Krh_I": null,
         "Vorz_akt_Faelle": "+",
         "Krh_I_covid": null,
-        "SterbeF_Sterbedatum": 0,
+        "SterbeF_Sterbedatum": 1,
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 5.1,
+        "H_Inzidenz": 7,
         "H_Zeitraum": "06.03.2023 - 12.03.2023",
-        "H_Datum": "07.03.2023",
+        "H_Datum": "14.03.2023",
         "Datum_Bett": "12.03.2023"
       }
     },
@@ -42170,25 +42170,25 @@
         "Fallzahl": 281470,
         "ObjectId": 1103,
         "Sterbefall": 1896,
-        "Genesungsfall": 279136,
-        "Anzeige_Indikator": "x",
-        "Hospitalisierung": 7751,
-        "Zuwachs_Fallzahl": 231,
-        "Zuwachs_Sterbefall": 3,
-        "Zuwachs_Krankenhauseinweisung": 25,
-        "Zuwachs_Genesung": 278,
+        "Genesungsfall": 279122,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7764,
+        "Zuwachs_Fallzahl": 13,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 13,
+        "Zuwachs_Genesung": 79,
         "BelegteBetten": null,
         "Inzidenz": 41.129350910593,
         "Datum_neu": 1678752000000,
-        "F\u00e4lle_Meldedatum": 13,
+        "F\u00e4lle_Meldedatum": 64,
         "Zeitraum": "07.03.2023 - 13.03.2023",
-        "Hosp_Meldedatum": 0,
+        "Hosp_Meldedatum": 2,
         "Inzidenz_RKI": 32.4,
-        "Fallzahl_aktiv": 438,
-        "Krh_N_belegt": 434,
-        "Krh_I_belegt": 28,
+        "Fallzahl_aktiv": 452,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
         "Krh_I_frei": null,
-        "Fallzahl_aktiv_Zuwachs": -50,
+        "Fallzahl_aktiv_Zuwachs": -66,
         "Krh_I": null,
         "Vorz_akt_Faelle": null,
         "Krh_I_covid": null,
@@ -42196,11 +42196,277 @@
         "Inzi_SN_RKI": null,
         "Mutation": null,
         "Zuwachs_Mutation": null,
-        "H_Inzidenz": 3.93,
+        "H_Inzidenz": 7.32,
         "H_Zeitraum": "07.03.2023 - 13.03.2023",
-        "H_Datum": "07.03.2023",
+        "H_Datum": "14.03.2023",
         "Datum_Bett": "13.03.2023"
       }
+    },
+    {
+      "attributes": {
+        "Datum": "15.03.2023",
+        "Fallzahl": 281561,
+        "ObjectId": 1104,
+        "Sterbefall": 1910,
+        "Genesungsfall": 279151,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7775,
+        "Zuwachs_Fallzahl": 91,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 11,
+        "Zuwachs_Genesung": 29,
+        "BelegteBetten": null,
+        "Inzidenz": 44.7214339595531,
+        "Datum_neu": 1678838400000,
+        "F\u00e4lle_Meldedatum": 37,
+        "Zeitraum": "08.03.2023 - 14.03.2023",
+        "Hosp_Meldedatum": 11,
+        "Inzidenz_RKI": 33.7,
+        "Fallzahl_aktiv": 500,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 48,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.89,
+        "H_Zeitraum": "08.03.2023 - 14.03.2023",
+        "H_Datum": "14.03.2023",
+        "Datum_Bett": "14.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "16.03.2023",
+        "Fallzahl": 281610,
+        "ObjectId": 1105,
+        "Sterbefall": 1910,
+        "Genesungsfall": 279184,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7781,
+        "Zuwachs_Fallzahl": 49,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 33,
+        "BelegteBetten": null,
+        "Inzidenz": 45.2602464168972,
+        "Datum_neu": 1678924800000,
+        "F\u00e4lle_Meldedatum": 49,
+        "Zeitraum": "09.03.2023 - 15.03.2023",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 38.5,
+        "Fallzahl_aktiv": 516,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 16,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 8.01,
+        "H_Zeitraum": "09.03.2023 - 15.03.2023",
+        "H_Datum": "14.03.2023",
+        "Datum_Bett": "15.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "17.03.2023",
+        "Fallzahl": 281635,
+        "ObjectId": 1106,
+        "Sterbefall": 1910,
+        "Genesungsfall": 279219,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7787,
+        "Zuwachs_Fallzahl": 25,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 6,
+        "Zuwachs_Genesung": 35,
+        "BelegteBetten": null,
+        "Inzidenz": 48.1339128560652,
+        "Datum_neu": 1679011200000,
+        "F\u00e4lle_Meldedatum": 25,
+        "Zeitraum": "10.03.2023 - 16.03.2023",
+        "Hosp_Meldedatum": 6,
+        "Inzidenz_RKI": 38.9,
+        "Fallzahl_aktiv": 506,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": -10,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.84,
+        "H_Zeitraum": "10.03.2023 - 16.03.2023",
+        "H_Datum": "14.03.2023",
+        "Datum_Bett": "16.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "18.03.2023",
+        "Fallzahl": 281659,
+        "ObjectId": 1107,
+        "Sterbefall": 1910,
+        "Genesungsfall": 279236,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7787,
+        "Zuwachs_Fallzahl": 24,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 17,
+        "BelegteBetten": null,
+        "Inzidenz": 45.2602464168972,
+        "Datum_neu": 1679097600000,
+        "F\u00e4lle_Meldedatum": 24,
+        "Zeitraum": "11.03.2023 - 17.03.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 41.6,
+        "Fallzahl_aktiv": 513,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 7,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 7.07,
+        "H_Zeitraum": "11.03.2023 - 17.03.2023",
+        "H_Datum": "14.03.2023",
+        "Datum_Bett": "17.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "19.03.2023",
+        "Fallzahl": 281673,
+        "ObjectId": 1108,
+        "Sterbefall": 1910,
+        "Genesungsfall": 279250,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7787,
+        "Zuwachs_Fallzahl": 14,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 0,
+        "Zuwachs_Genesung": 14,
+        "BelegteBetten": null,
+        "Inzidenz": 46.6970796364812,
+        "Datum_neu": 1679184000000,
+        "F\u00e4lle_Meldedatum": 14,
+        "Zeitraum": "12.03.2023 - 18.03.2023",
+        "Hosp_Meldedatum": 0,
+        "Inzidenz_RKI": 38.7,
+        "Fallzahl_aktiv": 513,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 0,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": null,
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.75,
+        "H_Zeitraum": "12.03.2023 - 18.03.2023",
+        "H_Datum": "14.03.2023",
+        "Datum_Bett": "18.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "20.03.2023",
+        "Fallzahl": 281705,
+        "ObjectId": 1109,
+        "Sterbefall": 1910,
+        "Genesungsfall": 279275,
+        "Anzeige_Indikator": null,
+        "Hospitalisierung": 7792,
+        "Zuwachs_Fallzahl": 32,
+        "Zuwachs_Sterbefall": 0,
+        "Zuwachs_Krankenhauseinweisung": 5,
+        "Zuwachs_Genesung": 25,
+        "BelegteBetten": null,
+        "Inzidenz": 46.6970796364812,
+        "Datum_neu": 1679270400000,
+        "F\u00e4lle_Meldedatum": 32,
+        "Zeitraum": "13.03.2023 - 19.03.2023",
+        "Hosp_Meldedatum": 5,
+        "Inzidenz_RKI": 36.2,
+        "Fallzahl_aktiv": 520,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 7,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.21,
+        "H_Zeitraum": "13.03.2023 - 19.03.2023",
+        "H_Datum": "14.03.2023",
+        "Datum_Bett": "19.03.2023"
+      }
+    },
+    {
+      "attributes": {
+        "Datum": "21.03.2023",
+        "Fallzahl": 281723,
+        "ObjectId": 1110,
+        "Sterbefall": 1910,
+        "Genesungsfall": 279315,
+        "Anzeige_Indikator": "x",
+        "Hospitalisierung": 7796,
+        "Zuwachs_Fallzahl": 253,
+        "Zuwachs_Sterbefall": 14,
+        "Zuwachs_Krankenhauseinweisung": 32,
+        "Zuwachs_Genesung": 193,
+        "BelegteBetten": null,
+        "Inzidenz": 44.0030173497611,
+        "Datum_neu": 1679356800000,
+        "F\u00e4lle_Meldedatum": 18,
+        "Zeitraum": "14.03.2023 - 20.03.2023",
+        "Hosp_Meldedatum": 4,
+        "Inzidenz_RKI": 38,
+        "Fallzahl_aktiv": 498,
+        "Krh_N_belegt": 447,
+        "Krh_I_belegt": 47,
+        "Krh_I_frei": null,
+        "Fallzahl_aktiv_Zuwachs": 46,
+        "Krh_I": null,
+        "Vorz_akt_Faelle": "+",
+        "Krh_I_covid": null,
+        "SterbeF_Sterbedatum": 0,
+        "Inzi_SN_RKI": null,
+        "Mutation": null,
+        "Zuwachs_Mutation": null,
+        "H_Inzidenz": 6.21,
+        "H_Zeitraum": "14.03.2023 - 20.03.2023",
+        "H_Datum": "14.03.2023",
+        "Datum_Bett": "20.03.2023"
+      }
     }
   ]
 }
\ No newline at end of file
```

If there are no anomalies, you are welcome to **merge** this symlink pointing to the new data set so that the new statistics will become publicly available on the [Grafana Dashboard](https://coronavirus-dresden.de/) within 5 minutes.

Thanks!
